### PR TITLE
feat(home): 카테고리/전체 메모 빈 상태 placeholder 셀 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  # Runs on every push EXCEPT main and release branches.
+  # main is protected via PR review; release/** is handled by release.yml.
+  push:
+    branches-ignore:
+      - main
+      - "release/**"
+  # Runs on every PR targeting main.
+  pull_request:
+    branches:
+      - main
+
+# When a new push arrives on the same branch, cancel the previous in-flight run.
+# Saves runner time on rapid pushes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Compile check (simulator)
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    env:
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode (latest-stable, same as Release workflow)
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Resolve SPM dependencies
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project NoteCard.xcodeproj \
+            -scheme NoteCard
+
+      - name: Build for iOS Simulator (Debug)
+        run: |
+          set -euo pipefail
+          xcodebuild build \
+            -project NoteCard.xcodeproj \
+            -scheme NoteCard \
+            -configuration Debug \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO

--- a/NoteCard.xcodeproj/project.pbxproj
+++ b/NoteCard.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		4E13854C2AF38BE40063817B /* DetailViewSelectedImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E13854B2AF38BE40063817B /* DetailViewSelectedImageViewController.swift */; };
 		4E13854E2AF38BFD0063817B /* DetailViewSelectedImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E13854D2AF38BFD0063817B /* DetailViewSelectedImageView.swift */; };
 		4E2712082DA1A5D30007D53A /* HomeHeaderButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2712072DA1A5D30007D53A /* HomeHeaderButton.swift */; };
+		4EAA570C2E0F26AB00000002 /* HomeAddPlaceholderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EAA570B2E0F26AB00000001 /* HomeAddPlaceholderCell.swift */; };
 		4E3E75742B678EB80073A951 /* DarkModeSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3E75712B677EFB0073A951 /* DarkModeSettingViewController.swift */; };
 		4E3E75752B678EBA0073A951 /* DarkModeSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3E75722B677EFB0073A951 /* DarkModeSettingView.swift */; };
 		4E3E75762B678EBD0073A951 /* DarkModeSettingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3E75732B677EFB0073A951 /* DarkModeSettingTableViewCell.swift */; };
@@ -141,6 +142,7 @@
 		4E13854B2AF38BE40063817B /* DetailViewSelectedImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewSelectedImageViewController.swift; sourceTree = "<group>"; };
 		4E13854D2AF38BFD0063817B /* DetailViewSelectedImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewSelectedImageView.swift; sourceTree = "<group>"; };
 		4E2712072DA1A5D30007D53A /* HomeHeaderButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeHeaderButton.swift; sourceTree = "<group>"; };
+		4EAA570B2E0F26AB00000001 /* HomeAddPlaceholderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeAddPlaceholderCell.swift; sourceTree = "<group>"; };
 		4E3E75712B677EFB0073A951 /* DarkModeSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkModeSettingViewController.swift; sourceTree = "<group>"; };
 		4E3E75722B677EFB0073A951 /* DarkModeSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkModeSettingView.swift; sourceTree = "<group>"; };
 		4E3E75732B677EFB0073A951 /* DarkModeSettingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkModeSettingTableViewCell.swift; sourceTree = "<group>"; };
@@ -287,6 +289,7 @@
 				4E2712072DA1A5D30007D53A /* HomeHeaderButton.swift */,
 				4E1384F02AF384A70063817B /* HomeCategoryCell.swift */,
 				4E1384F22AF384C80063817B /* HomeCardCell.swift */,
+				4EAA570B2E0F26AB00000001 /* HomeAddPlaceholderCell.swift */,
 				4E1384C32AF37E750063817B /* CategoryListTableView */,
 			);
 			path = HomeView;
@@ -597,6 +600,7 @@
 				4E00A0D12E5F4758007ABF00 /* CategoryEntity+Mapping.swift in Sources */,
 				4EDF43172B2EB3F200AFEEB5 /* CategorySelectionViewController.swift in Sources */,
 				4E1384F32AF384C80063817B /* HomeCardCell.swift in Sources */,
