### PR TITLE
[#6] 코어데이터 리팩토링

### DIFF
--- a/NoteCard.xcodeproj/project.pbxproj
+++ b/NoteCard.xcodeproj/project.pbxproj
@@ -15,12 +15,6 @@
 		4E1384A92AF37B350063817B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384A82AF37B350063817B /* ViewController.swift */; };
 		4E1384B12AF37B370063817B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4E1384B02AF37B370063817B /* Assets.xcassets */; };
 		4E1384B42AF37B370063817B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4E1384B22AF37B370063817B /* LaunchScreen.storyboard */; };
-		4E1384D82AF382A40063817B /* CategoryEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D22AF382A40063817B /* CategoryEntity+CoreDataClass.swift */; };
-		4E1384D92AF382A40063817B /* CategoryEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D32AF382A40063817B /* CategoryEntity+CoreDataProperties.swift */; };
-		4E1384DA2AF382A40063817B /* ImageEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D42AF382A40063817B /* ImageEntity+CoreDataClass.swift */; };
-		4E1384DB2AF382A40063817B /* ImageEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D52AF382A40063817B /* ImageEntity+CoreDataProperties.swift */; };
-		4E1384DC2AF382A40063817B /* MemoEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D62AF382A40063817B /* MemoEntity+CoreDataClass.swift */; };
-		4E1384DD2AF382A40063817B /* MemoEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D72AF382A40063817B /* MemoEntity+CoreDataProperties.swift */; };
 		4E1384DF2AF382F70063817B /* ImageEntityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384DE2AF382F70063817B /* ImageEntityManager.swift */; };
 		4E1384E12AF3833E0063817B /* MemoEntityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384E02AF3833E0063817B /* MemoEntityManager.swift */; };
 		4E1384E32AF3839F0063817B /* CategoryEntityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384E22AF3839F0063817B /* CategoryEntityManager.swift */; };
@@ -67,6 +61,13 @@
 		4E4FCCC42B3C5873000CBE17 /* TimeFormatSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E4FCCC22B3C5810000CBE17 /* TimeFormatSettingView.swift */; };
 		4E4FCCC52B3C5875000CBE17 /* TimeFormatSettingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E4FCCC12B3C5810000CBE17 /* TimeFormatSettingTableViewCell.swift */; };
 		4E57A6002E54380700418962 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E57A5FF2E54380700418962 /* CoreDataStack.swift */; };
+		4E57A7B32E554A2A00418962 /* MemoEntityManagerActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E57A7B22E554A2A00418962 /* MemoEntityManagerActor.swift */; };
+		4E57A7F62E555D5500418962 /* CategoryEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D22AF382A40063817B /* CategoryEntity+CoreDataClass.swift */; };
+		4E57A7F72E555D5500418962 /* ImageEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D52AF382A40063817B /* ImageEntity+CoreDataProperties.swift */; };
+		4E57A7F82E555D5500418962 /* MemoEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D72AF382A40063817B /* MemoEntity+CoreDataProperties.swift */; };
+		4E57A7F92E555D5500418962 /* ImageEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D42AF382A40063817B /* ImageEntity+CoreDataClass.swift */; };
+		4E57A7FA2E555D5500418962 /* MemoEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D62AF382A40063817B /* MemoEntity+CoreDataClass.swift */; };
+		4E57A7FB2E555D5500418962 /* CategoryEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D32AF382A40063817B /* CategoryEntity+CoreDataProperties.swift */; };
 		4E59602D2B064BE20029BA3D /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E59602C2B064BE20029BA3D /* SettingsViewController.swift */; };
 		4E59602F2B064C290029BA3D /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E59602E2B064C290029BA3D /* SettingsView.swift */; };
 		4E5960312B0652AF0029BA3D /* SettingsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5960302B0652AF0029BA3D /* SettingsTableViewCell.swift */; };
@@ -163,6 +164,7 @@
 		4E4FCCC12B3C5810000CBE17 /* TimeFormatSettingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeFormatSettingTableViewCell.swift; sourceTree = "<group>"; };
 		4E4FCCC22B3C5810000CBE17 /* TimeFormatSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeFormatSettingView.swift; sourceTree = "<group>"; };
 		4E57A5FF2E54380700418962 /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
+		4E57A7B22E554A2A00418962 /* MemoEntityManagerActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoEntityManagerActor.swift; sourceTree = "<group>"; };
 		4E59602C2B064BE20029BA3D /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		4E59602E2B064C290029BA3D /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		4E5960302B0652AF0029BA3D /* SettingsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableViewCell.swift; sourceTree = "<group>"; };
@@ -268,6 +270,7 @@
 				4E1384E02AF3833E0063817B /* MemoEntityManager.swift */,
 				4E1384E22AF3839F0063817B /* CategoryEntityManager.swift */,
 				4E57A5FF2E54380700418962 /* CoreDataStack.swift */,
+				4E57A7B22E554A2A00418962 /* MemoEntityManagerActor.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -623,8 +626,6 @@
 				4ED063B92E49A532005AD817 /* MemoImageCollectionViewCell.swift in Sources */,
 				4EDF43172B2EB3F200AFEEB5 /* CategorySelectionViewController.swift in Sources */,
 				4E1384F32AF384C80063817B /* HomeCardCell.swift in Sources */,
