### PR TITLE
fix(tuist): set CODE_SIGN_IDENTITY to "Apple Distribution" for Release

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -97,6 +97,7 @@ let project = Project(
                     .release(name: "Release", settings: [
                         "APP_DISPLAY_NAME": "NoteCard",
                         "CODE_SIGN_STYLE": "Manual",
+                        "CODE_SIGN_IDENTITY": "Apple Distribution",
                         "PROVISIONING_PROFILE_SPECIFIER": "match AppStore com.minsung.NoteCard",
                     ], xcconfig: "Configs/Version.xcconfig"),
                 ]


### PR DESCRIPTION
## 배경

`fastlane verify_archive` 실행 시 다음 에러로 archive가 실패했다.

```
Provisioning profile "match AppStore com.minsung.NoteCard" doesn't include
signing certificate "Apple Development: Minsung Kim (TW973AVL26)".
```

Release config가 Manual signing + `match AppStore ...` 프로파일을 지정하고 있지만 `CODE_SIGN_IDENTITY`는 별도 명시하지 않아 Xcode 기본값인 `iPhone Developer`(development cert)가 적용되었고, AppStore 프로파일에 포함되지 않은 development cert로 서명하려다 실패했다.

## 변경

App 타겟 Release config에 `CODE_SIGN_IDENTITY = "Apple Distribution"`을 명시하여 distribution cert로 서명되도록 한다. Debug config는 기존 Automatic signing 유지.

## 검증

- `bundle exec fastlane verify_archive` 통과 — IPA + dSYM 정상 생성됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)