+				4EAA570C2E0F26AB00000002 /* HomeAddPlaceholderCell.swift in Sources */,
 				4EFA2F3D2B27413700FCDD1B /* LeftAlignedFlowLayout.swift in Sources */,
 				4ED333A62B332FCD00492B0F /* ThemeColorPickingViewController.swift in Sources */,
 				4E4FCCC32B3C5871000CBE17 /* TimeFormatSettingViewController.swift in Sources */,

--- a/NoteCard/Global/Localization/L10n.swift
+++ b/NoteCard/Global/Localization/L10n.swift
@@ -26,6 +26,8 @@ enum L10n {
         static let allMemos = "home.allMemos".localized()
         static let makeCategory = "home.makeCategory".localized()
         static let noFavorites = "home.noFavorites".localized()
+        static let addCategoryPlaceholder = "home.addCategoryPlaceholder".localized()
+        static let addMemoPlaceholder = "home.addMemoPlaceholder".localized()
     }
 
     enum CategoryList {

--- a/NoteCard/Localizable.xcstrings
+++ b/NoteCard/Localizable.xcstrings
@@ -545,6 +545,40 @@
         }
       }
     },
+    "home.addCategoryPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Category"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "카테고리 추가"
+          }
+        }
+      }
+    },
+    "home.addMemoPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Memo"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메모 추가"
+          }
+        }
+      }
+    },
     "home.allMemos": {
       "extractionState": "manual",
       "localizations": {

--- a/NoteCard/Presentation/HomeView/HomeAddPlaceholderCell.swift
+++ b/NoteCard/Presentation/HomeView/HomeAddPlaceholderCell.swift
@@ -1,0 +1,96 @@
+//
+//  HomeAddPlaceholderCell.swift
+//  NoteCard
+//
+//  Created by 김민성 on 5/11/26.
+//
+
+import UIKit
+
+/// 홈 화면에서 카테고리 / 전체 메모가 하나도 없을 때 추가를 유도하는 placeholder 셀.
+/// 가운데 + 아이콘과 "OOO 추가" 레이블, 점선 보더로 구성된다.
+final class HomeAddPlaceholderCell: UICollectionViewCell, ViewShrinkable {
+
+    override var isHighlighted: Bool {
+        didSet { isHighlighted ? shrink(scale: 0.95) : restore() }
+    }
+
+    private let plusImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "plus")
+        imageView.contentMode = .scaleAspectFit
+        imageView.preferredSymbolConfiguration = UIImage.SymbolConfiguration(pointSize: 26, weight: .medium)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 15, weight: .medium)
+        label.textAlignment = .center
+        label.numberOfLines = 2
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let borderLayer = CAShapeLayer()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        setupConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupUI() {
+        contentView.backgroundColor = .clear
+        contentView.clipsToBounds = false
+        contentView.layer.cornerCurve = .continuous
+
+        borderLayer.fillColor = UIColor.clear.cgColor
+        borderLayer.lineDashPattern = [6, 4]
+        borderLayer.lineWidth = 1.5
+        contentView.layer.addSublayer(borderLayer)
+
+        contentView.addSubview(plusImageView)
+        contentView.addSubview(titleLabel)
+    }
+
+    private func setupConstraints() {
+        NSLayoutConstraint.activate([
+            plusImageView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            plusImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: -10),
+            plusImageView.widthAnchor.constraint(equalToConstant: 32),
+            plusImageView.heightAnchor.constraint(equalToConstant: 32),
+
+            titleLabel.topAnchor.constraint(equalTo: plusImageView.bottomAnchor, constant: 6),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 6),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -6),
+        ])
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        let cornerRadius = contentView.layer.cornerRadius
+        let path = UIBezierPath(roundedRect: contentView.bounds, cornerRadius: cornerRadius)
+        borderLayer.path = path.cgPath
+        borderLayer.frame = contentView.bounds
+
+        let tint = UIColor.currentTheme.withAlphaComponent(0.55)
+        borderLayer.strokeColor = tint.cgColor
+        plusImageView.tintColor = tint
+        titleLabel.textColor = tint
+    }
+
+    /// Placeholder 셀의 모양을 카테고리/메모 셀과 동일한 크기·코너로 맞춘다.
+    func configure(title: String, cornerRadius: CGFloat) {
+        titleLabel.text = title
+        contentView.layer.cornerRadius = cornerRadius
+        setNeedsLayout()
+    }
+
+}

