### PR TITLE
fix: 이미지 수정 중에 임시로 삭제한 사진이 실제로 삭제되던 문제 해결

### DIFF
--- a/NoteCard/MemoDetailView/MemoMakingView/MemoMakingViewController.swift
+++ b/NoteCard/MemoDetailView/MemoMakingView/MemoMakingViewController.swift
@@ -69,6 +69,7 @@ class MemoMakingViewController: UIViewController {
     
     
     init(category categoryEntity: CategoryEntity? = nil) {
+        print("MemoMakingViewController 생성됨.")
         self.selectedCategoryEntity = categoryEntity
         super.init(nibName: nil, bundle: nil)
     }
@@ -94,6 +95,9 @@ class MemoMakingViewController: UIViewController {
         setupObserver()
     }
     
+    deinit {
+        print("MemoMakingViewController 해제됨.")
+    }
     
     func setupDiffableDataSource() {
         self.imageDiffableDataSource = UICollectionViewDiffableDataSource<Section, ImageEntity>(collectionView: self.selectedImageCollectionView, cellProvider: { collectionView, indexPath, imageEntity in
@@ -167,6 +171,9 @@ class MemoMakingViewController: UIViewController {
         let cancelingAction = UIAlertAction(title: "메모 작성 취소".localized(), style: UIAlertAction.Style.destructive) { action in
             self.memoEntityManager.deleteMemoEntity(memoEntity: temporaryMemoEntity)
             self.memoTextViewBottomConstraint.isActive = false
+            
+            guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { fatalError() }
+            appDelegate.memoMakingVC = nil
             self.dismiss(animated: true)
         }
         alertCon.addAction(cancelCancelingAction)
@@ -218,6 +225,9 @@ class MemoMakingViewController: UIViewController {
         guard let temporaryMemoEntity else { fatalError() }
         NotificationCenter.default.post(name: NSNotification.Name("createdMemoNotification"), object: nil, userInfo: ["memo": temporaryMemoEntity])
         self.memoTextViewBottomConstraint.isActive = false
+        
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { fatalError() }
+        appDelegate.memoMakingVC = nil
         self.dismiss(animated: true)
     }
     


### PR DESCRIPTION
- 이미지 셀의 X 버튼을 누르면 NotificationCenter로 전송

- MemoMakingViewController 인스턴스는 이 notification을 받아 해당 이미지를 실제로 삭제.
(MemoEditingViewController 인스턴스는 실제로 삭제하지는 않고, 임시 삭제 flag 만 변경)

- 그런데 MemoMakingViewController 인스턴스가 내려간 후에도 appDelegate가 소유하고 있어 deinit되지 않아서 여전히 MemoMakingViewController 인스턴스가 메모리에 남아있는 문제가 발생. -> 메모 수정 시 X 버튼을 누르면 이 인스턴스가 notification을 받아서 실제로 메모를 삭제해 버림.

- MemoMakingViewController 가 dismiss되기 전 appDelegate에서 소유권을 해제함으로써 해결함.