-				4E1384DD2AF382A40063817B /* MemoEntity+CoreDataProperties.swift in Sources */,
-				4E1384D92AF382A40063817B /* CategoryEntity+CoreDataProperties.swift in Sources */,
 				4EFA2F3D2B27413700FCDD1B /* LeftAlignedFlowLayout.swift in Sources */,
 				4ED333A62B332FCD00492B0F /* ThemeColorPickingViewController.swift in Sources */,
 				4E4FCCC32B3C5871000CBE17 /* TimeFormatSettingViewController.swift in Sources */,
@@ -652,9 +653,15 @@
 				4E59602D2B064BE20029BA3D /* SettingsViewController.swift in Sources */,
 				4EFC02E02B42928F00C778DF /* TextSizeSettingView.swift in Sources */,
 				4E3E757A2B67D3D40073A951 /* QuickMemoEmptyView.swift in Sources */,
-				4E1384DA2AF382A40063817B /* ImageEntity+CoreDataClass.swift in Sources */,
 				4E3E75782B67D3B60073A951 /* QuickMemoEmptyViewController.swift in Sources */,
 				4E1385052AF385F20063817B /* CreateCategoryViewController.swift in Sources */,
+				4E57A7F62E555D5500418962 /* CategoryEntity+CoreDataClass.swift in Sources */,
+				4E57A7F72E555D5500418962 /* ImageEntity+CoreDataProperties.swift in Sources */,
+				4E57A7F82E555D5500418962 /* MemoEntity+CoreDataProperties.swift in Sources */,
+				4E57A7F92E555D5500418962 /* ImageEntity+CoreDataClass.swift in Sources */,
+				4E57A7FA2E555D5500418962 /* MemoEntity+CoreDataClass.swift in Sources */,
+				4E57A7FB2E555D5500418962 /* CategoryEntity+CoreDataProperties.swift in Sources */,
+				4E57A7B32E554A2A00418962 /* MemoEntityManagerActor.swift in Sources */,
 				4ED333A82B332FF000492B0F /* ThemeColorPickingView.swift in Sources */,
 				4ECDA56F2E162753003D15F5 /* ThirdTabViewController.swift in Sources */,
 				4E5960372B072E6F0029BA3D /* TotalListView.swift in Sources */,
@@ -663,7 +670,6 @@
 				4EC9B6A72E430FD30031250B /* SearchBar.swift in Sources */,
 				4EC9B6502E42EBD40031250B /* MemoSearchingViewController.swift in Sources */,
 				4E5960332B072E380029BA3D /* TotalListViewController.swift in Sources */,
-				4E1384DB2AF382A40063817B /* ImageEntity+CoreDataProperties.swift in Sources */,
 				4E1385012AF3859D0063817B /* CategoryListViewController.swift in Sources */,
 				4EEEB25E2B0864740027AF01 /* MemoDetailViewSelectedImageCell.swift in Sources */,
 				4E5960352B072E640029BA3D /* TotalListCollectionViewCell.swift in Sources */,
@@ -676,7 +682,6 @@
 				4E3E75762B678EBD0073A951 /* DarkModeSettingTableViewCell.swift in Sources */,
 				4EDD37012E330286002AF29B /* CustomIntensityBlurView.swift in Sources */,
 				4E2712082DA1A5D30007D53A /* HomeHeaderButton.swift in Sources */,
-				4E1384DC2AF382A40063817B /* MemoEntity+CoreDataClass.swift in Sources */,
 				4E1384A92AF37B350063817B /* ViewController.swift in Sources */,
 				4E1384EF2AF384880063817B /* HomeHeaderView.swift in Sources */,
 				4E1385222AF387AA0063817B /* CardImageShowingPresentationController.swift in Sources */,
@@ -685,7 +690,6 @@
 				4E3F63562B0B7BFF004DD676 /* CategoryListView.swift in Sources */,
 				4E1384F72AF385090063817B /* PopupCardViewController.swift in Sources */,
 				4EC9B6A52E42F1ED0031250B /* MemoSearchingCell.swift in Sources */,
-				4E1384D82AF382A40063817B /* CategoryEntity+CoreDataClass.swift in Sources */,
 				4E13851C2AF387480063817B /* CardImageShowingViewController.swift in Sources */,
 				4EC220262B077F6B007C9326 /* TotalListCellCategoryCell.swift in Sources */,
 				4E13851E2AF3875D0063817B /* CardImageShowingView.swift in Sources */,

--- a/NoteCard.xcodeproj/project.pbxproj
+++ b/NoteCard.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		4E57A7F92E555D5500418962 /* ImageEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D42AF382A40063817B /* ImageEntity+CoreDataClass.swift */; };
 		4E57A7FA2E555D5500418962 /* MemoEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D62AF382A40063817B /* MemoEntity+CoreDataClass.swift */; };
 		4E57A7FB2E555D5500418962 /* CategoryEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D32AF382A40063817B /* CategoryEntity+CoreDataProperties.swift */; };
+		4E57ABD62E599F3C00418962 /* MemoEntityRepository+FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E57ABD52E599F3C00418962 /* MemoEntityRepository+FileManager.swift */; };
 		4E59602D2B064BE20029BA3D /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E59602C2B064BE20029BA3D /* SettingsViewController.swift */; };
 		4E59602F2B064C290029BA3D /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E59602E2B064C290029BA3D /* SettingsView.swift */; };
 		4E5960312B0652AF0029BA3D /* SettingsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5960302B0652AF0029BA3D /* SettingsTableViewCell.swift */; };
