### PR TITLE
ci: drop pull_request trigger to avoid duplicate runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,6 @@ on:
     branches-ignore:
       - main
       - "release/**"
-  # Runs on every PR targeting main.
-  pull_request:
-    branches:
-      - main
 
 # When a new push arrives on the same branch, cancel the previous in-flight run.
 # Saves runner time on rapid pushes.


### PR DESCRIPTION
PR이 열릴 때 \`push\`와 \`pull_request\` 이벤트가 동시에 트리거되어 CI가 두 번 돌던 문제 해소.
fork PR을 받지 않는 1인 저장소라 \`push:\` 단독으로 충분.

🤖 Generated with [Claude Code](https://claude.com/claude-code)