### PR TITLE
feat(memo): 메모 편집 모드용 커스텀 floating toolbar 도입

### DIFF
--- a/NoteCard.xcodeproj/project.pbxproj
+++ b/NoteCard.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		4E1385092AF386260063817B /* InsetTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1385082AF386260063817B /* InsetTextField.swift */; };
 		4E13850F2AF386750063817B /* MemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E13850E2AF386750063817B /* MemoViewController.swift */; };
 		4E1385112AF386920063817B /* MemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1385102AF386920063817B /* MemoView.swift */; };
+		4EBB000B2E0F30CD00000011 /* MemoEditingToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EBB000A2E0F30CD00000010 /* MemoEditingToolbarView.swift */; };
 		4E1385192AF387100063817B /* SmallCardCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1385182AF387100063817B /* SmallCardCollectionViewCell.swift */; };
 		4E13851C2AF387480063817B /* CardImageShowingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E13851B2AF387480063817B /* CardImageShowingViewController.swift */; };
 		4E13851E2AF3875D0063817B /* CardImageShowingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E13851D2AF3875D0063817B /* CardImageShowingView.swift */; };
@@ -133,6 +134,7 @@
 		4E1385082AF386260063817B /* InsetTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetTextField.swift; sourceTree = "<group>"; };
 		4E13850E2AF386750063817B /* MemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoViewController.swift; sourceTree = "<group>"; };
 		4E1385102AF386920063817B /* MemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoView.swift; sourceTree = "<group>"; };
+		4EBB000A2E0F30CD00000010 /* MemoEditingToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoEditingToolbarView.swift; sourceTree = "<group>"; };
 		4E1385142AF386D10063817B /* MemoImageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoImageCollectionViewCell.swift; sourceTree = "<group>"; };
 		4E1385182AF387100063817B /* SmallCardCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallCardCollectionViewCell.swift; sourceTree = "<group>"; };
 		4E13851B2AF387480063817B /* CardImageShowingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardImageShowingViewController.swift; sourceTree = "<group>"; };
@@ -300,6 +302,7 @@
 			children = (
 				4E13850E2AF386750063817B /* MemoViewController.swift */,
 				4E1385102AF386920063817B /* MemoView.swift */,
+				4EBB000A2E0F30CD00000010 /* MemoEditingToolbarView.swift */,
 				4E462D682E2A1AF5004C0215 /* SmallCardCollectionView.swift */,
 				4E1385182AF387100063817B /* SmallCardCollectionViewCell.swift */,
 				4E1385142AF386D10063817B /* MemoImageCollectionViewCell.swift */,
@@ -611,6 +614,7 @@
 				4E4FCCBE2B3C3644000CBE17 /* DateFormatSettingTableViewCell.swift in Sources */,
 				4E13850F2AF386750063817B /* MemoViewController.swift in Sources */,
 				4E1385112AF386920063817B /* MemoView.swift in Sources */,
+				4EBB000B2E0F30CD00000011 /* MemoEditingToolbarView.swift in Sources */,
 				4E4FCCC52B3C5875000CBE17 /* TimeFormatSettingTableViewCell.swift in Sources */,
 				4EFC02DE2B42927700C778DF /* TextSizeSettingViewController.swift in Sources */,
 				4E1385032AF385B00063817B /* CategoryListTableViewCell.swift in Sources */,

--- a/NoteCard/Global/Localization/L10n.swift
+++ b/NoteCard/Global/Localization/L10n.swift
@@ -149,6 +149,7 @@ enum L10n {
         static let remove = "common.remove".localized()
         static let select = "common.select".localized()
         static let editingMode = "common.editingMode".localized()
+        static let more = "common.more".localized()
         static let recover = "common.recover".localized()
         static let alert = "common.alert".localized()
         static let actionCannotBeUndone = "common.actionCannotBeUndone".localized()

--- a/NoteCard/Localizable.xcstrings
+++ b/NoteCard/Localizable.xcstrings
@@ -290,6 +290,23 @@
         }
       }
     },