@@ -165,6 +166,7 @@
 		4E4FCCC22B3C5810000CBE17 /* TimeFormatSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeFormatSettingView.swift; sourceTree = "<group>"; };
 		4E57A5FF2E54380700418962 /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
 		4E57A7B22E554A2A00418962 /* MemoEntityRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoEntityRepository.swift; sourceTree = "<group>"; };
+		4E57ABD52E599F3C00418962 /* MemoEntityRepository+FileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MemoEntityRepository+FileManager.swift"; sourceTree = "<group>"; };
 		4E59602C2B064BE20029BA3D /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		4E59602E2B064C290029BA3D /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		4E5960302B0652AF0029BA3D /* SettingsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableViewCell.swift; sourceTree = "<group>"; };
@@ -271,6 +273,7 @@
 				4E1384E22AF3839F0063817B /* CategoryEntityManager.swift */,
 				4E57A5FF2E54380700418962 /* CoreDataStack.swift */,
 				4E57A7B22E554A2A00418962 /* MemoEntityRepository.swift */,
+				4E57ABD52E599F3C00418962 /* MemoEntityRepository+FileManager.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -655,6 +658,7 @@
 				4E3E757A2B67D3D40073A951 /* QuickMemoEmptyView.swift in Sources */,
 				4E3E75782B67D3B60073A951 /* QuickMemoEmptyViewController.swift in Sources */,
 				4E1385052AF385F20063817B /* CreateCategoryViewController.swift in Sources */,
+				4E57ABD62E599F3C00418962 /* MemoEntityRepository+FileManager.swift in Sources */,
 				4E57A7F62E555D5500418962 /* CategoryEntity+CoreDataClass.swift in Sources */,
 				4E57A7F72E555D5500418962 /* ImageEntity+CoreDataProperties.swift in Sources */,
 				4E57A7F82E555D5500418962 /* MemoEntity+CoreDataProperties.swift in Sources */,

--- a/NoteCard.xcodeproj/project.pbxproj
+++ b/NoteCard.xcodeproj/project.pbxproj
@@ -61,7 +61,7 @@
 		4E4FCCC42B3C5873000CBE17 /* TimeFormatSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E4FCCC22B3C5810000CBE17 /* TimeFormatSettingView.swift */; };
 		4E4FCCC52B3C5875000CBE17 /* TimeFormatSettingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E4FCCC12B3C5810000CBE17 /* TimeFormatSettingTableViewCell.swift */; };
 		4E57A6002E54380700418962 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E57A5FF2E54380700418962 /* CoreDataStack.swift */; };
-		4E57A7B32E554A2A00418962 /* MemoEntityManagerActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E57A7B22E554A2A00418962 /* MemoEntityManagerActor.swift */; };
+		4E57A7B32E554A2A00418962 /* MemoEntityRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E57A7B22E554A2A00418962 /* MemoEntityRepository.swift */; };
 		4E57A7F62E555D5500418962 /* CategoryEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D22AF382A40063817B /* CategoryEntity+CoreDataClass.swift */; };
 		4E57A7F72E555D5500418962 /* ImageEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D52AF382A40063817B /* ImageEntity+CoreDataProperties.swift */; };
 		4E57A7F82E555D5500418962 /* MemoEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1384D72AF382A40063817B /* MemoEntity+CoreDataProperties.swift */; };
@@ -164,7 +164,7 @@
 		4E4FCCC12B3C5810000CBE17 /* TimeFormatSettingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeFormatSettingTableViewCell.swift; sourceTree = "<group>"; };
 		4E4FCCC22B3C5810000CBE17 /* TimeFormatSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeFormatSettingView.swift; sourceTree = "<group>"; };
 		4E57A5FF2E54380700418962 /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
-		4E57A7B22E554A2A00418962 /* MemoEntityManagerActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoEntityManagerActor.swift; sourceTree = "<group>"; };
+		4E57A7B22E554A2A00418962 /* MemoEntityRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoEntityRepository.swift; sourceTree = "<group>"; };
 		4E59602C2B064BE20029BA3D /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		4E59602E2B064C290029BA3D /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		4E5960302B0652AF0029BA3D /* SettingsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableViewCell.swift; sourceTree = "<group>"; };
@@ -270,7 +270,7 @@
 				4E1384E02AF3833E0063817B /* MemoEntityManager.swift */,
 				4E1384E22AF3839F0063817B /* CategoryEntityManager.swift */,
 				4E57A5FF2E54380700418962 /* CoreDataStack.swift */,
-				4E57A7B22E554A2A00418962 /* MemoEntityManagerActor.swift */,
+				4E57A7B22E554A2A00418962 /* MemoEntityRepository.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -661,7 +661,7 @@
 				4E57A7F92E555D5500418962 /* ImageEntity+CoreDataClass.swift in Sources */,
 				4E57A7FA2E555D5500418962 /* MemoEntity+CoreDataClass.swift in Sources */,
 				4E57A7FB2E555D5500418962 /* CategoryEntity+CoreDataProperties.swift in Sources */,