--- a/NoteCard/Presentation/HomeView/HomeAddPlaceholderCell.swift
+++ b/NoteCard/Presentation/HomeView/HomeAddPlaceholderCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 /// 홈 화면에서 카테고리 / 전체 메모가 하나도 없을 때 추가를 유도하는 placeholder 셀.
-/// 가운데 + 아이콘과 "OOO 추가" 레이블, 점선 보더로 구성된다.
+/// 회색 배경 위에 가운데 + 아이콘과 "OOO 추가" 레이블로 구성된다.
 final class HomeAddPlaceholderCell: UICollectionViewCell, ViewShrinkable {
 
     override var isHighlighted: Bool {
@@ -20,6 +20,7 @@ final class HomeAddPlaceholderCell: UICollectionViewCell, ViewShrinkable {
         imageView.image = UIImage(systemName: "plus")
         imageView.contentMode = .scaleAspectFit
         imageView.preferredSymbolConfiguration = UIImage.SymbolConfiguration(pointSize: 26, weight: .medium)
+        imageView.tintColor = .secondaryLabel
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView
     }()
@@ -29,11 +30,10 @@ final class HomeAddPlaceholderCell: UICollectionViewCell, ViewShrinkable {
         label.font = .systemFont(ofSize: 15, weight: .medium)
         label.textAlignment = .center
         label.numberOfLines = 2
+        label.textColor = .secondaryLabel
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
-
-    private let borderLayer = CAShapeLayer()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -46,14 +46,9 @@ final class HomeAddPlaceholderCell: UICollectionViewCell, ViewShrinkable {
     }
 
     private func setupUI() {
-        contentView.backgroundColor = .clear
-        contentView.clipsToBounds = false
+        contentView.backgroundColor = .secondarySystemFill
+        contentView.clipsToBounds = true
         contentView.layer.cornerCurve = .continuous
-
-        borderLayer.fillColor = UIColor.clear.cgColor
-        borderLayer.lineDashPattern = [6, 4]
-        borderLayer.lineWidth = 1.5
-        contentView.layer.addSublayer(borderLayer)
 
         contentView.addSubview(plusImageView)
         contentView.addSubview(titleLabel)
@@ -72,25 +67,10 @@ final class HomeAddPlaceholderCell: UICollectionViewCell, ViewShrinkable {
         ])
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-
-        let cornerRadius = contentView.layer.cornerRadius
-        let path = UIBezierPath(roundedRect: contentView.bounds, cornerRadius: cornerRadius)
-        borderLayer.path = path.cgPath
-        borderLayer.frame = contentView.bounds
-
-        let tint = UIColor.currentTheme.withAlphaComponent(0.55)
-        borderLayer.strokeColor = tint.cgColor
-        plusImageView.tintColor = tint
-        titleLabel.textColor = tint
-    }
-
     /// Placeholder 셀의 모양을 카테고리/메모 셀과 동일한 크기·코너로 맞춘다.
     func configure(title: String, cornerRadius: CGFloat) {
         titleLabel.text = title
         contentView.layer.cornerRadius = cornerRadius
-        setNeedsLayout()
     }
 
 }

--- a/NoteCard/Presentation/HomeView/HomeAddPlaceholderCell.swift
+++ b/NoteCard/Presentation/HomeView/HomeAddPlaceholderCell.swift
@@ -35,6 +35,8 @@ final class HomeAddPlaceholderCell: UICollectionViewCell, ViewShrinkable {
         return label
     }()
 
+    private var plusImageCenterYConstraint: NSLayoutConstraint!
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
@@ -52,12 +54,17 @@ final class HomeAddPlaceholderCell: UICollectionViewCell, ViewShrinkable {
 
         contentView.addSubview(plusImageView)
         contentView.addSubview(titleLabel)
+
+        isAccessibilityElement = true
+        accessibilityTraits = .button
     }
 
     private func setupConstraints() {
+        plusImageCenterYConstraint = plusImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: -10)
+
         NSLayoutConstraint.activate([
             plusImageView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
-            plusImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: -10),
+            plusImageCenterYConstraint,
             plusImageView.widthAnchor.constraint(equalToConstant: 32),
             plusImageView.heightAnchor.constraint(equalToConstant: 32),
 
@@ -68,9 +75,17 @@ final class HomeAddPlaceholderCell: UICollectionViewCell, ViewShrinkable {
     }
 
     /// Placeholder 셀의 모양을 카테고리/메모 셀과 동일한 크기·코너로 맞춘다.
-    func configure(title: String, cornerRadius: CGFloat) {
-        titleLabel.text = title
+    /// - Parameters:
+    ///   - displayedTitle: 시각적으로 표시할 문구. nil이면 라벨을 숨기고 + 아이콘만 노출한다.
+    ///   - accessibilityLabel: VoiceOver에서 읽어줄 문구. 시각 라벨 유무와 무관하게 항상 설정한다.
+    ///   - cornerRadius: 셀 모서리 반경.
+    func configure(displayedTitle: String?, accessibilityLabel: String, cornerRadius: CGFloat) {
+        titleLabel.text = displayedTitle
+        titleLabel.isHidden = (displayedTitle == nil)
+        // 라벨이 숨겨지면 + 아이콘을 정중앙으로, 보이면 라벨 공간을 비워두기 위해 살짝 위로 이동.
+        plusImageCenterYConstraint.constant = (displayedTitle == nil) ? 0 : -10
         contentView.layer.cornerRadius = cornerRadius
+        self.accessibilityLabel = accessibilityLabel
     }
 
 }

--- a/NoteCard/Presentation/HomeView/HomeView.swift
+++ b/NoteCard/Presentation/HomeView/HomeView.swift
@@ -119,6 +119,7 @@ final class HomeView: UIView {
         
         self.homeCollectionView.register(HomeCategoryCell.self, forCellWithReuseIdentifier: HomeCategoryCell.reuseIdentifier)
         self.homeCollectionView.register(HomeCardCell.self, forCellWithReuseIdentifier: HomeCardCell.reuseIdentifier)
+        self.homeCollectionView.register(HomeAddPlaceholderCell.self, forCellWithReuseIdentifier: HomeAddPlaceholderCell.reuseIdentifier)
     }
     
     private func setupStyle() {

--- a/NoteCard/Presentation/HomeView/HomeViewController.swift
+++ b/NoteCard/Presentation/HomeView/HomeViewController.swift
@@ -21,14 +21,17 @@ class HomeViewController: UIViewController {
     enum HomeItem: Hashable {
         case category(Category)
         case memo(MemoHomeUIModel)
+        case addCategoryPlaceholder
+        case addMemoPlaceholder
     }
-    
+
     typealias DiffableDataSource = UICollectionViewDiffableDataSource<Section, HomeItem>
     typealias Snapshot = NSDiffableDataSourceSnapshot<Section, HomeItem>
     typealias CellProvider = DiffableDataSource.CellProvider
     typealias HeaderRegistration = UICollectionView.SupplementaryRegistration<HomeHeaderView>
     typealias CategoryCellRegistration = UICollectionView.CellRegistration<HomeCategoryCell, Category>
     typealias MemoCellRegistration = UICollectionView.CellRegistration<HomeCardCell, MemoHomeUIModel>
+    typealias PlaceholderCellRegistration = UICollectionView.CellRegistration<HomeAddPlaceholderCell, HomeItem>
     
     let sectionHederTitleArray: [String] = [
         L10n.Home.category,
@@ -112,11 +115,25 @@ class HomeViewController: UIViewController {
         let categoryCellRegistration = CategoryCellRegistration { cell, indexPath, category in
             cell.configure(with: category)
         }
-        
+
         let memoCellRegistration = MemoCellRegistration { cell, indexPath, memoUIModel in
             cell.configure(with: memoUIModel)
         }
-        
+
+        let placeholderCellRegistration = PlaceholderCellRegistration { cell, indexPath, item in
+            switch item {
+            case .addCategoryPlaceholder:
+                // HomeCategoryCell의 cornerRadius(25)와 동일.
+                cell.configure(title: L10n.Home.addCategoryPlaceholder, cornerRadius: 25)
+            case .addMemoPlaceholder:
+                // HomeCardCell의 cornerRadius(20)와 동일.
+                cell.configure(title: L10n.Home.addMemoPlaceholder, cornerRadius: 20)
+            case .category, .memo:
+                // 등록은 placeholder 전용이라 도달 불가.
+                break
+            }
+        }
+
         let headerViewRegistration = HeaderRegistration.init(
             elementKind: UICollectionView.elementKindSectionHeader
         ) { [weak self] headerView, elementKind, indexPath in
@@ -127,7 +144,7 @@ class HomeViewController: UIViewController {
             headerView.button.configuration?.title = self.sectionHederTitleArray[indexPath.section] + " "
             headerView.button.addTarget(self, action: #selector(self.onHeaderButtonTapped), for: .touchUpInside)
         }
-        
+
         // Cell Provider
         let cellProvider: CellProvider = { collectionView, indexPath, itemIdentifier in
             switch itemIdentifier {
@@ -141,6 +158,12 @@ class HomeViewController: UIViewController {
                     using: memoCellRegistration,
                     for: indexPath,
                     item: memo
+                )
+            case .addCategoryPlaceholder, .addMemoPlaceholder:
+                return collectionView.dequeueConfiguredReusableCell(
+                    using: placeholderCellRegistration,
+                    for: indexPath,
+                    item: itemIdentifier
                 )
             }
         }
@@ -165,9 +188,21 @@ class HomeViewController: UIViewController {
     private func applySnapshot() {
         var snapshot: Snapshot = .init()
         snapshot.appendSections(Section.allCases)
-        snapshot.appendItems(categories.map({ .category($0) }), toSection: .category)
+
+        if categories.isEmpty {
+            snapshot.appendItems([.addCategoryPlaceholder], toSection: .category)
+        } else {
+            snapshot.appendItems(categories.map({ .category($0) }), toSection: .category)
+        }
+
         snapshot.appendItems(favoriteMemos.map({ .memo(MemoHomeUIModel(memo: $0, section: .favorite)) }), toSection: .favorite)
-        snapshot.appendItems(allMemos.map({ .memo(MemoHomeUIModel(memo: $0, section: .all)) }), toSection: .all)
+
+        if allMemos.isEmpty {
+            snapshot.appendItems([.addMemoPlaceholder], toSection: .all)
+        } else {
+            snapshot.appendItems(allMemos.map({ .memo(MemoHomeUIModel(memo: $0, section: .all)) }), toSection: .all)
+        }
+
         diffableDataSource.apply(snapshot)
     }
     
@@ -245,7 +280,25 @@ class HomeViewController: UIViewController {
 extension HomeViewController: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        
+
+        // 빈 상태 placeholder 탭: 카테고리/메모 생성 화면을 곧바로 띄운다.
+        if let itemIdentifier = diffableDataSource.itemIdentifier(for: indexPath) {
+            switch itemIdentifier {
+            case .addCategoryPlaceholder:
+                let createCategoryVC = CreateCategoryViewController()
+                let naviCon = UINavigationController(rootViewController: createCategoryVC)
+                present(naviCon, animated: true)
+                return
+            case .addMemoPlaceholder:
+                let memoMakingVC = MemoDetailViewController(type: .making(category: nil))
+                let naviCon = UINavigationController(rootViewController: memoMakingVC)
+                present(naviCon, animated: true)
+                return
+            case .category, .memo:
+                break
+            }
+        }
+
         let config = WispConfiguration { config in
             config.setLayout { layout in
                 let topInset: CGFloat

--- a/NoteCard/Presentation/HomeView/HomeViewController.swift
+++ b/NoteCard/Presentation/HomeView/HomeViewController.swift
@@ -123,11 +123,20 @@ class HomeViewController: UIViewController {
         let placeholderCellRegistration = PlaceholderCellRegistration { cell, indexPath, item in
             switch item {
             case .addCategoryPlaceholder:
-                // HomeCategoryCell의 cornerRadius(25)와 동일.
-                cell.configure(title: L10n.Home.addCategoryPlaceholder, cornerRadius: 25)
+                // 카테고리 셀은 폭이 좁아 영문 "Add Category"가 줄바꿈되므로 시각 라벨은 생략하고
+                // VoiceOver에만 문구를 노출한다. cornerRadius는 HomeCategoryCell(25)과 동일.
+                cell.configure(
+                    displayedTitle: nil,
+                    accessibilityLabel: L10n.Home.addCategoryPlaceholder,
+                    cornerRadius: 25
+                )
             case .addMemoPlaceholder:
                 // HomeCardCell의 cornerRadius(20)와 동일.
-                cell.configure(title: L10n.Home.addMemoPlaceholder, cornerRadius: 20)
+                cell.configure(
+                    displayedTitle: L10n.Home.addMemoPlaceholder,
+                    accessibilityLabel: L10n.Home.addMemoPlaceholder,
+                    cornerRadius: 20
+                )
             case .category, .memo:
                 // 등록은 placeholder 전용이라 도달 불가.
                 break


### PR DESCRIPTION
## Summary
- 홈 화면에서 **카테고리** 또는 **전체 메모** 섹션이 비어 있을 때, 추가를 유도하는 placeholder 셀(가운데 + 아이콘 + 회색 배경)을 노출.
- 카테고리 placeholder: 폭이 좁아 영문 "Add Category"가 두 줄로 깨지는 문제를 피해 시각 라벨은 생략하고 + 아이콘만 표시. VoiceOver에는 `home.addCategoryPlaceholder` 문구를 `accessibilityLabel`로 노출.
- 메모 placeholder: 카드 폭이 넉넉해 "메모 추가" / "Add Memo" 텍스트도 함께 표시.
- 즐겨찾기 섹션은 작업 대상에서 제외 — 기존 동작 그대로.
- 섹션에 항목이 하나라도 있으면 placeholder는 자동으로 사라짐 (`applySnapshot`에서 `isEmpty` 분기).
- placeholder 탭 시:
  - 카테고리 → `CreateCategoryViewController` 모달
  - 메모 → `MemoDetailViewController(type: .making(category: nil))` 모달

## 변경 파일
- `HomeAddPlaceholderCell.swift` (신규): 회색 배경(`secondarySystemFill`) 위의 + 아이콘 + 선택적 타이틀 라벨, `ViewShrinkable` 적용.
- `HomeViewController.swift`: `HomeItem`에 `addCategoryPlaceholder` / `addMemoPlaceholder` 케이스 추가, cellProvider·snapshot·`didSelectItemAt` 갱신.
- `HomeView.swift`: 새 셀 register.
- `L10n.swift` + `Localizable.xcstrings`: `home.addCategoryPlaceholder`, `home.addMemoPlaceholder` 키 추가 (한/영).
- `NoteCard.xcodeproj/project.pbxproj`: 새 파일 등록.

## Test plan
- [x] 신규 설치 / 모든 카테고리·메모 삭제 후 홈 화면 진입 시 두 섹션에 placeholder가 표시된다.
- [x] 카테고리 placeholder 탭 → 카테고리 생성 모달이 뜨고, 생성 완료 후 placeholder가 새 카테고리 셀로 대체된다.
- [x] 메모 placeholder 탭 → 메모 작성 모달이 뜨고, 저장 후 placeholder가 새 메모 셀로 대체된다.
- [x] 카테고리/메모를 모두 삭제하면 placeholder가 다시 등장.
- [x] 즐겨찾기 섹션은 비어 있어도 placeholder가 나타나지 않는다.
- [x] 영어 로케일에서 카테고리 placeholder가 한 줄짜리 + 아이콘만 보인다 (텍스트 줄바꿈 없음).
- [x] VoiceOver로 카테고리 placeholder 포커스 시 "Add Category" (또는 "카테고리 추가")가 읽힌다.
- [x] 라이트/다크 모드 모두에서 회색 배경과 아이콘이 자연스럽게 표시된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)