### PR TITLE
docs: add AGENTS.md and Claude Code skill scaffolding

### DIFF
--- a/.claude/skills/commit-creator/SKILL.md
+++ b/.claude/skills/commit-creator/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: commit-creator
+description: 현재 변경사항(staged + unstaged)을 의미 단위로 분할해 commit한다. 변경이 여러 의미로 쪼개져 있으면 여러 번 commit. 기존 commit에 합치는 게 더 자연스러우면 rebase로 squash. 매 commit 끝에서 컴파일 통과를 보장.
+---
+
+# commit-creator
+
+현재 working tree의 변경사항을 의미가 살아있는 최소 단위로 commit한다. PR 리뷰어가 commit 순서를 따라가며 작업 흐름을 유추할 수 있게 만드는 것이 목표.
+
+## 작업 흐름
+
+1. **현재 상태 파악**
+   - `git status` / `git diff` / `git diff --staged` / `git log --oneline -10`로 변경량과 이전 흐름 확인.
+   - 변경된 파일들을 의미 단위로 그룹화 (한 묶음 = 한 commit).
+
+2. **의미 분할 검토**
+   - "한 commit이 한 의미"를 만족하는지 본인이 판단.
+   - 의미가 모호하거나 분할 방법이 여러 가지면 **`AskUserQuestion`으로 사용자에게 확인**. 예: "변경이 X(파일 A·B)와 Y(파일 C)로 보이는데, 분리하시겠어요?"
+
+3. **기존 commit과 합칠지 결정**
+   - 이번 변경이 **직전 commit의 의도와 동일**하다면 (예: 같은 작업의 후속 마무리) `git commit --amend`.
+   - **더 이전 commit과 동일 의도**라면 `git rebase -i`로 fixup/squash. 단 **commit 사이에 의존성이 있으면 합치지 말 것** — 중간 commit이 동작에 의존한다면 별개 commit 유지.
+   - 합칠지 모호하면 사용자에게 질문.
+
+4. **각 commit 만들기**
+   - 한 의미 단위씩 stage → commit.
+   - 메시지 형식:
+     ```
+     scope: 한 줄 요약 (50자 내외)
+
+     - 변경사항 1
+     - 변경사항 2
+     - 변경사항 3
+     ```
+   - scope는 저장소 기존 패턴 따라가기 (`chore(tuist)`, `refactor(memo)`, `fix(coredata)`, `ci`, `docs`, `test` 등).
+   - description은 줄글 X, bullet list로 변경사항 나열.
+   - AI 작업 시 `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` trailer 추가.
+
+5. **컴파일 검증**
+   - 모든 commit이 끝난 시점에 컴파일 통과해야 함.
+   - 검증 방법이 프로젝트마다 다르므로 명시되지 않았으면 사용자에게 질문 (예: "컴파일 검증으로 `xcodebuild build`를 돌릴까요?")
+   - NoteCard의 경우: `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`.
+
+6. **사용자 확인 요청**
+   - 모든 commit 후 `git log --oneline -<N>`으로 결과 보고.
+   - push 여부는 묻지 말 것 — push는 사용자 직접.
+
+## 모호함 해소 — `AskUserQuestion` 사용 시점
+
+- 변경 분할 방식이 둘 이상 합리적일 때
+- 어떤 기존 commit과 합칠지 모호할 때
+- commit 메시지의 scope나 요약이 명확하지 않을 때
+- 컴파일 검증 명령이 사전에 합의되지 않았을 때
+- working tree에 의도되지 않은 변경(예: 임시 디버그 코드, 우연히 변경된 파일)이 있을 때
+
+## 금지 사항
+
+- 줄글로 장황한 commit description 작성 금지. 항상 bullet list.
+- 의미가 다른 변경을 한 commit에 묶지 말 것.
+- 사용자 명시 없이 force push 또는 published commit amend 금지.
+- 컴파일 깨진 상태로 commit 종료 금지.
+- `--no-verify`로 pre-commit hook 우회 금지.