-				4E57A7B32E554A2A00418962 /* MemoEntityManagerActor.swift in Sources */,
+				4E57A7B32E554A2A00418962 /* MemoEntityRepository.swift in Sources */,
 				4ED333A82B332FF000492B0F /* ThemeColorPickingView.swift in Sources */,
 				4ECDA56F2E162753003D15F5 /* ThirdTabViewController.swift in Sources */,
 				4E5960372B072E6F0029BA3D /* TotalListView.swift in Sources */,

--- a/NoteCard/CoreData/CoreDataStack.swift
+++ b/NoteCard/CoreData/CoreDataStack.swift
@@ -42,6 +42,8 @@ final class CoreDataStack: ObservableObject {
         })
         return container
     }()
+    
+    lazy var backgroundContext = persistentContainer.newBackgroundContext()
 
     // MARK: - Core Data Saving support
 

--- a/NoteCard/CoreData/CoreDataStack.swift
+++ b/NoteCard/CoreData/CoreDataStack.swift
@@ -43,7 +43,7 @@ final class CoreDataStack: ObservableObject {
         return container
     }()
     
-    lazy var backgroundContext = persistentContainer.newBackgroundContext()
+    private(set) lazy var backgroundContext = persistentContainer.newBackgroundContext()
 
     // MARK: - Core Data Saving support
 