+    "common.more": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "더 보기"
+          }
+        }
+      }
+    },
     "common.ok": {
       "extractionState": "manual",
       "localizations": {

--- a/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
+++ b/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
@@ -100,16 +100,30 @@ final class MemoEditingToolbarView: UIView {
     // MARK: - Setup
 
     private func setupViewHierarchy() {
+        // 그림자가 잘리지 않도록 self는 clip하지 않고, 내부 backgroundEffectView에 코너 처리 + 클립.
         // 양 끝이 반원인 pill 모양. 탭바와 떨어져 떠 있는 floating bar 느낌.
-        clipsToBounds = true
-        layer.cornerRadius = Self.preferredHeight / 2
-        layer.cornerCurve = .continuous
+        backgroundEffectView.layer.cornerRadius = Self.preferredHeight / 2
+        backgroundEffectView.layer.cornerCurve = .continuous
+        backgroundEffectView.clipsToBounds = true
+
+        // 배경과의 경계가 흐릿한 글래스 머티리얼을 시각적으로 분리하기 위한 그림자.
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.22
+        layer.shadowRadius = 12
+        layer.shadowOffset = CGSize(width: 0, height: 4)
 
         addSubview(backgroundEffectView)
         let contentContainer: UIView = backgroundEffectView.contentView
         contentContainer.addSubview(countLabel)
         contentContainer.addSubview(deleteButton)
         contentContainer.addSubview(menuButton)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // pill 모양 그대로 그림자를 그리도록 path 캐시. 매 프레임 렌더링 비용 ↓.
+        let path = UIBezierPath(roundedRect: bounds, cornerRadius: Self.preferredHeight / 2)
+        layer.shadowPath = path.cgPath
     }
 
     private func setupLayoutConstraints() {

--- a/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
+++ b/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
@@ -159,4 +159,9 @@ final class MemoEditingToolbarView: UIView {
         menuButton.menu = menu
     }
 
+    /// Toolbar의 가시성을 토글한다. (이 단계에선 즉시 토글만, 다음 단계에서 슬라이드/페이드 애니메이션 추가)
+    func setVisible(_ visible: Bool, animated: Bool) {
+        isHidden = !visible
+    }
+
 }

--- a/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
+++ b/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
@@ -45,7 +45,11 @@ final class MemoEditingToolbarView: UIView {
 
     private let countLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 17, weight: .bold)
+        // Dynamic Type 대응: 17pt bold를 baseline으로 시스템 텍스트 크기 설정에 따라 스케일.
+        // pill 높이(49pt)를 유지하기 위해 AX 크기는 cap 처리 — 표준 XXXL까지만 적용.
+        label.font = UIFontMetrics.default.scaledFont(for: .systemFont(ofSize: 17, weight: .bold))
+        label.adjustsFontForContentSizeCategory = true
+        label.maximumContentSizeCategory = .extraExtraExtraLarge
         label.textColor = .label
         label.textAlignment = .natural
         label.lineBreakMode = .byTruncatingTail
@@ -59,9 +63,12 @@ final class MemoEditingToolbarView: UIView {
     private let deleteButton: UIButton = {
         var config = UIButton.Configuration.plain()
         config.image = UIImage(systemName: "trash")
+        // SF Symbol도 라벨과 같이 스케일하도록 textStyle 기반 symbol configuration 적용.
+        config.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(textStyle: .body)
         config.baseForegroundColor = .systemRed
         config.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12)
         let button = UIButton(configuration: config)
+        button.maximumContentSizeCategory = .extraExtraExtraLarge
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
@@ -69,9 +76,11 @@ final class MemoEditingToolbarView: UIView {
     private let menuButton: UIButton = {
         var config = UIButton.Configuration.plain()
         config.image = UIImage(systemName: "ellipsis.circle")
+        config.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(textStyle: .body)
         config.baseForegroundColor = .label
         config.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12)
         let button = UIButton(configuration: config)
+        button.maximumContentSizeCategory = .extraExtraExtraLarge
         button.showsMenuAsPrimaryAction = true
         button.translatesAutoresizingMaskIntoConstraints = false
         return button

--- a/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
+++ b/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
@@ -17,6 +17,14 @@ final class MemoEditingToolbarView: UIView {
     /// 권장 높이 — 시스템 toolbar(44~49pt)와 시각적으로 동등.
     static let preferredHeight: CGFloat = 49
 
+    /// 마지막으로 적용한 가시성. 같은 값으로 setVisible이 들어오면 무시한다.
+    private var isToolbarVisible: Bool = false
+
+    /// 숨겨진 상태에서 적용할 transform — 화면 아래로 살짝 더 밀어둠.
+    private var hiddenTransform: CGAffineTransform {
+        CGAffineTransform(translationX: 0, y: Self.preferredHeight + 12)
+    }
+
     // MARK: - Callbacks
 
     var onDeleteTapped: (() -> Void)?
@@ -80,6 +88,12 @@ final class MemoEditingToolbarView: UIView {
         setupLayoutConstraints()
         setupActions()
         setupAccessibility()
+
+        // 초기 상태: 화면 밖 + 투명 + 비활성. setVisible(true, ...)로 등장.
+        alpha = 0
+        transform = hiddenTransform
+        isUserInteractionEnabled = false
+        accessibilityElementsHidden = true
     }
 
     required init?(coder: NSCoder) {
@@ -159,9 +173,30 @@ final class MemoEditingToolbarView: UIView {
         menuButton.menu = menu
     }
 
-    /// Toolbar의 가시성을 토글한다. (이 단계에선 즉시 토글만, 다음 단계에서 슬라이드/페이드 애니메이션 추가)
+    /// Toolbar의 가시성을 토글한다. transform + alpha 보간으로 슬라이드 + 페이드.
     func setVisible(_ visible: Bool, animated: Bool) {
-        isHidden = !visible
+        guard visible != isToolbarVisible else { return }
+        isToolbarVisible = visible
+
+        let apply: () -> Void = { [weak self] in
+            guard let self else { return }
+            self.alpha = visible ? 1 : 0
+            self.transform = visible ? .identity : self.hiddenTransform
+        }
+
+        if animated {
+            UIView.springAnimate(
+                withDuration: 0.35,
+                dampingRatio: 0.85,
+                options: [.beginFromCurrentState],
+                animations: apply
+            )
+        } else {
+            apply()
+        }
+
+        isUserInteractionEnabled = visible
+        accessibilityElementsHidden = !visible
     }
 
 }

--- a/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
+++ b/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
@@ -47,8 +47,12 @@ final class MemoEditingToolbarView: UIView {
         let label = UILabel()
         label.font = .systemFont(ofSize: 17, weight: .bold)
         label.textColor = .label
-        label.textAlignment = .center
+        label.textAlignment = .natural
+        label.lineBreakMode = .byTruncatingTail
         label.translatesAutoresizingMaskIntoConstraints = false
+        // 가로 폭이 좁아지면 카운트 라벨을 우선적으로 줄임 (액션 버튼 보존).
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
         return label
     }()
 
@@ -117,13 +121,16 @@ final class MemoEditingToolbarView: UIView {
             backgroundEffectView.trailingAnchor.constraint(equalTo: trailingAnchor),
             backgroundEffectView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
-            countLabel.centerXAnchor.constraint(equalTo: contentContainer.centerXAnchor),
+            // 카운트 라벨: 좌측 정렬, pill 둥근 가장자리에서 18pt 안쪽.
+            // 액션 버튼 영역을 침범하지 않도록 trailing은 <=로 두어 좁아질 때 잘리도록 함.
+            countLabel.leadingAnchor.constraint(equalTo: contentContainer.leadingAnchor, constant: 18),
             countLabel.centerYAnchor.constraint(equalTo: contentContainer.centerYAnchor),
+            countLabel.trailingAnchor.constraint(lessThanOrEqualTo: deleteButton.leadingAnchor, constant: -8),
 
+            // 액션 버튼: 우측 정렬, 우선순위 높음 (압축 저항 default → 라벨이 먼저 줄어듦).
             deleteButton.trailingAnchor.constraint(equalTo: menuButton.leadingAnchor, constant: -4),
             deleteButton.centerYAnchor.constraint(equalTo: contentContainer.centerYAnchor),
 
-            // pill의 둥근 우측 가장자리에 가까이 붙지 않도록 인셋을 키움.
             menuButton.trailingAnchor.constraint(equalTo: contentContainer.trailingAnchor, constant: -14),
             menuButton.centerYAnchor.constraint(equalTo: contentContainer.centerYAnchor),
         ])

--- a/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
+++ b/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
@@ -1,0 +1,162 @@
+//
+//  MemoEditingToolbarView.swift
+//  NoteCard
+//
+//  Created by 김민성 on 5/11/26.
+//
+
+import UIKit
+
+/// 메모 편집 모드에서 시스템 `UINavigationController.toolbar`를 대체하는 커스텀 하단 toolbar.
+///
+/// iOS 26+에서는 Liquid Glass 머티리얼을, 그 이전 버전에서는 chrome blur 머티리얼을 사용한다.
+/// `MemoView` 안에 임베드되어 `safeAreaLayoutGuide.bottomAnchor`에 부착되므로 OS 버전과 무관하게
+/// 항상 콘텐츠 safe area 하단(탭바 위)에 위치한다.
+final class MemoEditingToolbarView: UIView {
+
+    /// 권장 높이 — 시스템 toolbar(44~49pt)와 시각적으로 동등.
+    static let preferredHeight: CGFloat = 49
+
+    // MARK: - Callbacks
+
+    var onDeleteTapped: (() -> Void)?
+
+    // MARK: - Subviews
+
+    private let backgroundEffectView: UIVisualEffectView = {
+        let effect: UIVisualEffect
+        if #available(iOS 26.0, *) {
+            effect = UIGlassEffect(style: .regular)
+        } else {
+            effect = UIBlurEffect(style: .systemChromeMaterial)
+        }
+        let view = UIVisualEffectView(effect: effect)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let topSeparator: UIView = {
+        let view = UIView()
+        view.backgroundColor = .separator
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let countLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 17, weight: .bold)
+        label.textColor = .label
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let deleteButton: UIButton = {
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "trash")
+        config.baseForegroundColor = .systemRed
+        config.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12)
+        let button = UIButton(configuration: config)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private let menuButton: UIButton = {
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "ellipsis.circle")
+        config.baseForegroundColor = .label
+        config.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12)
+        let button = UIButton(configuration: config)
+        button.showsMenuAsPrimaryAction = true
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    // MARK: - Init
+
+    init() {
+        super.init(frame: .zero)
+        setupViewHierarchy()
+        setupLayoutConstraints()
+        setupActions()
+        setupAccessibility()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupViewHierarchy() {
+        addSubview(backgroundEffectView)
+        // iOS 26 Liquid Glass에는 별도 separator가 어울리지 않으므로 pre-iOS 26에서만 표시.
+        if #available(iOS 26.0, *) {
+            // separator 미사용
+        } else {
+            addSubview(topSeparator)
+        }
+        let contentContainer: UIView = backgroundEffectView.contentView
+        contentContainer.addSubview(countLabel)
+        contentContainer.addSubview(deleteButton)
+        contentContainer.addSubview(menuButton)
+    }
+
+    private func setupLayoutConstraints() {
+        let contentContainer = backgroundEffectView.contentView
+
+        NSLayoutConstraint.activate([
+            backgroundEffectView.topAnchor.constraint(equalTo: topAnchor),
+            backgroundEffectView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            backgroundEffectView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            backgroundEffectView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            countLabel.centerXAnchor.constraint(equalTo: contentContainer.centerXAnchor),
+            countLabel.centerYAnchor.constraint(equalTo: contentContainer.centerYAnchor),
+
+            deleteButton.trailingAnchor.constraint(equalTo: menuButton.leadingAnchor, constant: -4),
+            deleteButton.centerYAnchor.constraint(equalTo: contentContainer.centerYAnchor),
+
+            menuButton.trailingAnchor.constraint(equalTo: contentContainer.trailingAnchor, constant: -8),
+            menuButton.centerYAnchor.constraint(equalTo: contentContainer.centerYAnchor),
+        ])
+
+        if topSeparator.superview != nil {
+            NSLayoutConstraint.activate([
+                topSeparator.topAnchor.constraint(equalTo: topAnchor),
+                topSeparator.leadingAnchor.constraint(equalTo: leadingAnchor),
+                topSeparator.trailingAnchor.constraint(equalTo: trailingAnchor),
+                topSeparator.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale),
+            ])
+        }
+    }
+
+    private func setupActions() {
+        deleteButton.addTarget(self, action: #selector(deleteTapped), for: .touchUpInside)
+    }
+
+    private func setupAccessibility() {
+        deleteButton.accessibilityLabel = L10n.Common.delete
+        menuButton.accessibilityLabel = L10n.Common.editingMode
+    }
+
+    @objc private func deleteTapped() {
+        onDeleteTapped?()
+    }
+
+    // MARK: - Public API
+
+    /// 선택된 메모 개수를 반영한다. 라벨/액션 버튼 활성 상태를 함께 갱신한다.
+    func setSelectedCount(_ count: Int) {
+        countLabel.text = String(format: L10n.MemoView.memosSelectedFormat, count)
+        let hasSelection = count > 0
+        deleteButton.isEnabled = hasSelection
+        menuButton.isEnabled = hasSelection
+    }
+
+    /// 메뉴 버튼에 표시할 `UIMenu`를 주입한다. memoVCType에 따른 분기는 호출 측이 담당.
+    func configureMenu(_ menu: UIMenu) {
+        menuButton.menu = menu
+    }
+
+}

--- a/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
+++ b/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
@@ -100,30 +100,19 @@ final class MemoEditingToolbarView: UIView {
     // MARK: - Setup
 
     private func setupViewHierarchy() {
-        // 그림자가 잘리지 않도록 self는 clip하지 않고, 내부 backgroundEffectView에 코너 처리 + 클립.
         // 양 끝이 반원인 pill 모양. 탭바와 떨어져 떠 있는 floating bar 느낌.
-        backgroundEffectView.layer.cornerRadius = Self.preferredHeight / 2
-        backgroundEffectView.layer.cornerCurve = .continuous
-        backgroundEffectView.clipsToBounds = true
-
-        // 배경과의 경계가 흐릿한 글래스 머티리얼을 시각적으로 분리하기 위한 그림자.
-        layer.shadowColor = UIColor.black.cgColor
-        layer.shadowOpacity = 0.22
-        layer.shadowRadius = 12
-        layer.shadowOffset = CGSize(width: 0, height: 4)
+        // cornerRadius/clipsToBounds는 self에 둔다. UIVisualEffectView 쪽에 두면
+        // 메뉴 표시/해제 시 시스템이 effect view 레이어를 재구성하는 과정에서
+        // cornerRadius가 일시적으로 리셋되는 quirk가 발생함.
+        clipsToBounds = true
+        layer.cornerRadius = Self.preferredHeight / 2
+        layer.cornerCurve = .continuous
 
         addSubview(backgroundEffectView)
         let contentContainer: UIView = backgroundEffectView.contentView
         contentContainer.addSubview(countLabel)
         contentContainer.addSubview(deleteButton)
         contentContainer.addSubview(menuButton)
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        // pill 모양 그대로 그림자를 그리도록 path 캐시. 매 프레임 렌더링 비용 ↓.
-        let path = UIBezierPath(roundedRect: bounds, cornerRadius: Self.preferredHeight / 2)
-        layer.shadowPath = path.cgPath
     }
 
     private func setupLayoutConstraints() {

--- a/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
+++ b/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
@@ -43,13 +43,6 @@ final class MemoEditingToolbarView: UIView {
         return view
     }()
 
-    private let topSeparator: UIView = {
-        let view = UIView()
-        view.backgroundColor = .separator
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
-    }()
-
     private let countLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 17, weight: .bold)
@@ -103,13 +96,12 @@ final class MemoEditingToolbarView: UIView {
     // MARK: - Setup
 
     private func setupViewHierarchy() {
+        // 양 끝이 반원인 pill 모양. 탭바와 떨어져 떠 있는 floating bar 느낌.
+        clipsToBounds = true
+        layer.cornerRadius = Self.preferredHeight / 2
+        layer.cornerCurve = .continuous
+
         addSubview(backgroundEffectView)
-        // iOS 26 Liquid Glass에는 별도 separator가 어울리지 않으므로 pre-iOS 26에서만 표시.
-        if #available(iOS 26.0, *) {
-            // separator 미사용
-        } else {
-            addSubview(topSeparator)
-        }
         let contentContainer: UIView = backgroundEffectView.contentView
         contentContainer.addSubview(countLabel)
         contentContainer.addSubview(deleteButton)
@@ -131,18 +123,10 @@ final class MemoEditingToolbarView: UIView {
             deleteButton.trailingAnchor.constraint(equalTo: menuButton.leadingAnchor, constant: -4),
             deleteButton.centerYAnchor.constraint(equalTo: contentContainer.centerYAnchor),
 
-            menuButton.trailingAnchor.constraint(equalTo: contentContainer.trailingAnchor, constant: -8),
+            // pill의 둥근 우측 가장자리에 가까이 붙지 않도록 인셋을 키움.
+            menuButton.trailingAnchor.constraint(equalTo: contentContainer.trailingAnchor, constant: -14),
             menuButton.centerYAnchor.constraint(equalTo: contentContainer.centerYAnchor),
         ])
-
-        if topSeparator.superview != nil {
-            NSLayoutConstraint.activate([
-                topSeparator.topAnchor.constraint(equalTo: topAnchor),
-                topSeparator.leadingAnchor.constraint(equalTo: leadingAnchor),
-                topSeparator.trailingAnchor.constraint(equalTo: trailingAnchor),
-                topSeparator.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale),
-            ])
-        }
     }
 
     private func setupActions() {

--- a/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
+++ b/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
@@ -151,7 +151,8 @@ final class MemoEditingToolbarView: UIView {
 
     private func setupAccessibility() {
         deleteButton.accessibilityLabel = L10n.Common.delete
-        menuButton.accessibilityLabel = L10n.Common.editingMode
+        menuButton.accessibilityLabel = L10n.Common.more
+        countLabel.accessibilityTraits = .updatesFrequently
     }
 
     @objc private func deleteTapped() {
@@ -197,6 +198,11 @@ final class MemoEditingToolbarView: UIView {
 
         isUserInteractionEnabled = visible
         accessibilityElementsHidden = !visible
+
+        if visible && UIAccessibility.isVoiceOverRunning {
+            // VoiceOver 사용자가 toolbar 등장을 알아챌 수 있도록 포커스를 카운트 라벨로 이동
+            UIAccessibility.post(notification: .layoutChanged, argument: countLabel)
+        }
     }
 
 }

--- a/NoteCard/Presentation/MemoView/MemoView.swift
+++ b/NoteCard/Presentation/MemoView/MemoView.swift
@@ -88,9 +88,10 @@ final class MemoView: UIView {
 
         editingToolbar.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            editingToolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
-            editingToolbar.trailingAnchor.constraint(equalTo: trailingAnchor),
-            editingToolbar.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+            // 탭바와 떨어진 floating pill로 보이도록 좌우 인셋 + 탭바 위 gap.
+            editingToolbar.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            editingToolbar.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            editingToolbar.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -12),
             editingToolbar.heightAnchor.constraint(equalToConstant: MemoEditingToolbarView.preferredHeight),
         ])
     }

--- a/NoteCard/Presentation/MemoView/MemoView.swift
+++ b/NoteCard/Presentation/MemoView/MemoView.swift
@@ -9,9 +9,10 @@ import UIKit
 
 
 final class MemoView: UIView {
-    
+
     let categoryNameTextField = UITextField()
     let smallCardCollectionView = SmallCardCollectionView()
+    let editingToolbar = MemoEditingToolbarView()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -63,8 +64,9 @@ final class MemoView: UIView {
     private func configureViewHierarchy() {
         self.addSubview(categoryNameTextField)
         self.addSubview(smallCardCollectionView)
+        self.addSubview(editingToolbar)
     }
-    
+
     func setupConstraints() {
         categoryNameTextField.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -72,13 +74,22 @@ final class MemoView: UIView {
             categoryNameTextField.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 20),
             categoryNameTextField.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -20),
         ])
-        
+
         smallCardCollectionView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             smallCardCollectionView.topAnchor.constraint(equalTo: categoryNameTextField.bottomAnchor, constant: 20),
             smallCardCollectionView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 0),
             smallCardCollectionView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 0),
             smallCardCollectionView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: 0)