--- a/.claude/skills/pr-creator/SKILL.md
+++ b/.claude/skills/pr-creator/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: pr-creator
+description: 현재 브랜치를 main에 머지하기 위한 PR을 생성. push되지 않았으면 push 후 PR 작성. PR은 배경 / 변경사항 / 테스트 방법 / 리뷰 노트(선택) / 스크린샷(선택) 섹션으로 구성하며 핵심만 간결하게.
+---
+
+# pr-creator
+
+현재 작업 브랜치를 main에 머지하기 위한 PR을 만든다. 본문은 장황한 줄글 대신 핵심만 bullet list로 나열.
+
+## 작업 흐름
+
+1. **현재 브랜치 확인**
+   - `git branch --show-current`로 작업 브랜치 확인. main이면 PR 생성 거부 (어디로 머지할지 모호).
+   - `git log main..HEAD --oneline`로 포함될 commit 목록 확인.
+   - working tree clean인지 `git status`로 확인 (uncommitted 변경 있으면 commit 먼저 또는 사용자에게 확인).
+
+2. **Push 여부 확인**
+   - `git status -sb` 또는 `git rev-parse --abbrev-ref --symbolic-full-name @{u}`로 upstream 여부 확인.
+   - upstream 없거나 ahead 상태면 `git push -u origin <branch>`로 push.
+
+3. **PR 본문 구성**
+   - 아래 템플릿 사용. 빈 섹션은 생략.
+   - 리뷰 노트 / 스크린샷은 선택. 해당 변경이 있을 때만 포함.
+   - 본문은 줄글 X, 항목별 bullet list.
+
+4. **`gh pr create` 호출**
+   - `--base main --head <current_branch> --title "..." --body "$(cat <<'EOF' ... EOF)"`
+   - 생성된 PR URL 출력으로 보고.
+
+## PR 템플릿
+
+```markdown
+## 배경
+(변경의 동기 한두 줄. 이슈 / 컨텍스트가 있으면 링크. 자명하면 생략.)
+
+## 변경사항
+- 변경 1
+- 변경 2
+- 변경 3
+
+## 테스트 방법
+- 단계 1 (명령 또는 동작 확인 절차)
+- 단계 2
+
+## 리뷰 노트
+- 리뷰어가 특별히 신경써야 할 부분
+- 의도된 깨짐 또는 후속 작업 예고
+
+## 스크린샷
+| Before | After |
+|---|---|
+| 이미지 | 이미지 |
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+## 모호함 해소 — `AskUserQuestion` 사용 시점
+
+- PR 제목 / 배경 문구가 모호할 때 (commit 메시지만으로 추정 불가)
+- 테스트 방법이 자명하지 않을 때 (수동 QA 단계 / 자동 테스트 명령 무엇을 적을지)
+- 리뷰 노트가 필요한 변경인지 모호할 때 (위험 요인이 있는지)
+- 스크린샷이 필요한 UI 변경인지 모호할 때 (있는데 누락하면 리뷰 어려움)
+- 머지 대상이 main이 아닐 때 (예: release 브랜치 머지)
+
+## 금지 사항
+
+- 줄글로 장황한 본문 작성 금지. 항상 bullet list.
+- 빈 섹션을 그대로 두지 말 것 (해당 없으면 섹션 자체 생략).
+- 사용자 확인 없이 push --force 금지.
+- main에서 PR 생성 금지 (어디로 머지할지 알 수 없음).
+- commit / push 도중 컴파일 깨짐 상태로 PR 만들지 말 것.

--- a/.gitignore
+++ b/.gitignore
@@ -112,7 +112,8 @@ graph.png
 *.xcappdata
 
 # Claude Code
-.claude/
+.claude/*
+!.claude/skills/
 
 # Python
 __pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,113 @@
+# AGENTS.md
+
+NoteCard는 Tuist 기반 모듈러 iOS 앱이다. 이 문서는 AI agent가 코드를 변경하기 전 반드시 확인해야 할 핵심 사항을 정리한다. 본문에서 명령은 모두 저장소 루트(`/Users/kimminsung/development/NoteCard`)에서 실행하는 기준이다.
+
+## Stack
+
+- UIKit + Combine + Core Data + Swift 5
+- iOS 15.0 deployment target
+- Tuist 4.x (modular project generation)
+- 외부 의존성: Wisp 1.10.1 (검색 UI 라이브러리, SPM via Tuist Dependencies)
+- 분석/로깅: 없음 (Analytics 모듈은 NoOp placeholder만 마련)
+
+## Module structure
+
+`Projects/` 하위 폴더가 곧 레이어다. 모듈 그래프는 단방향이며, 역방향 import는 컴파일 에러로 차단된다.
+
+```
+App (NoteCard, NoteCard-Eng)
+ ├─ Domain   ← Data
+ ├─ Domain, Data, DesignSystem, Shared, AnalyticsInterface
+ ├─ Core/DesignSystem  → Shared
+ ├─ Core/Shared
+ ├─ Core/AnalyticsInterface
+ └─ Core/AnalyticsImpl → AnalyticsInterface
+```
+
+- Repository **프로토콜은 Domain**이 소유하고 **구현은 Data**가 제공 (의존성 역전)
+- 횡단 관심사(DesignSystem / Shared / Analytics)는 `Core/` 아래로
+- Presentation은 현재 App 타겟 안에 그대로 (별도 Feature 모듈 분할은 후속 작업)
+- 새 모듈 추가 시 `Tuist/ProjectDescriptionHelpers/ModulePaths.swift`의 `Module` enum과 `Layer` enum에 등록 필요
+
+## Dev environment setup
+
+```bash
+mise install                              # 또는 brew install tuist (Tuist 4.x 필요)
+tuist install                              # SPM 의존성 fetch
+tuist generate --no-open                   # NoteCard.xcworkspace 생성
+open NoteCard.xcworkspace                  # Xcode 열기
+```
+
+- `.xcodeproj` / `.xcworkspace`는 generated artifact라 git에 commit하지 않는다 (`.gitignore`에 포함됨). 직접 편집 금지 — 항상 `Project.swift` 수정 후 `tuist generate`.
+- `Configs/Version.xcconfig`에 `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION`이 있다. fastlane이 정규식 치환으로 편집하므로 형식(`KEY = value`)을 유지할 것.
+
+## Build & test
+
+```bash
+# 평상시 개발 빌드 (한국어 데이터 sandbox)
+xcodebuild build -workspace NoteCard.xcworkspace \
+    -scheme NoteCard -configuration Debug \
+    -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+
+# 영어 스크린샷용 빌드 (별도 bundle id로 시뮬레이터에 추가 설치됨)
+xcodebuild build -workspace NoteCard.xcworkspace \
+    -scheme NoteCard-Eng -configuration Debug \
+    -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+
+# 단위 테스트 (Domain / Shared / NoteCardTests)
+xcodebuild test -workspace NoteCard.xcworkspace \
+    -scheme NoteCard -configuration Debug \
+    -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+- 두 App 타겟이 같은 sources / resources를 공유하고 **bundle id만 다르다** (`com.minsung.NoteCard` vs `com.minsung.NoteCard.eng`). 시뮬레이터에 두 앱이 별개로 설치되어 각자 Core Data sandbox를 가진다.
+- Configuration은 `Debug` / `Release` 2개뿐. Display name은 NoteCard target Debug=`NoteCard(Dev)`, NoteCard target Release=`NoteCard`, NoteCard-Eng target=`NoteCard-Eng`.
+
+## Core Data ⚠
+
+Core Data는 가장 위험한 영역이다. 다음을 어기면 사용자 데이터 손실로 이어진다.
+
+- **Bundle 접근**: `Bundle.main`이나 `Bundle(for: Self.self)`로 모델을 찾으면 안 된다 (staticFramework에서 main bundle을 반환). 반드시 `DataResources.bundle`(= `Bundle.module`) 사용. 참고: `Projects/Data/Sources/CoreData/CoreDataStack.swift`.
+- **매핑 모델**: `.xcdatamodeld`와 `.xcmappingmodel`은 **같은 번들**에 함께 있어야 NSMigrationManager가 자동 검색한다. `Projects/Data/Project.swift`의 resources glob에 두 패턴 모두 포함되어 있음 — 절대 빼지 말 것.
+- **`@objc(EntityName)` 어노테이션**: 모든 NSManagedObject 서브클래스에 부착되어 있다. 모듈명이 바뀌어도 Obj-C 런타임 클래스명이 고정되어 기존 .sqlite의 클래스 매핑을 유지. 새 entity 추가 시 동일하게 부착.
+- **Migration**: Lightweight + Heavyweight(매핑 모델) 혼합 사용 중. 모델 변경 시 `Projects/Data/Tests/MigrationTests.swift`에 회귀 시나리오 추가.
+- **현재 컨테이너**: `NoteCardCoreData` (active). `CardMemoCoreData`는 마이그레이션 source용 잔재 — 삭제하지 말 것.
+
+## Naming gotchas
+
+- ObjC runtime의 `Category` typedef와 충돌하므로 도메인 모델 `Category`는 호출부에서 **`Domain.Category`로 명시**한다. 새 코드에도 동일 규칙.
+- Localization 호출은 `"key".localized()` 형태. 기본 bundle이 `SharedResources.bundle`이므로 다른 모듈에 자체 xcstrings를 두면 `bundle:` 인자를 명시 전달.
+
+## Code conventions
+
+- 모든 cross-module API는 명시적 `public`. 모듈 내부 detail은 `internal`(기본) 또는 `private` 유지.
+- protocol 멤버에는 `public` 모디파이어를 붙이지 않는다 (Swift 컴파일러가 거부).
+- protocol conformance를 가진 extension(`extension X: SomeProtocol`)에도 `public` 모디파이어 금지. 멤버에 개별 `public`을 붙일 것.
+- `public class` 안의 `override` 메서드도 `public` 명시 (Swift 규칙).
+- ViewController 등 App 타겟 내부 코드는 internal로 충분 (cross-module 노출 불필요).
+
+## Commit / PR conventions
+
+- 의미 단위로 분할 commit. 한 commit이 끝난 시점의 코드는 컴파일 통과 보장.
+- 메시지 형식: `scope: 한 줄 요약` (예: `chore(tuist): ...`, `refactor(memo): ...`, `fix(coredata): ...`, `ci: ...`). 본문은 변경사항 bullet list. 줄글 장황 설명 X.
+- Co-authored-by trailer는 AI 어시스턴트로 작업했을 때만 추가.
+- PR base는 `main`. 본인이 작업한 브랜치는 push 후 직접 확인하고 PR 생성.
+- Push는 사용자 확인 후 직접. 자동 push 금지.
+
+## fastlane
+
+```bash
+bundle exec fastlane bump_version type:minor   # patch / minor / major
+bundle exec fastlane bump_build
+bundle exec fastlane verify_archive            # archive만, upload X
+bundle exec fastlane beta                      # archive + TestFlight upload
+```
+
+- `bump_version`은 `Configs/Version.xcconfig`만 편집하고 자동 commit한다 (release 브랜치에서만 실행).
+- bundler 2.5.11 필요. ruby 3.3.3 (rbenv) 환경에서 동작.
+- CI에서는 `release.yml`이 자동 호출. 일반 push는 `ci.yml`(build + test)만 실행.
+
+## Deferred / known limitations
+
+- **Feature 모듈 분할**: Asset Symbol cross-module access 처리(`ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS_ACCESS_LEVEL = public`) 후 별도 작업으로 진행 예정.
+- **Core Data 회귀 테스트**: v3 fixture `.sqlite` 미확보로 `MigrationTests`가 `XCTSkip` 상태. 모델 변경 시 사용자 시뮬레이터에서 fixture 추출 후 활성화.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](./AGENTS.md).


### PR DESCRIPTION
## 배경
AI agent가 NoteCard 코드베이스를 다룰 때 사전 인지해야 할 핵심 사항을 정리하고, 자주 쓰는 workflow(commit / PR 생성)를 skill로 자동화.

## 변경사항
- `AGENTS.md` 신규 — stack / module structure / dependency direction / build & test / Core Data 주의사항 / 코드 컨벤션 / fastlane / 알려진 한계
- `CLAUDE.md` 신규 — AGENTS.md로 라우팅하는 한 줄
- `.claude/skills/commit-creator/SKILL.md` 신규 — 의미 단위 commit + 필요 시 rebase squash, 컴파일 통과 보장
- `.claude/skills/pr-creator/SKILL.md` 신규 — main 대상 PR 생성 흐름과 템플릿
- `.gitignore` 갱신 — `.claude/*` + `!.claude/skills/` (skills 만 추적, settings.local.json 등 다른 세션 데이터는 무시 유지)

## 테스트 방법
- AGENTS.md / CLAUDE.md 내용 검토
- 이후 작업에서 commit-creator / pr-creator skill 실제 사용해 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)