--- a/NoteCard/CoreData/MemoEntityManager.swift
+++ b/NoteCard/CoreData/MemoEntityManager.swift
@@ -255,7 +255,7 @@ final class MemoEntityManager {
         memoEntity.deletedDate = Date()
         CoreDataStack.shared.saveContext()
         
-        memoEntity.categories?.forEach({ element in
+        memoEntity.categories.forEach({ element in
             guard let category = element as? CategoryEntity else { fatalError() }
             memoEntity.removeFromCategories(category)
         })
@@ -277,7 +277,7 @@ final class MemoEntityManager {
     ///
     /// 매개변수로 들어온 memoEntity와 그 메모에 속한 이미지들 및 imageEntity들까지 모두 삭제한다.
     func deleteMemoEntity(memoEntity: MemoEntity) {
-        guard let categories = memoEntity.categories else { return }
+        let categories = memoEntity.categories
         guard let images = memoEntity.images as? Set<ImageEntity> else { return }
         memoEntity.removeFromCategories(categories)
         
@@ -322,10 +322,7 @@ final class MemoEntityManager {
     
     func replaceCategories(of memoEntity: MemoEntity, with newCategorySet: Set<CategoryEntity>) {
         
-        guard let categories = memoEntity.categories else {
-            print("memo has no cateogories")
-            return
-        }
+        let categories = memoEntity.categories
         let newNSSet = newCategorySet as NSSet
         memoEntity.removeFromCategories(categories)
         memoEntity.addToCategories(newNSSet)

--- a/NoteCard/CoreData/MemoEntityManagerActor.swift
+++ b/NoteCard/CoreData/MemoEntityManagerActor.swift
@@ -1,0 +1,29 @@
+//
+//  MemoEntityManagerActor.swift
+//  NoteCard
+//
+//  Created by 김민성 on 8/20/25.
+//
+
+import CoreData
+import Foundation
+
+@globalActor
+actor MemoEntityActor {
+    static let shared = MemoEntityActor()
+}
+
+
+@MemoEntityActor
+final class MemoEntityActorManager {
+    
+    static let shared = MemoEntityActorManager()
+    private init() { }
+    
+    private var entityName: String { return "MemoEntity" }
+    
+    private var context: NSManagedObjectContext {
+        CoreDataStack.shared.persistentContainer.viewContext
+    }
+    
+}

--- a/NoteCard/CoreData/MemoEntityRepository+FileManager.swift
+++ b/NoteCard/CoreData/MemoEntityRepository+FileManager.swift
@@ -27,9 +27,9 @@ enum MemoEntityFileManagerError: LocalizedError {
     
 }
 
-extension MemoEntityManager {
+extension MemoEntityRepository {
     
-    func getMemoDirectory(of memo: MemoEntity) async throws -> URL {
+    func getMemoDirectoryURL(of memo: MemoEntity) throws -> URL {
         guard let documentURL = FileManager.default.urls(
             for: .documentDirectory,
             in: .userDomainMask

--- a/NoteCard/CoreData/MemoEntityRepository+FileManager.swift
+++ b/NoteCard/CoreData/MemoEntityRepository+FileManager.swift
@@ -1,0 +1,65 @@
+//
+//  MemoEntityRepository+FileManager.swift
+//  NoteCard
+//
+//  Created by 김민성 on 8/23/25.
+//
+
+import Foundation
+
+
+enum MemoEntityFileManagerError: LocalizedError {
+    
+    case documentDirectoryNotFound // 이건 추후 FileManagerError 등으로 빼는 게 나을 듯...?
+    case failedToCreateNewDirectory
+    case fileExistInMemoID
+    
+    var errorDescription: String? {
+        switch self {
+        case .documentDirectoryNotFound:
+            return "FileManager에서 Document Directory를 찾을 수 없습니다."
+        case .failedToCreateNewDirectory:
+            return "새로운 디렉토리를 만드는 데 실패했습니다."
+        case .fileExistInMemoID:
+            return "메모 이름으로 된 파일이 존재합니다."
+        }
+    }
+    
+}
+
+extension MemoEntityManager {
+    
+    func getMemoDirectory(of memo: MemoEntity) async throws -> URL {
+        guard let documentURL = FileManager.default.urls(
+            for: .documentDirectory,
+            in: .userDomainMask
+        ).first else {
+            throw MemoEntityFileManagerError.documentDirectoryNotFound
+        }
+        
+        let memoDirectoryURL: URL
+        if #available(iOS 16, *) {
+            memoDirectoryURL = documentURL.appending(
+                path: memo.memoID.uuidString,
+                directoryHint: .isDirectory
+            )
+        } else {
+            memoDirectoryURL = documentURL.appendingPathComponent(
+                memo.memoID.uuidString,
+                isDirectory: true
+            )
+        }
+        
+        let memoDirectoryStatus = FileManager.default.fileOrDirectoryExist(at: memoDirectoryURL)
+        switch memoDirectoryStatus {
+        case .isDirectory:
+            return memoDirectoryURL
+        case .isFile:
+            throw MemoEntityFileManagerError.fileExistInMemoID
+        case .notExist:
+            try FileManager.default.createDirectory(at: memoDirectoryURL, withIntermediateDirectories: false)
+            return memoDirectoryURL
+        }
+    }
+    
+}

--- a/NoteCard/CoreData/MemoEntityRepository.swift
+++ b/NoteCard/CoreData/MemoEntityRepository.swift
@@ -101,3 +101,38 @@ extension MemoEntityRepository {
     }
     
 }
+
+
+// MARK: - DELETE(Soft)
+extension MemoEntityRepository {
+    
+    func moveToTrash(_ memoEntity: MemoEntity) async throws {
+        try await context.perform {
+            memoEntity.isFavorite = false
+            memoEntity.isInTrash = true
+            memoEntity.deletedDate = .now
+            guard let categories = memoEntity.categories as? Set<CategoryEntity> else {
+                fatalError("memo's categories casting failed")
+            }
+            for category in categories {
+                memoEntity.removeFromCategories(category)
+            }
+            try self.context.save()
+        }
+    }
+    
+}
+
+
+// MARK: - RESTORING
+extension MemoEntityRepository {
+    
+    func restore(_ memoEntity: MemoEntity) async throws {
+        try await context.perform {
+            memoEntity.isInTrash = false
+            memoEntity.deletedDate = nil
+            try self.context.save()
+        }
+    }
+    
+}

--- a/NoteCard/CoreData/MemoEntityRepository.swift
+++ b/NoteCard/CoreData/MemoEntityRepository.swift
@@ -43,8 +43,8 @@ actor MemoEntityRepository {
 // MARK: - CREATE
 extension MemoEntityRepository {
     
-    func createNewMemo() async throws -> MemoEntity {
-        try await context.perform {
+    func createNewMemo() throws -> MemoEntity {
+        try context.performAndWait {
             let newMemoEntity = MemoEntity(context: self.context)
             try self.context.save()
             return newMemoEntity
@@ -57,8 +57,8 @@ extension MemoEntityRepository {
 // MARK: - READ
 extension MemoEntityRepository {
     
-    func getMemo(id: UUID) async throws -> MemoEntity {
-        try await context.perform {
+    func getMemo(id: UUID) throws -> MemoEntity {
+        try context.performAndWait {
             let request = MemoEntity.fetchRequest()
             let sortDescriptor = NSSortDescriptor(key: self.orderCriterion, ascending: self.isOrderAscending)
             request.sortDescriptors = [sortDescriptor]
@@ -78,8 +78,8 @@ extension MemoEntityRepository {
         }
     }
     
-    func getAllMemo() async throws -> [MemoEntity]  {
-        try await context.perform {
+    func getAllMemo() throws -> [MemoEntity]  {
+        try context.performAndWait {
             let request = MemoEntity.fetchRequest()
             let sortDescriptor = NSSortDescriptor(key: self.orderCriterion, ascending: self.isOrderAscending)
             request.sortDescriptors = [sortDescriptor]
@@ -87,8 +87,8 @@ extension MemoEntityRepository {
         }
     }
     
-    func getFilteredMemo(inCategory category: CategoryEntity) async throws -> [MemoEntity] {
-        try await context.perform {
+    func getFilteredMemo(inCategory category: CategoryEntity) throws -> [MemoEntity] {
+        try context.performAndWait {
             let request = MemoEntity.fetchRequest()
             let sortDescriptor = NSSortDescriptor(key: self.orderCriterion, ascending: self.isOrderAscending)
             request.sortDescriptors = [sortDescriptor]
@@ -100,8 +100,8 @@ extension MemoEntityRepository {
         }
     }
     
-    func getMemoInTrash() async throws -> [MemoEntity] {
-        try await context.perform {
+    func getMemoInTrash() throws -> [MemoEntity] {
+        try context.performAndWait {
             let request = MemoEntity.fetchRequest()
             let sortDescriptor = NSSortDescriptor(key: self.orderCriterion, ascending: self.isOrderAscending)
             request.sortDescriptors = [sortDescriptor]
@@ -110,8 +110,8 @@ extension MemoEntityRepository {
         }
     }
     
-    func searchMemo(searchText: String, inCategory: CategoryEntity? = nil) async throws -> [MemoEntity] {
-        try await context.perform {
+    func searchMemo(searchText: String, inCategory: CategoryEntity? = nil) throws -> [MemoEntity] {
+        try context.performAndWait {
             let request = MemoEntity.fetchRequest()
             let sortDescriptor = NSSortDescriptor(key: self.orderCriterion, ascending: self.isOrderAscending)
             request.sortDescriptors = [sortDescriptor]
@@ -127,8 +127,8 @@ extension MemoEntityRepository {
         }
     }
     
-    func getFavoriteMemo() async throws -> [MemoEntity] {
-        try await context.perform {
+    func getFavoriteMemo() throws -> [MemoEntity] {
+        try context.performAndWait {
             let request = MemoEntity.fetchRequest()
             let sortDescriptor = NSSortDescriptor(key: self.orderCriterion, ascending: self.isOrderAscending)
             request.sortDescriptors = [sortDescriptor]
@@ -143,8 +143,8 @@ extension MemoEntityRepository {
 // MARK: - DELETE(Soft)
 extension MemoEntityRepository {
     
-    func moveToTrash(_ memoEntity: MemoEntity) async throws {
-        try await context.perform {
+    func moveToTrash(_ memoEntity: MemoEntity) throws {
+        try context.performAndWait {
             memoEntity.isFavorite = false
             memoEntity.isInTrash = true
             memoEntity.deletedDate = .now
@@ -164,8 +164,8 @@ extension MemoEntityRepository {
 // MARK: - ⚠️ DELETE(Hard)
 extension MemoEntityRepository {
     
-    func deleteMemo(_ memoEntity: MemoEntity) async throws {
-        try await context.perform {
+    func deleteMemo(_ memoEntity: MemoEntity) throws {
+        try context.performAndWait {
             // 카테고리들로부터 메모를 삭제
             let categories = memoEntity.categories
             guard let images = memoEntity.images as? Set<ImageEntity> else { return }
@@ -190,8 +190,8 @@ extension MemoEntityRepository {
 // MARK: - RESTORING
 extension MemoEntityRepository {
     
-    func restore(_ memoEntity: MemoEntity) async throws {
-        try await context.perform {
+    func restore(_ memoEntity: MemoEntity) throws {
+        try context.performAndWait {
             memoEntity.isInTrash = false
             memoEntity.deletedDate = nil
             try self.context.save()
@@ -204,8 +204,8 @@ extension MemoEntityRepository {
 // MARK: - UPDATE
 extension MemoEntityRepository {
     
-    func replaceCategories(_ memoEntity: MemoEntity, newCategories: Set<CategoryEntity>) async throws {
-        try await context.perform {
+    func replaceCategories(_ memoEntity: MemoEntity, newCategories: Set<CategoryEntity>) throws {
+        try context.performAndWait {
             let oldCategories = memoEntity.categories
             let newNSSet = newCategories as NSSet
             memoEntity.removeFromCategories(oldCategories)
@@ -214,8 +214,8 @@ extension MemoEntityRepository {
         }
     }
     
-    func setFavorite(_ memoEntity: MemoEntity, to value: Bool) async throws {
-        try await context.perform {
+    func setFavorite(_ memoEntity: MemoEntity, to value: Bool) throws {
+        try context.performAndWait {
             memoEntity.isFavorite = value
             try self.context.save()
         }

--- a/NoteCard/CoreData/MemoEntityRepository.swift
+++ b/NoteCard/CoreData/MemoEntityRepository.swift
@@ -1,5 +1,5 @@
 //
-//  MemoEntityManagerActor.swift
+//  MemoEntityRepository.swift
 //  NoteCard
 //
 //  Created by 김민성 on 8/20/25.
@@ -9,12 +9,12 @@ import CoreData
 import Foundation
 
 @globalActor
-actor MemoEntityActor {
-    static let shared = MemoEntityActor()
+actor MemoEntityRepository {
+    static let shared = MemoEntityRepository()
 }
 
 
-@MemoEntityActor
+@MemoEntityRepository
 final class MemoEntityActorManager {
     
     static let shared = MemoEntityActorManager()

--- a/NoteCard/CoreData/MemoEntityRepository.swift
+++ b/NoteCard/CoreData/MemoEntityRepository.swift
@@ -199,3 +199,26 @@ extension MemoEntityRepository {
     }
     
 }
+
+
+// MARK: - UPDATE
+extension MemoEntityRepository {
+    
+    func replaceCategories(_ memoEntity: MemoEntity, newCategories: Set<CategoryEntity>) async throws {
+        try await context.perform {
+            let oldCategories = memoEntity.categories
+            let newNSSet = newCategories as NSSet
+            memoEntity.removeFromCategories(oldCategories)
+            memoEntity.addToCategories(newNSSet)
+            try self.context.save()
+        }
+    }
+    
+    func setFavorite(_ memoEntity: MemoEntity, to value: Bool) async throws {
+        try await context.perform {
+            memoEntity.isFavorite = value
+            try self.context.save()
+        }
+    }
+    
+}

--- a/NoteCard/CoreData/Models/CategoryEntity+CoreDataProperties.swift
+++ b/NoteCard/CoreData/Models/CategoryEntity+CoreDataProperties.swift
@@ -16,11 +16,10 @@ extension CategoryEntity {
         return NSFetchRequest<CategoryEntity>(entityName: "CategoryEntity")
     }
 
-    @NSManaged public var categoryDirectoryURL: URL
     @NSManaged public var creationDate: Date
     @NSManaged public var modificationDate: Date
     @NSManaged public var name: String
-    @NSManaged public weak var memoSet: NSSet?
+    @NSManaged public var memoSet: NSSet
 
 }
 
@@ -44,5 +43,3 @@ extension CategoryEntity {
 extension CategoryEntity : Identifiable {
 
 }
-
-

--- a/NoteCard/CoreData/Models/ImageEntity+CoreDataClass.swift
+++ b/NoteCard/CoreData/Models/ImageEntity+CoreDataClass.swift
@@ -11,5 +11,40 @@ import CoreData
 
 @objc(ImageEntity)
 public class ImageEntity: NSManagedObject {
-
+    
+    @available(*, unavailable)
+    public init() {
+        fatalError()
+    }
+    
+    @available(*, unavailable)
+    public init(context: NSManagedObjectContext) {
+        fatalError()
+    }
+    
+    @objc
+    override private init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
+        super.init(entity: entity, insertInto: context)
+    }
+    
+    init(
+        temporaryOrderIndex: Int,
+        orderIndex: Int,
+        uuid: UUID,
+        thumbnailUUID: UUID,
+        memo: MemoEntity,
+        isTemporaryAppended: Bool,
+        context: NSManagedObjectContext
+    ) {
+        guard let entityDescription = NSEntityDescription.entity(
+            forEntityName: "ImageEntity",
+            in: context
+        ) else {
+            fatalError()
+        }
+        super.init(entity: entityDescription, insertInto: context)
+        
+        isTemporaryDeleted = false
+    }
+    
 }

--- a/NoteCard/CoreData/Models/MemoEntity+CoreDataClass.swift
+++ b/NoteCard/CoreData/Models/MemoEntity+CoreDataClass.swift
@@ -22,6 +22,20 @@ public class MemoEntity: NSManagedObject {
 
 extension MemoEntity {
     
+    var memoTextShortBuffer: String {
+        let paragraphsInString = self.memoText.components(separatedBy: CharacterSet.newlines)
+        if self.memoText.count > 5000 && paragraphsInString.count > 4 {
+            var buffer: String = ""
+            for i in 0...3 {
+                buffer.append(paragraphsInString[i])
+                buffer.append("\n")
+            }
+            return buffer
+        } else {
+            return self.memoText
+        }
+    }
+    
     var memoTextLongBuffer: String {
         let paragraphsInString = self.memoText.components(separatedBy: CharacterSet.newlines)
         if self.memoText.count > 5000 && paragraphsInString.count > 4 {

--- a/NoteCard/CoreData/Models/MemoEntity+CoreDataClass.swift
+++ b/NoteCard/CoreData/Models/MemoEntity+CoreDataClass.swift
@@ -18,6 +18,32 @@ public class MemoEntity: NSManagedObject {
         return array.count
     }
     
+    @available(*, unavailable)
+    public init() {
+        fatalError()
+    }
+    
+    @objc
+    override private init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
+        super.init(entity: entity, insertInto: context)
+    }
+    
+    init(context: NSManagedObjectContext) {
+        guard let entityDescription = NSEntityDescription.entity(forEntityName: "MemoEntity", in: context) else { fatalError() }
+        super.init(entity: entityDescription, insertInto: context)
+        
+        creationDate = .now
+        deletedDate = nil
+        isFavorite = false
+        isInTrash = false
+        memoID = UUID()
+        memoText = ""
+        memoTitle = ""
+        modificationDate = .now
+        categories = []
+        images = []
+    }
+    
 }
 
 extension MemoEntity {

--- a/NoteCard/CoreData/Models/MemoEntity+CoreDataProperties.swift
+++ b/NoteCard/CoreData/Models/MemoEntity+CoreDataProperties.swift
@@ -17,50 +17,30 @@ extension MemoEntity {
     }
 
     @NSManaged public var creationDate: Date
+    @NSManaged public var deletedDate: Date?
     @NSManaged public var isFavorite: Bool
     @NSManaged public var isInTrash: Bool
-    @NSManaged public var latitude: Double
-    @NSManaged public var longitude: Double
+    @NSManaged public var memoID: UUID
     @NSManaged public var memoText: String
     @NSManaged public var memoTitle: String
     @NSManaged public var modificationDate: Date
-    @NSManaged public var memoID: UUID
-    @NSManaged public var deletedDate: Date?
-    
-    //메모와 카테고리가 서로 강한 참조하고 있으면 순환 참조 생겨서 메모리 누수 방지
-    //그래서 메모의 다른 값들은 모두 강한 참조여도 categories 는 옵셔널 타입으로 할 수 밖에 없었던 이유가, 약한 참조를 해야 했기 때문.
-    @NSManaged public weak var categories: NSSet?
+    @NSManaged public var categories: NSSet
     @NSManaged public var images: NSSet
-    
-    
-    var memoTextShortBuffer: String {
-        let paragraphsInString = self.memoText.components(separatedBy: CharacterSet.newlines)
-        if self.memoText.count > 5000 && paragraphsInString.count > 4 {
-            var buffer: String = ""
-            for i in 0...3 {
-                buffer.append(paragraphsInString[i])
-                buffer.append("\n")
-            }
-            return buffer
-        } else {
-            return self.memoText
-        }
-    }
-    
+
 }
 
 // MARK: Generated accessors for categories
 extension MemoEntity {
-    
+
     @objc(addCategoriesObject:)
     @NSManaged public func addToCategories(_ value: CategoryEntity)
-    
+
     @objc(removeCategoriesObject:)
     @NSManaged public func removeFromCategories(_ value: CategoryEntity)
-    
+
     @objc(addCategories:)
     @NSManaged public func addToCategories(_ values: NSSet)
-    
+
     @objc(removeCategories:)
     @NSManaged public func removeFromCategories(_ values: NSSet)
 

--- a/NoteCard/Extensions/FileManager+.swift
+++ b/NoteCard/Extensions/FileManager+.swift
@@ -1,0 +1,38 @@
+//
+//  FileManager+.swift
+//  NoteCard
+//
+//  Created by 김민성 on 8/23/25.
+//
+
+import Foundation
+
+extension FileManager {
+    
+    enum FileStatus {
+        case isDirectory
+        case isFile
+        case notExist
+    }
+    
+    func fileOrDirectoryExist(at path: URL) -> FileStatus {
+        var isDirectory = ObjCBool(false)
+        let isExistAtPath: Bool
+        if #available(iOS 16, *) {
+            isExistAtPath = fileExists(atPath: path.path(), isDirectory: &isDirectory)
+        } else {
+            isExistAtPath = fileExists(atPath: path.path, isDirectory: &isDirectory)
+        }
+        
+        if isExistAtPath {
+            if isDirectory.boolValue {
+                return .isDirectory
+            } else {
+                return .isFile
+            }
+        } else {
+            return .notExist
+        }
+    }
+    
+}

--- a/NoteCard/Presentation/HomeView/CategoryListTableView/CategoryListViewController.swift
+++ b/NoteCard/Presentation/HomeView/CategoryListTableView/CategoryListViewController.swift
@@ -205,11 +205,11 @@ extension CategoryListViewController {
             // Delete the row from the data source
             let categoryEntityToDelete = categoryManager.getCategoryEntities(inOrderOf: CategoryProperties.creationDate, isAscending: true)[indexPath.row]
             
-            do {
-                try fileManager.removeItem(at: categoryEntityToDelete.categoryDirectoryURL)
-            } catch let error {
-                print(error.localizedDescription)
-            }
+//            do {
+//                try fileManager.removeItem(at: categoryEntityToDelete.categoryDirectoryURL)
+//            } catch let error {
+//                print(error.localizedDescription)
+//            }
             
             categoryManager.deleteCategoryEntity(of: categoryEntityToDelete)
             tableView.deleteRows(at: [indexPath], with: .fade)

--- a/NoteCard/Presentation/MemoDetailView/MemoEditingView/MemoEditingViewController.swift
+++ b/NoteCard/Presentation/MemoDetailView/MemoEditingView/MemoEditingViewController.swift
@@ -245,7 +245,7 @@ class MemoEditingViewController: UIViewController {
         //카테고리 변경사항 적용
         MemoEntityManager.shared.replaceCategories(of: self.selectedMemoEntity, with: self.temporaryCategorySet)
         
-        guard let categoryEntityList = self.selectedMemoEntity.categories?.sortedArray(using: []) as? [CategoryEntity] else {
+        guard let categoryEntityList = self.selectedMemoEntity.categories.sortedArray(using: []) as? [CategoryEntity] else {
             fatalError("temporaryMemoEnity's categories's sortedArray method return nil")
         }
         

--- a/NoteCard/Presentation/MemoDetailView/MemoMakingView/MemoMakingViewController.swift
+++ b/NoteCard/Presentation/MemoDetailView/MemoMakingView/MemoMakingViewController.swift
@@ -197,7 +197,7 @@ class MemoMakingViewController: UIViewController {
             imageEntity.orderIndex = imageEntity.temporaryOrderIndex
         }
         
-        guard let categoryEntityList = self.temporaryMemoEntity.categories?.sortedArray(using: []) as? [CategoryEntity] else {
+        guard let categoryEntityList = self.temporaryMemoEntity.categories.sortedArray(using: []) as? [CategoryEntity] else {
             fatalError("temporaryMemoEnity's categories's sortedArray method return nil")
         }
         

--- a/NoteCard/Presentation/MemoView/MemoViewController.swift
+++ b/NoteCard/Presentation/MemoView/MemoViewController.swift
@@ -542,7 +542,7 @@ class MemoViewController: UIViewController {
         }
         
         guard let createdMemoEntity = notification.userInfo?["memo"] as? MemoEntity else { fatalError() }
-        guard let categories = createdMemoEntity.categories else { fatalError() }
+        let categories = createdMemoEntity.categories
         let isOrderAscending = UserDefaults.standard.bool(forKey: UserDefaultsKeys.isOrderAscending.rawValue)
         
         switch self.memoVCType {


### PR DESCRIPTION
(아직은 MemoEntity 관리만)
코어데이터를 관리하는 싱글톤 액터를 만들어 MemoEntity의 CRUD 동작을 보다 Thread-Safe하게 구현할 수 있도록 개선