+        ])
+
+        editingToolbar.translatesAutoresizingMaskIntoConstraints = false
+        editingToolbar.isHidden = true
+        NSLayoutConstraint.activate([
+            editingToolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
+            editingToolbar.trailingAnchor.constraint(equalTo: trailingAnchor),
+            editingToolbar.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+            editingToolbar.heightAnchor.constraint(equalToConstant: MemoEditingToolbarView.preferredHeight),
         ])
     }
     

--- a/NoteCard/Presentation/MemoView/MemoView.swift
+++ b/NoteCard/Presentation/MemoView/MemoView.swift
@@ -84,7 +84,6 @@ final class MemoView: UIView {
         ])
 
         editingToolbar.translatesAutoresizingMaskIntoConstraints = false
-        editingToolbar.isHidden = true
         NSLayoutConstraint.activate([
             editingToolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
             editingToolbar.trailingAnchor.constraint(equalTo: trailingAnchor),

--- a/NoteCard/Presentation/MemoView/MemoView.swift
+++ b/NoteCard/Presentation/MemoView/MemoView.swift
@@ -80,7 +80,10 @@ final class MemoView: UIView {
             smallCardCollectionView.topAnchor.constraint(equalTo: categoryNameTextField.bottomAnchor, constant: 20),
             smallCardCollectionView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 0),
             smallCardCollectionView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 0),
-            smallCardCollectionView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: 0)
+            // 카드가 글래스 탭바/편집 toolbar 뒤로 스크롤되어 깊이감을 살리도록 화면 최하단까지 확장.
+            // 콘텐츠가 가려지지 않도록 하는 건 contentInsetAdjustmentBehavior(.automatic)의 safe area 보정 +
+            // MemoViewController가 toolbar 가시성에 맞춰 토글하는 contentInset.bottom이 함께 처리한다.
+            smallCardCollectionView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 0)
         ])
 
         editingToolbar.translatesAutoresizingMaskIntoConstraints = false

