### PR TITLE
refactor(data): rename *EntityRepository to *RepositoryImpl

### DIFF
--- a/NoteCard/Presentation/HomeView/CategoryListTableView/CategoryListViewController.swift
+++ b/NoteCard/Presentation/HomeView/CategoryListTableView/CategoryListViewController.swift
@@ -288,7 +288,7 @@ extension CategoryListViewController {
             let deleteAction = UIAlertAction(title: L10n.Common.delete, style: UIAlertAction.Style.destructive) { [weak self] action in
                 guard let self else { fatalError() }
                 Task {
-                    try await CategoryEntityRepository.shared.deleteCategory(swipedCell.categoryEntity.toDomain())
+                    try await CategoryRepositoryImpl.shared.deleteCategory(swipedCell.categoryEntity.toDomain())
                     self.applySnapshot(animatingDifferences: true, usingReloadData: false)
                     completionHandler(true)
                 }

--- a/NoteCard/Presentation/HomeView/CategoryListTableView/CreateCategoryView/CreateCategoryViewController.swift
+++ b/NoteCard/Presentation/HomeView/CategoryListTableView/CreateCategoryView/CreateCategoryViewController.swift
@@ -92,7 +92,7 @@ class CreateCategoryViewController: UIViewController {
         Task {
             do {
                 // try categoryManager.createCategoryEntity(withName: text)
-                try await CategoryEntityRepository.shared.create(name: text.trimmingCharacters(in: .whitespacesAndNewlines))
+                try await CategoryRepositoryImpl.shared.create(name: text.trimmingCharacters(in: .whitespacesAndNewlines))
                 onCategoryCreated?()
                 dismiss(animated: true)
             } catch CoreDataError.duplicateCategoryDetected {

--- a/NoteCard/Presentation/HomeView/HomeViewController.swift
+++ b/NoteCard/Presentation/HomeView/HomeViewController.swift
@@ -111,8 +111,8 @@ class HomeViewController: UIViewController {
             inOrderOf: .modificationDate,
             isAscending: false
         )
-        favoriteMemos = try await MemoEntityRepository.shared.getFavoriteMemos()
-        allMemos = try await MemoEntityRepository.shared.getAllMemos()
+        favoriteMemos = try await MemoRepositoryImpl.shared.getFavoriteMemos()
+        allMemos = try await MemoRepositoryImpl.shared.getAllMemos()
     }
     
     private func setupDiffableDataSource() {

--- a/NoteCard/Presentation/HomeView/HomeViewController.swift
+++ b/NoteCard/Presentation/HomeView/HomeViewController.swift
@@ -107,7 +107,7 @@ class HomeViewController: UIViewController {
     }
     
     private func fetchData() async throws {
-        categories = try await CategoryEntityRepository.shared.getAllCategories(
+        categories = try await CategoryRepositoryImpl.shared.getAllCategories(
             inOrderOf: .modificationDate,
             isAscending: false
         )

--- a/NoteCard/Presentation/MemoDetailView/MemoDetailViewController.swift
+++ b/NoteCard/Presentation/MemoDetailView/MemoDetailViewController.swift
@@ -320,14 +320,14 @@ private extension MemoDetailViewController {
                          `model`은 `ImageUIModel` 타입
                          `model`을 바탕으로 `ImageEntity`를 불러온 후 이 레코드의 `index`를 `item.offset`으로 업데이트
                          */
-                        try await ImageEntityRepository.shared.updateImageIndex(model.info, newIndex: index)
+                        try await ImageRepositoryImpl.shared.updateImageIndex(model.info, newIndex: index)
                     case .pendingAddition(model: let model):
                         /**
                          `model`은 `ImageUITemporaryModel` 타입
                          `model`을 바탕으로 새 이미지 파일과 `ImageEntity`를 생성한 후에 각각 `FileManager`, `CoreData`에 저장.
                          저장 시 index 정보는 `item.offset`
                          */
-                        let _ = try await ImageEntityRepository.shared.createImage(
+                        let _ = try await ImageRepositoryImpl.shared.createImage(
                             from: model.pickerResult,
                             for: memo,
                             orderIndex: index,
@@ -338,7 +338,7 @@ private extension MemoDetailViewController {
                          `model`은 `ImageUIModel` 타입
                          model을 바탕으로 `ImageEntity`를 불러온 후 이 이 레코드의 데이터 및 이미지 파일 삭제
                          */
-                        try await ImageEntityRepository.shared.deleteImage(model.info)
+                        try await ImageRepositoryImpl.shared.deleteImage(model.info)
                     }
                 }
                 try await group.waitForAll()

--- a/NoteCard/Presentation/MemoDetailView/MemoDetailViewController.swift
+++ b/NoteCard/Presentation/MemoDetailView/MemoDetailViewController.swift
@@ -83,7 +83,7 @@ class MemoDetailViewController: UIViewController {
         setupDelegates()
         Task {
             do {
-                categories = try await CategoryEntityRepository.shared.getAllCategories(
+                categories = try await CategoryRepositoryImpl.shared.getAllCategories(
                     inOrderOf: .modificationDate,
                     isAscending: false
                 )

--- a/NoteCard/Presentation/MemoDetailView/MemoDetailViewController.swift
+++ b/NoteCard/Presentation/MemoDetailView/MemoDetailViewController.swift
@@ -272,7 +272,7 @@ private extension MemoDetailViewController {
         
         switch detailType {
         case .editing(let memo, _):
-            try await MemoEntityRepository.shared.updateMemoContent(
+            try await MemoRepositoryImpl.shared.updateMemoContent(
                 memo,
                 newTitle: newTitle,
                 newMemoText: newMemoText
@@ -280,8 +280,8 @@ private extension MemoDetailViewController {
             if let newTitle { self.memo?.memoTitle = newTitle }
             if let newMemoText { self.memo?.memoText = newMemoText }
         case .making:
-            let newMemo = try await MemoEntityRepository.shared.createNewMemo()
-            try await MemoEntityRepository.shared.updateMemoContent(
+            let newMemo = try await MemoRepositoryImpl.shared.createNewMemo()
+            try await MemoRepositoryImpl.shared.updateMemoContent(
                 newMemo,
                 newTitle: newTitle,
                 newMemoText: newMemoText
@@ -303,7 +303,7 @@ private extension MemoDetailViewController {
             debugPrint("카테고리 목록에 변화가 없으므로 DB에 덮어쓰지 않음.")
             return
         }
-        try await MemoEntityRepository.shared.replaceCategories(to: memo, newCategories: Set(selectedCategories))
+        try await MemoRepositoryImpl.shared.replaceCategories(to: memo, newCategories: Set(selectedCategories))
     }
     
     func updateImages() async throws {

--- a/NoteCard/Presentation/MemoSearching/MemoSearchingViewController.swift
+++ b/NoteCard/Presentation/MemoSearching/MemoSearchingViewController.swift
@@ -81,7 +81,7 @@ private extension MemoSearchingViewController {
             .debounce(for: 0.2, scheduler: RunLoop.main)
             .sink { searchText in
                 Task {
-                    let memoSearchResult = try await MemoEntityRepository.shared.searchMemo(searchText: searchText)
+                    let memoSearchResult = try await MemoRepositoryImpl.shared.searchMemo(searchText: searchText)
                     self.applySnapshot(with: memoSearchResult)
                 }
             }

--- a/NoteCard/Presentation/MemoView/CategorySelectionView/CategorySelectionViewController.swift
+++ b/NoteCard/Presentation/MemoView/CategorySelectionView/CategorySelectionViewController.swift
@@ -104,8 +104,8 @@ class CategorySelectionViewController: UIViewController {
         
         let selectedCategories: Set<Domain.Category> = Set(self.selectedCategorySet.map { $0.toDomain() })
         Task {
-            try await MemoEntityRepository.shared.restore(selectedMemos)
-            try await MemoEntityRepository.shared.addCategories(
+            try await MemoRepositoryImpl.shared.restore(selectedMemos)
+            try await MemoRepositoryImpl.shared.addCategories(
                 to: selectedMemos,
                 newCategories: selectedCategories
             )
@@ -132,11 +132,11 @@ class CategorySelectionViewController: UIViewController {
         
         let selectedCategories: Set<Domain.Category> = Set(self.selectedCategorySet.map { $0.toDomain() })
         Task {
-            try await MemoEntityRepository.shared.removeCategories(
+            try await MemoRepositoryImpl.shared.removeCategories(
                 to: selectedMemos,
                 newCategories: selectedCategories
             )
-            try await MemoEntityRepository.shared.restore(selectedMemos)
+            try await MemoRepositoryImpl.shared.restore(selectedMemos)
         }
         
         memoVC.isEditing = false

--- a/NoteCard/Presentation/MemoView/MemoViewController.swift
+++ b/NoteCard/Presentation/MemoView/MemoViewController.swift
@@ -629,7 +629,7 @@ extension MemoViewController: UITextFieldDelegate {
         
         Task {
             do {
-                try await CategoryEntityRepository.shared.changeCategoryName(selectedCategory, newName: trimmedNewCategoryName)
+                try await CategoryRepositoryImpl.shared.changeCategoryName(selectedCategory, newName: trimmedNewCategoryName)
             } catch {
                 print(error.localizedDescription)
                 let alertCon = UIAlertController(title: L10n.CategoryList.duplicateName, message: L10n.CategoryList.duplicateNameMessage, preferredStyle: UIAlertController.Style.actionSheet)

--- a/NoteCard/Presentation/MemoView/MemoViewController.swift
+++ b/NoteCard/Presentation/MemoView/MemoViewController.swift
@@ -286,7 +286,7 @@ private extension MemoViewController {
     }
     
     func setupObservers() {
-        MemoEntityRepository.shared.memoUpdatedPublisher
+        MemoRepositoryImpl.shared.memoUpdatedPublisher
             .sink { [weak self] _ in
                 guard let self else { return }
                 Task {
@@ -332,7 +332,7 @@ private extension MemoViewController {
                 selectedMemos.append(memoArray[indexPath.item])
             }
             Task {
-                try await MemoEntityRepository.shared.restore(selectedMemos)
+                try await MemoRepositoryImpl.shared.restore(selectedMemos)
                 try await self.updateMemoContents()
             }
         }
@@ -367,7 +367,7 @@ private extension MemoViewController {
             .map(\.element)
         
         Task {
-            try await MemoEntityRepository.shared.setFavorite(selectedMemos, to: true)
+            try await MemoRepositoryImpl.shared.setFavorite(selectedMemos, to: true)
             self.setEditing(false, animated: true)
         }
     }
@@ -383,7 +383,7 @@ private extension MemoViewController {
             .map(\.element)
         
         Task {
-            try await MemoEntityRepository.shared.setFavorite(selectedMemos, to: false)
+            try await MemoRepositoryImpl.shared.setFavorite(selectedMemos, to: false)
             
             guard self.memoVCType == .favorite else { return }
             try await self.updateMemoContents()
@@ -433,9 +433,9 @@ private extension MemoViewController {
             
             Task {
                 if self.memoVCType == .trash {
-                    try await MemoEntityRepository.shared.deleteMemos(selectedMemos)
+                    try await MemoRepositoryImpl.shared.deleteMemos(selectedMemos)
                 } else {
-                    try await MemoEntityRepository.shared.moveToTrash(selectedMemos)
+                    try await MemoRepositoryImpl.shared.moveToTrash(selectedMemos)
                 }
                 try await self.updateMemoContents()
             }
@@ -590,13 +590,13 @@ extension MemoViewController: UICollectionViewDelegate {
     func fetchMemos() async throws -> [Memo] {
         switch memoVCType {
         case .category, .uncategorized:
-            return try await MemoEntityRepository.shared.getAllMemos(inCategory: selectedCategory)
+            return try await MemoRepositoryImpl.shared.getAllMemos(inCategory: selectedCategory)
         case .favorite:
-            return try await MemoEntityRepository.shared.getFavoriteMemos()
+            return try await MemoRepositoryImpl.shared.getFavoriteMemos()
         case .all:
-            return try await MemoEntityRepository.shared.getAllMemos()
+            return try await MemoRepositoryImpl.shared.getAllMemos()
         case .trash:
-            return try await MemoEntityRepository.shared.getAllMemosInTrash()
+            return try await MemoRepositoryImpl.shared.getAllMemosInTrash()
         }
     }
     

--- a/NoteCard/Presentation/PopupCardView/PopupCardView.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardView.swift
@@ -191,7 +191,7 @@ final class PopupCardView: UIView {
         if isTextFieldChanged {
             Task {
                 let trimmedTitleText = titleTextField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
-                try await MemoEntityRepository.shared.updateMemoContent(memo, newTitle: trimmedTitleText)
+                try await MemoRepositoryImpl.shared.updateMemoContent(memo, newTitle: trimmedTitleText)
                 self.isTextFieldChanged = false
             }
         }
@@ -200,7 +200,7 @@ final class PopupCardView: UIView {
     func updateMemoTextView() {
         if isTextViewChanged {
             Task {
-                try await MemoEntityRepository.shared.updateMemoContent(memo, newMemoText: memoTextView.text)
+                try await MemoRepositoryImpl.shared.updateMemoContent(memo, newMemoText: memoTextView.text)
                 self.isTextViewChanged = false
             }
         }

--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -84,7 +84,7 @@ class PopupCardViewController: UIViewController {
             memoTextViewTapGesture.isEnabled = false
         }
         
-        ImageEntityRepository.shared.imageUpdatedPublisher
+        ImageRepositoryImpl.shared.imageUpdatedPublisher
             .filter { [weak self] updateType in
                 guard let self else { return false }
                 return updateType.memoID == self.memo.memoID
@@ -380,7 +380,7 @@ private extension PopupCardViewController {
     private func makeImageUIModels() async throws -> [ImageUIModel] {
         var imageUIModels: [ImageUIModel] = []
         
-        let fetchedImageInfoList = try await ImageEntityRepository.shared.getAllImageInfo(for: memo)
+        let fetchedImageInfoList = try await ImageRepositoryImpl.shared.getAllImageInfo(for: memo)
         let fetchedThumbnails = try await fetchThumbnailsConcurrently(for: fetchedImageInfoList)
         let fetchedImages = try await fetchImagesConcurrently(for: fetchedImageInfoList)
         
@@ -406,7 +406,7 @@ private extension PopupCardViewController {
         try await withThrowingTaskGroup(of: (Int, UIImage).self) { group in
             for (index, info) in imageInfos.enumerated() {
                 group.addTask {
-                    let thumbnail = try await ImageEntityRepository.shared.getThumbnailImage(from: info)
+                    let thumbnail = try await ImageRepositoryImpl.shared.getThumbnailImage(from: info)
                     return (index, thumbnail)
                 }
             }
@@ -422,7 +422,7 @@ private extension PopupCardViewController {
         try await withThrowingTaskGroup(of: (Int, UIImage).self) { group in
             for (index, info) in imageInfos.enumerated() {
                 group.addTask {
-                    let image = try await ImageEntityRepository.shared.getImage(from: info)
+                    let image = try await ImageRepositoryImpl.shared.getImage(from: info)
                     return (index, image)
                 }
             }

--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -108,7 +108,7 @@ class PopupCardViewController: UIViewController {
             }
             .store(in: &cancellables)
         
-        MemoEntityRepository.shared.memoUpdatedPublisher
+        MemoRepositoryImpl.shared.memoUpdatedPublisher
             .filter({ [weak self] updateType in
                 guard let self else { return false }
                 guard case .update(let updatedAttribute) = updateType else { return false }
@@ -119,7 +119,7 @@ class PopupCardViewController: UIViewController {
                 guard let self else { return }
                 Task {
                     do {
-                        let updatedMemo = try await MemoEntityRepository.shared.getMemo(id: self.memo.memoID)
+                        let updatedMemo = try await MemoRepositoryImpl.shared.getMemo(id: self.memo.memoID)
                         self.memo = updatedMemo
                         self.categories = try await self.fetchCategories()
                         
@@ -215,7 +215,7 @@ private extension PopupCardViewController {
         }
         Task {
             do {
-                try await MemoEntityRepository.shared.updateMemoContent(memo, newTitle: sender.text)
+                try await MemoRepositoryImpl.shared.updateMemoContent(memo, newTitle: sender.text)
             } catch {
                 print(error.localizedDescription)
             }
@@ -242,7 +242,7 @@ private extension PopupCardViewController {
     @objc func likeButtonTapped() {
         Task {
             do {
-                try await MemoEntityRepository.shared.setFavorite(memo, to: !memo.isFavorite)
+                try await MemoRepositoryImpl.shared.setFavorite(memo, to: !memo.isFavorite)
                 rootView.likeButton.isSelected.toggle()
             } catch {
                 print(error.localizedDescription)
@@ -313,7 +313,7 @@ extension PopupCardViewController: UITextViewDelegate {
         }
         Task {
             do {
-                try await MemoEntityRepository.shared.updateMemoContent(memo, newMemoText: textView.text)
+                try await MemoRepositoryImpl.shared.updateMemoContent(memo, newMemoText: textView.text)
             } catch {
                 print(error.localizedDescription)
             }
@@ -333,7 +333,7 @@ extension PopupCardViewController: UITextFieldDelegate {
         }
         Task {
             do {
-                try await MemoEntityRepository.shared.updateMemoContent(memo, newTitle: trimmedInput)
+                try await MemoRepositoryImpl.shared.updateMemoContent(memo, newTitle: trimmedInput)
             } catch {
                 print(error.localizedDescription)
             }
@@ -450,7 +450,7 @@ extension PopupCardViewController {
         let restoreAction = UIAlertAction(title: L10n.Common.recover, style: .default) { action in
             Task{
                 do {
-                    try await MemoEntityRepository.shared.restore(self.memo)
+                    try await MemoRepositoryImpl.shared.restore(self.memo)
                     self.dismiss(animated: true)
                 } catch {
                     print(error.localizedDescription)
@@ -477,9 +477,9 @@ extension PopupCardViewController {
             Task {
                 do {
                     if self.memo.isInTrash {
-                        try await MemoEntityRepository.shared.deleteMemo(self.memo)
+                        try await MemoRepositoryImpl.shared.deleteMemo(self.memo)
                     } else {
-                        try await MemoEntityRepository.shared.moveToTrash(self.memo)
+                        try await MemoRepositoryImpl.shared.moveToTrash(self.memo)
                     }
                     self.dismiss(animated: true)
                 } catch {

--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -364,7 +364,7 @@ extension PopupCardViewController {
 private extension PopupCardViewController {
     
     private func fetchCategories() async throws -> [Domain.Category] {
-        return try await CategoryEntityRepository.shared.getAllCategories(
+        return try await CategoryRepositoryImpl.shared.getAllCategories(
             ofMemo: memo,
             inOrderOf: .modificationDate,
             isAscending: false

--- a/Projects/Data/Sources/Repositories/CategoryRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/CategoryRepositoryImpl.swift
@@ -1,5 +1,5 @@
 //
-//  CategoryEntityRepository.swift
+//  CategoryRepositoryImpl.swift
 //  NoteCard
 //
 //  Created by 김민성 on 8/28/25.
@@ -13,9 +13,9 @@ public protocol ComparableValue: Comparable {}
 extension String: ComparableValue {}
 extension Date: ComparableValue {}
 
-public actor CategoryEntityRepository: CategoryRepository {
+public actor CategoryRepositoryImpl: CategoryRepository {
     
-    public static let shared = CategoryEntityRepository()
+    public static let shared = CategoryRepositoryImpl()
     private init() { }
     
     private let context = CoreDataStack.shared.backgroundContext
@@ -32,7 +32,7 @@ public actor CategoryEntityRepository: CategoryRepository {
 }
 
 
-public extension CategoryEntityRepository {
+public extension CategoryRepositoryImpl {
     
     private func fetchMemoEntity(id: UUID) throws -> MemoEntity {
         let request = MemoEntity.fetchRequest()
@@ -51,7 +51,7 @@ public extension CategoryEntityRepository {
 }
 
 
-public extension CategoryEntityRepository {
+public extension CategoryRepositoryImpl {
     
     private func fetchCategoryEntity(name: String) throws -> CategoryEntity {
         let request = CategoryEntity.fetchRequest()

--- a/Projects/Data/Sources/Repositories/ImageRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/ImageRepositoryImpl.swift
@@ -58,7 +58,7 @@ public actor ImageRepositoryImpl: ImageRepository {
         let thumbnailData = try ImageFileHandler.createThumbnailData(from: originalData)
         
         // MemoEntity 불러오기(후에 ImageEntity에서 생성자의 매개변수로 넣기 위함)
-        let memoEntity = try await MemoEntityRepository.shared.fetchMemoEntity(id: memo.memoID)
+        let memoEntity = try await MemoRepositoryImpl.shared.fetchMemoEntity(id: memo.memoID)
         
         let createdMemoInfo =  try await context.perform { [unowned self] in
             // 코어데이터에 저장할 데이터

--- a/Projects/Data/Sources/Repositories/ImageRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/ImageRepositoryImpl.swift
@@ -1,5 +1,5 @@
 //
-//  ImageEntityRepository.swift
+//  ImageRepositoryImpl.swift
 //  NoteCard
 //
 //  Created by 김민성 on 9/10/25.
@@ -13,7 +13,7 @@ import PhotosUI
 import UIKit
 import UniformTypeIdentifiers
 
-public actor ImageEntityRepository: ImageRepository {
+public actor ImageRepositoryImpl: ImageRepository {
     
     public enum ImageUpdateType: Equatable {
         case create(memoID: UUID)
@@ -32,7 +32,7 @@ public actor ImageEntityRepository: ImageRepository {
         }
     }
     
-    public static let shared = ImageEntityRepository()
+    public static let shared = ImageRepositoryImpl()
     private init() { }
     
     private let context = CoreDataStack.shared.backgroundContext

--- a/Projects/Data/Sources/Repositories/MemoRepositoryImpl+FileManager.swift
+++ b/Projects/Data/Sources/Repositories/MemoRepositoryImpl+FileManager.swift
@@ -1,5 +1,5 @@
 //
-//  MemoEntityRepository+FileManager.swift
+//  MemoRepositoryImpl+FileManager.swift
 //  NoteCard
 //
 //  Created by 김민성 on 8/23/25.
@@ -29,7 +29,7 @@ public enum MemoEntityFileManagerError: LocalizedError {
     
 }
 
-public extension MemoEntityRepository {
+public extension MemoRepositoryImpl {
     
     public func getMemoDirectoryURL(of memo: MemoEntity) throws -> URL {
         guard let documentURL = FileManager.default.urls(

--- a/Projects/Data/Sources/Repositories/MemoRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/MemoRepositoryImpl.swift
@@ -1,5 +1,5 @@
 //
-//  MemoEntityRepository.swift
+//  MemoRepositoryImpl.swift
 //  NoteCard
 //
 //  Created by 김민성 on 8/20/25.
@@ -27,7 +27,7 @@ public enum MemoEntityError: LocalizedError {
     
 }
 
-public actor MemoEntityRepository: MemoRepository {
+public actor MemoRepositoryImpl: MemoRepository {
     
     public enum MemoUpdateType: Equatable {
         public enum UpdateAttribute: Equatable {
@@ -51,7 +51,7 @@ public actor MemoEntityRepository: MemoRepository {
         case update(content: UpdateAttribute)
     }
     
-    public static let shared = MemoEntityRepository()
+    public static let shared = MemoRepositoryImpl()
     private init() { }
     
     private let context = CoreDataStack.shared.backgroundContext
@@ -98,7 +98,7 @@ public actor MemoEntityRepository: MemoRepository {
 
 
 // MARK: - CREATE
-public extension MemoEntityRepository {
+public extension MemoRepositoryImpl {
     
     public func createNewMemo() async throws -> Memo {
         let createdMemo = try await context.perform { [unowned self] in
@@ -114,7 +114,7 @@ public extension MemoEntityRepository {
 
 
 // MARK: - READ
-public extension MemoEntityRepository {
+public extension MemoRepositoryImpl {
     
     public func fetchMemoEntity(id: UUID) throws -> MemoEntity {
         let request = MemoEntity.fetchRequest()
@@ -239,7 +239,7 @@ public extension MemoEntityRepository {
 
 
 // MARK: - DELETE(Soft)
-public extension MemoEntityRepository {
+public extension MemoRepositoryImpl {
     
     public func moveToTrash(_ memo: Memo) async throws {
         try await context.perform { [unowned self] in
@@ -271,7 +271,7 @@ public extension MemoEntityRepository {
 
 
 // MARK: - ⚠️ DELETE(Hard)
-public extension MemoEntityRepository {
+public extension MemoRepositoryImpl {
     
     public func deleteMemo(_ memo: Memo) async throws {
         try await context.perform { [unowned self] in
@@ -313,7 +313,7 @@ public extension MemoEntityRepository {
 
 
 // MARK: - RESTORING
-public extension MemoEntityRepository {
+public extension MemoRepositoryImpl {
     
     public func restore(_ memo: Memo) async throws {
         try await context.perform { [unowned self] in
@@ -341,7 +341,7 @@ public extension MemoEntityRepository {
 
 
 // MARK: - UPDATE
-public extension MemoEntityRepository {
+public extension MemoRepositoryImpl {
     
     public func replaceCategories(to memo: Memo, newCategories: Set<Domain.Category>) async throws {
         try await context.perform { [unowned self] in


### PR DESCRIPTION
## 배경
- Protocol 구현체 네이밍을 `~Impl` 컨벤션으로 통일
- 기존 `~EntityRepository` 접두는 Core Data의 `*Entity` 클래스(`MemoEntity`, `CategoryEntity`, `ImageEntity`)와 의미가 겹쳐 혼란

## 변경사항
- `CategoryEntityRepository` → `CategoryRepositoryImpl`
- `ImageEntityRepository` → `ImageRepositoryImpl`
- `MemoEntityRepository` → `MemoRepositoryImpl` (확장 파일 `+FileManager.swift` 동반 리네임)
- Presentation 9개 파일의 `.shared` 호출부 일괄 업데이트
- Data 모듈 내부 cross-reference(`ImageRepositoryImpl` → `MemoRepositoryImpl.shared.fetchMemoEntity`) 업데이트

## 테스트 방법
- `tuist generate --no-open`
- `xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- `xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard-Eng -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- `xcodebuild test -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`

## 리뷰 노트
- 순수 rename(behavior 무변경). 타입명/파일명만 변경, 로직 수정 없음
- `NoOpAnalytics`는 *flavor*(no-op) 이름이라 `~Impl`로 바꾸지 않음 (향후 `SentryAnalytics` 등이 추가될 자리)
- `CoreDataError` / `ImageFileError` 등 `NoteCardError` conformer enum은 도메인 카테고리라 `~Impl` 부적합
- `static let shared` 싱글톤 패턴 제거는 별도 PR로 분리 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)