--- a/NoteCard/Presentation/MemoView/MemoViewController.swift
+++ b/NoteCard/Presentation/MemoView/MemoViewController.swift
@@ -121,13 +121,33 @@ class MemoViewController: UIViewController {
             self.plusBarButtonItem.isEnabled = false
             let selectedCount = smallCardCollectionView.indexPathsForSelectedItems?.count ?? 0
             rootView.editingToolbar.setSelectedCount(selectedCount)
-            rootView.editingToolbar.setVisible(selectedCount > 0, animated: animated)
+            updateToolbarVisibility(visible: selectedCount > 0, animated: animated)
 
         case false:
             self.tabBarController?.tabBar.clipsToBounds = false
             self.smallCardCollectionView.reconfigureItems(at: self.smallCardCollectionView.indexPathsForVisibleItems)
             self.plusBarButtonItem.isEnabled = true
-            rootView.editingToolbar.setVisible(false, animated: animated)
+            updateToolbarVisibility(visible: false, animated: animated)
+        }
+    }
+
+    /// 편집 toolbar 가시성과 콘텐츠 인셋을 함께 보간한다.
+    /// toolbar 등장 시 collection view 마지막 셀이 가려지지 않도록 additionalSafeAreaInsets.bottom을 토글.
+    private func updateToolbarVisibility(visible: Bool, animated: Bool) {
+        rootView.editingToolbar.setVisible(visible, animated: animated)
+        let targetBottomInset: CGFloat = visible ? MemoEditingToolbarView.preferredHeight : 0
+        guard additionalSafeAreaInsets.bottom != targetBottomInset else { return }
+
+        let apply = { [weak self] in
+            guard let self else { return }
+            self.additionalSafeAreaInsets.bottom = targetBottomInset
+            self.view.layoutIfNeeded()
+        }
+
+        if animated {
+            UIView.springAnimate(withDuration: 0.35, dampingRatio: 0.85, animations: apply)
+        } else {
+            apply()
         }
     }
     
@@ -545,7 +565,7 @@ extension MemoViewController: UICollectionViewDelegate {
         let count = smallCardCollectionView.indexPathsForSelectedItems?.count ?? 0
         rootView.editingToolbar.setSelectedCount(count)
         if count == 1 {
-            rootView.editingToolbar.setVisible(true, animated: true)
+            updateToolbarVisibility(visible: true, animated: true)
         }
     }
 
@@ -554,7 +574,7 @@ extension MemoViewController: UICollectionViewDelegate {
         let count = smallCardCollectionView.indexPathsForSelectedItems?.count ?? 0
         rootView.editingToolbar.setSelectedCount(count)
         if count == 0 {
-            rootView.editingToolbar.setVisible(false, animated: true)
+            updateToolbarVisibility(visible: false, animated: true)
         }
     }
     

--- a/NoteCard/Presentation/MemoView/MemoViewController.swift
+++ b/NoteCard/Presentation/MemoView/MemoViewController.swift
@@ -139,7 +139,9 @@ class MemoViewController: UIViewController {
     /// toolbar 자체까지 위로 밀어버려 탭바와의 간격을 망가뜨림.)
     private func updateToolbarVisibility(visible: Bool, animated: Bool) {
         rootView.editingToolbar.setVisible(visible, animated: animated)
-        let targetBottomInset: CGFloat = visible ? MemoEditingToolbarView.preferredHeight : 0
+        // toolbar는 safe area 위로 12pt 띄워 floating pill로 배치되므로 콘텐츠가
+        // 토글바 바로 위에서 멈추려면 toolbar height + 12pt gap만큼 인셋 확보.
+        let targetBottomInset: CGFloat = visible ? MemoEditingToolbarView.preferredHeight + 12 : 0
         let cv = rootView.smallCardCollectionView
         guard cv.contentInset.bottom != targetBottomInset else { return }
 

--- a/NoteCard/Presentation/MemoView/MemoViewController.swift
+++ b/NoteCard/Presentation/MemoView/MemoViewController.swift
@@ -132,16 +132,18 @@ class MemoViewController: UIViewController {
     }
 
     /// 편집 toolbar 가시성과 콘텐츠 인셋을 함께 보간한다.
-    /// toolbar 등장 시 collection view 마지막 셀이 가려지지 않도록 additionalSafeAreaInsets.bottom을 토글.
+    /// toolbar 등장 시 collection view 마지막 셀이 가려지지 않도록 contentInset.bottom을 토글한다.
+    /// (additionalSafeAreaInsets 대신 contentInset을 쓰는 이유: 전자는 safeAreaLayoutGuide에 묶인
+    /// toolbar 자체까지 위로 밀어버려 탭바와의 간격을 망가뜨림.)
     private func updateToolbarVisibility(visible: Bool, animated: Bool) {
         rootView.editingToolbar.setVisible(visible, animated: animated)
         let targetBottomInset: CGFloat = visible ? MemoEditingToolbarView.preferredHeight : 0
-        guard additionalSafeAreaInsets.bottom != targetBottomInset else { return }
+        let cv = rootView.smallCardCollectionView
+        guard cv.contentInset.bottom != targetBottomInset else { return }
 
-        let apply = { [weak self] in
-            guard let self else { return }
-            self.additionalSafeAreaInsets.bottom = targetBottomInset
-            self.view.layoutIfNeeded()
+        let apply = {
+            cv.contentInset.bottom = targetBottomInset
+            cv.verticalScrollIndicatorInsets.bottom = targetBottomInset
         }
 
         if animated {

--- a/NoteCard/Presentation/MemoView/MemoViewController.swift
+++ b/NoteCard/Presentation/MemoView/MemoViewController.swift
@@ -53,13 +53,7 @@ class MemoViewController: UIViewController {
     
     // navigationItems
     private let plusBarButtonItem = UIBarButtonItem()
-    
-    // (bottom) tool bar Items
-    private let labelBarButtonItem = UIBarButtonItem()
-    private let flexibleBarButtonItems = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-    private let deleteBarButtonItem = UIBarButtonItem()
-    private let ellipsisBarButtonItem = UIBarButtonItem()
-    
+
     private var restoreMemoAction: UIAction!
     private var batchAddCategoryMenuAction: UIAction!
     private var batchRemoveCategoryMenuAction: UIAction!
@@ -91,11 +85,11 @@ class MemoViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         setupNaviBar()
-        setupToolbar()
         setupBarButtonActions()
         setupBarButtonItems()
+        setupEditingToolbar()
         setupDelegates()
         setupObservers()
         Task {
@@ -109,32 +103,31 @@ class MemoViewController: UIViewController {
     
     override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: animated)
-        
+
         UIView.springAnimate(withDuration: 0.4) { [weak self] in
-            self?.navigationController?.isToolbarHidden = !editing
             self?.rootView.layoutIfNeeded()
         }
         self.smallCardCollectionView.isEditing = editing
         self.smallCardCollectionView.delaysContentTouches = editing
         self.categoryNameTextField.isEnabled = (!editing && memoVCType.isCategory)
-        // editnButtonItem 의 기본 구현이라서 굳이 필요 없는 듯...?
-//        self.editButtonItem.title = editing ? L10n.Common.done : L10n.Common.select
-        
+
         switch editing {
         case true:
             self.smallCardCollectionView.reconfigureItems(at: self.smallCardCollectionView.indexPathsForVisibleItems)
             self.smallCardCollectionView.visibleCells.forEach { cell in
                 cell.layoutSubviews()
             }
-            
+
             self.plusBarButtonItem.isEnabled = false
-            self.deleteBarButtonItem.isEnabled = false
-            self.ellipsisBarButtonItem.isEnabled = false
-            
+            let selectedCount = smallCardCollectionView.indexPathsForSelectedItems?.count ?? 0
+            rootView.editingToolbar.setSelectedCount(selectedCount)
+            rootView.editingToolbar.setVisible(selectedCount > 0, animated: animated)
+
         case false:
             self.tabBarController?.tabBar.clipsToBounds = false
             self.smallCardCollectionView.reconfigureItems(at: self.smallCardCollectionView.indexPathsForVisibleItems)
             self.plusBarButtonItem.isEnabled = true
+            rootView.editingToolbar.setVisible(false, animated: animated)
         }
     }
     
@@ -164,29 +157,8 @@ private extension MemoViewController {
         self.navigationController?.navigationBar.compactAppearance = appearance
         self.navigationController?.navigationBar.compactScrollEdgeAppearance = appearance
         self.navigationController?.navigationBar.tintColor = .currentTheme
-        
-        let toolbarAppearance = UIToolbarAppearance()
-        toolbarAppearance.configureWithDefaultBackground()
-        
-        let transparentToolbarAppearance = UIToolbarAppearance()
-        transparentToolbarAppearance.configureWithTransparentBackground()
-        
-        self.navigationController?.toolbar.standardAppearance = toolbarAppearance
-        self.navigationController?.toolbar.scrollEdgeAppearance = toolbarAppearance
-        self.navigationController?.isToolbarHidden = true
     }
-    
-    func setupToolbar(animated: Bool = true) {
-        setToolbarItems(
-            [flexibleBarButtonItems,
-             labelBarButtonItem,
-             flexibleBarButtonItems,
-             deleteBarButtonItem,
-             ellipsisBarButtonItem],
-            animated: animated
-        )
-    }
-    
+
     func setupBarButtonActions() {
         restoreMemoAction = UIAction(
             title: L10n.MemoView.recoverAsUncategorizedMultiple,
@@ -253,38 +225,28 @@ private extension MemoViewController {
         plusBarButtonItem.image = UIImage(systemName: "plus")
         plusBarButtonItem.target = self
         plusBarButtonItem.action = #selector(presentMemoMakingVC)
-        
-        deleteBarButtonItem.image = UIImage(systemName: "trash")
-        deleteBarButtonItem.tintColor = .systemRed
-        deleteBarButtonItem.target = self
-        deleteBarButtonItem.action = #selector(deleteEverySelectedMemo)
-        
-        ellipsisBarButtonItem.image = UIImage(systemName: "ellipsis.circle")
-        let ellipsisBarButtonItemMenu: UIMenu
+    }
+
+    func setupEditingToolbar() {
+        let menu: UIMenu
         if memoVCType == .trash {
-            ellipsisBarButtonItemMenu = UIMenu(children: [
+            menu = UIMenu(children: [
                 batchAddCategoryMenuAction,
                 restoreMemoAction
             ])
         } else {
-            ellipsisBarButtonItemMenu = UIMenu(children: [
+            menu = UIMenu(children: [
                 batchRemoveCategoryMenuAction,
                 batchAddCategoryMenuAction,
                 unsetFavoriteMenuAction,
                 setFavoriteMenuAction
             ])
         }
-        ellipsisBarButtonItem.menu = ellipsisBarButtonItemMenu
-        
-        labelBarButtonItem.setTitleTextAttributes(
-            [.font: UIFont.systemFont(ofSize: 17, weight: .bold)],
-            for: .normal
-        )
-        labelBarButtonItem.tintColor = .label
-        labelBarButtonItem.title = String(
-            format: L10n.MemoView.memosSelectedFormat,
-            smallCardCollectionView.indexPathsForSelectedItems?.count ?? 0
-        )
+        rootView.editingToolbar.configureMenu(menu)
+        rootView.editingToolbar.setSelectedCount(0)
+        rootView.editingToolbar.onDeleteTapped = { [weak self] in
+            self?.deleteEverySelectedMemo()
+        }
     }
     
     func setupDelegates() {
@@ -580,26 +542,19 @@ extension MemoViewController: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard self.smallCardCollectionView.isEditing else { return }
-        self.deleteBarButtonItem.isEnabled = true
-        self.ellipsisBarButtonItem.isEnabled = true
-        labelBarButtonItem.title = String(
-            format: L10n.MemoView.memosSelectedFormat,
-            smallCardCollectionView.indexPathsForSelectedItems?.count ?? 0
-        )
+        let count = smallCardCollectionView.indexPathsForSelectedItems?.count ?? 0
+        rootView.editingToolbar.setSelectedCount(count)
+        if count == 1 {
+            rootView.editingToolbar.setVisible(true, animated: true)
+        }
     }
 
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         guard collectionView == self.smallCardCollectionView else { return }
-        labelBarButtonItem.title = String(
-            format: L10n.MemoView.memosSelectedFormat,
-            smallCardCollectionView.indexPathsForSelectedItems?.count ?? 0
-        )
-        if self.smallCardCollectionView.indexPathsForSelectedItems?.count == 0 {
-            self.ellipsisBarButtonItem.isEnabled = false
-            self.deleteBarButtonItem.isEnabled = false
-        } else {
-            self.deleteBarButtonItem.isEnabled = true
-            self.ellipsisBarButtonItem.isEnabled = true
+        let count = smallCardCollectionView.indexPathsForSelectedItems?.count ?? 0
+        rootView.editingToolbar.setSelectedCount(count)
+        if count == 0 {
+            rootView.editingToolbar.setVisible(false, animated: true)
         }
     }
     

--- a/NoteCard/Presentation/MemoView/MemoViewController.swift
+++ b/NoteCard/Presentation/MemoView/MemoViewController.swift
@@ -121,7 +121,9 @@ class MemoViewController: UIViewController {
             self.plusBarButtonItem.isEnabled = false
             let selectedCount = smallCardCollectionView.indexPathsForSelectedItems?.count ?? 0
             rootView.editingToolbar.setSelectedCount(selectedCount)
-            updateToolbarVisibility(visible: selectedCount > 0, animated: animated)
+            // 선택 카운트와 무관하게 편집 모드 동안은 항상 toolbar 노출.
+            // 0개 선택 시에는 카운트 라벨만 표시되고 액션 버튼은 비활성으로 그레이아웃됨.
+            updateToolbarVisibility(visible: true, animated: animated)
 
         case false:
             self.tabBarController?.tabBar.clipsToBounds = false
@@ -566,18 +568,12 @@ extension MemoViewController: UICollectionViewDelegate {
         guard self.smallCardCollectionView.isEditing else { return }
         let count = smallCardCollectionView.indexPathsForSelectedItems?.count ?? 0
         rootView.editingToolbar.setSelectedCount(count)
-        if count == 1 {
-            updateToolbarVisibility(visible: true, animated: true)
-        }
     }
 
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         guard collectionView == self.smallCardCollectionView else { return }
         let count = smallCardCollectionView.indexPathsForSelectedItems?.count ?? 0
         rootView.editingToolbar.setSelectedCount(count)
-        if count == 0 {
-            updateToolbarVisibility(visible: false, animated: true)
-        }
     }
     
     func updateMemoContents() async throws {

--- a/NoteCard/Presentation/TabBar/MainTabBarController.swift
+++ b/NoteCard/Presentation/TabBar/MainTabBarController.swift
@@ -39,7 +39,12 @@ class MainTabBarController: UITabBarController {
         let standardAppearance = UITabBarAppearance()
         standardAppearance.configureWithDefaultBackground()
         tabBar.standardAppearance = standardAppearance
-        
+        // scrollEdgeAppearance를 명시하지 않으면 시스템이 standardAppearance를
+        // 가져다 배경을 투명으로 바꿔 사용함. content가 작아 scroll edge에 머무는 화면
+        // (예: 메모가 적은 MemoView)에서 tab bar가 투명해지는 현상의 원인.
+        // iOS 26+에서는 default background가 곧 Liquid Glass 머티리얼이므로 동일 객체로 충분.
+        tabBar.scrollEdgeAppearance = standardAppearance
+
         tabBar.tintColor = UIColor.currentTheme
     }
     


### PR DESCRIPTION
## Summary

iOS 26의 floating Liquid Glass 탭바 도입 이후, 메모 편집 모드 진입 시 `navigationController.toolbar`가 탭바 뒤에 가려지던 인터랙션 이슈를 **커스텀 toolbar 뷰로 교체**해 해결. 이 김에 디자인 자율도(pill 모양, floating 배치, glass 머티리얼 분기)도 함께 확보. 발견된 부수 버그(탭바 scrollEdgeAppearance 누락)도 같이 잡음.

### 핵심 변경
- **신규 `MemoEditingToolbarView`** (`NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift`)
  - iOS 26+: `UIGlassEffect(style: .regular)` Liquid Glass / pre-26: `UIBlurEffect(.systemChromeMaterial)` 분기
  - 양 끝 반원 pill 모양 (`cornerRadius = height/2`), 탭바와 12pt gap, 좌우 20pt 인셋의 floating 배치
  - `setSelectedCount` / `setVisible(_:animated:)` / `configureMenu(_:)` / `onDeleteTapped` 콜백 API
  - 등장/퇴장: spring 0.35s, dampingRatio 0.85, `.beginFromCurrentState`로 빠른 토글 인터럽션 안전
  - 카운트 라벨 좌측 / 액션 버튼 우측. 좁은 폭(iPad split view 등)에서 라벨이 먼저 truncate, 액션 버튼 우선 보존
  - Dynamic Type 표준 크기까지 지원 (XXXL cap)
  - VoiceOver: 각 버튼 한국어/영어 accessibilityLabel, 등장 시 `.layoutChanged` notification으로 포커스 이동
- **`MemoViewController`**: 시스템 `UINavigationController.toolbar` 관련 코드 제거. 편집 모드 진입/종료 시 항상 toolbar 노출, 선택 카운트에 따라 액션 버튼 enable 토글. 콘텐츠 영역 보정은 `cv.contentInset.bottom`으로 (additionalSafeAreaInsets 사용 시 발생하던 toolbar floating 버그 회피)
- **`MemoView`**: collection view 하단을 `safeAreaLayoutGuide.bottomAnchor` → `view.bottomAnchor`로 확장. 카드가 글래스 탭바/toolbar 뒤로 자연스럽게 스크롤되며 깊이감 살아남
- **`MainTabBarController` (별도 fix)**: `scrollEdgeAppearance`를 `standardAppearance`와 동일 객체로 명시. content가 적은 화면(MemoView 등)에서 탭바가 투명해지던 문제 해결. iOS 26 Liquid Glass 머티리얼은 default background로 보존

### 로컬라이즈 추가
- `common.more` (한: "더 보기" / 영: "More") — ellipsis 메뉴 버튼 VoiceOver 라벨

## Test plan

### 자동
- [x] `xcodebuild -scheme NoteCard -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO` 통과 (각 커밋 단위 + 최종)

### 수동 (시뮬레이터)
- [ ] **iPhone 17 Pro (iOS 26.1)**: 편집 모드 진입 → toolbar가 탭바 *위에* 등장, 가려지지 않음. Liquid Glass 머티리얼이 시각적으로 보임
- [ ] **iPhone 15 (iOS 18)**: chrome blur 머티리얼로 표시, 동일한 pill 모양과 동작
- [ ] 메모 0개 선택 상태: toolbar 노출 + 카운트 라벨 표시 + delete/menu 버튼 비활성(그레이아웃)
- [ ] 메모 1+개 선택: 버튼 활성화, 카운트 라벨 업데이트
- [ ] Delete 탭 → confirm alert → 삭제 후 편집 모드 종료 + toolbar 슬라이드 아웃
- [ ] Menu 탭 → batch add/remove categories / favorite / unfavorite / restore (memoVCType별)
- [ ] `memoVCType` 5종 (.all / .category / .uncategorized / .favorite / .trash) 회귀 없음
- [ ] 메뉴 표시/해제 후 cornerRadius 깜빡임 없음
- [ ] **탭바 fix**: content 적은 메모 화면에서도 탭바 배경이 블러로 보임 (이전에는 투명)
- [ ] 마지막 카드가 toolbar 뒤에 영구히 가려지지 않음 (스크롤로 toolbar 위에 올라옴)
- [ ] iPad split view: secondary column 폭에 맞게 pill 표시
- [ ] **Dynamic Type**: Settings → Display & Text Size → Larger Text 슬라이더 조정 시 toolbar 텍스트/아이콘 같이 커짐 (XXXL까지)
- [ ] **VoiceOver**: 첫 선택 시 toolbar로 포커스 이동, 각 버튼 라벨이 한국어/영어로 올바르게 발화

## 작업 기록 (개발 일지 역할)

13개 커밋, 진행 순서대로:

1. `feat(memo): 편집 모드용 커스텀 toolbar 뷰 추가` — MemoEditingToolbarView 신규
2. `feat(memo): MemoView에 편집 toolbar 인스턴스 추가` — 임베드 + 제약
3. `feat(memo): 시스템 toolbar → 커스텀 toolbar로 교체` — controller 마이그레이션
4. `polish(memo): 편집 toolbar 등장/퇴장 애니메이션 + 콘텐츠 인셋 보정`
5. `a11y(memo): 편집 toolbar VoiceOver 라벨 + 등장 알림 추가`
6. `fix(memo): toolbar floating + collection view를 화면 최하단까지 확장` — `additionalSafeAreaInsets` → `contentInset` 전환 (toolbar 부유 버그 fix) + CV 확장
7. `fix(tabbar): scrollEdgeAppearance 누락으로 인한 투명 배경 문제 해결`
8. `feat(memo): 편집 모드 진입 시 toolbar 항상 표시` — 선택 0개일 때도 노출
9. `style(memo): toolbar를 양 끝 반원 pill + 탭바 위 floating으로 변경`
10. `style(memo): toolbar 카운트 라벨 좌측 정렬 + 액션 버튼 우측 정렬` (압축 우선순위 포함)
11. `style(memo): floating toolbar에 그림자 추가` — 실험
12. `revert(memo): floating toolbar 그림자 제거 + cornerRadius 위치 원복` — 메뉴 quirk로 인해 되돌림
13. `a11y(memo): toolbar에 Dynamic Type 지원 (표준 크기까지)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)