### PR TITLE
refactor(di): RepositoryImpl 싱글톤 제거 및 생성자 주입 적용

### DIFF
--- a/NoteCard/Global/Application/AppDelegate.swift
+++ b/NoteCard/Global/Application/AppDelegate.swift
@@ -15,7 +15,10 @@ import CoreData
 @main
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    
+
+    /// 앱 전체가 공유하는 의존성. 프로세스 수명 동안 하나만 존재한다.
+    let environment = AppEnvironment()
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         

--- a/NoteCard/Global/Application/AppDelegate.swift
+++ b/NoteCard/Global/Application/AppDelegate.swift
@@ -17,7 +17,7 @@ import CoreData
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     /// 앱 전체가 공유하는 의존성. 프로세스 수명 동안 하나만 존재한다.
-    let environment = AppEnvironment()
+    let environment = AppEnvironment(stack: .shared)
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.

--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -17,9 +17,9 @@ struct AppEnvironment {
     let categoryRepository: CategoryRepositoryImpl
     let imageRepository: ImageRepositoryImpl
 
-    init() {
+    init(stack: CoreDataStack) {
         self.memoRepository = MemoRepositoryImpl.shared
         self.categoryRepository = CategoryRepositoryImpl.shared
-        self.imageRepository = ImageRepositoryImpl.shared
+        self.imageRepository = ImageRepositoryImpl(stack: stack, memoRepository: MemoRepositoryImpl.shared)
     }
 }

--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -1,0 +1,25 @@
+//
+//  AppEnvironment.swift
+//  NoteCard
+//
+
+import Data
+
+/// 앱 전체에서 공유되는 의존성 묶음.
+///
+/// 프로세스 수명 동안 단 하나만 생성되어 `AppDelegate`가 소유하고,
+/// `SceneDelegate`를 거쳐 화면 계층으로 생성자 주입된다.
+/// Repository 구현체는 모두 같은 `CoreDataStack` 인스턴스를 공유하므로,
+/// Combine publisher 이벤트도 화면 간에 끊김 없이 전달된다.
+struct AppEnvironment {
+
+    let memoRepository: MemoRepositoryImpl
+    let categoryRepository: CategoryRepositoryImpl
+    let imageRepository: ImageRepositoryImpl
+
+    init() {
+        self.memoRepository = MemoRepositoryImpl.shared
+        self.categoryRepository = CategoryRepositoryImpl.shared
+        self.imageRepository = ImageRepositoryImpl.shared
+    }
+}

--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -20,7 +20,7 @@ struct AppEnvironment {
     init(stack: CoreDataStack) {
         let memoRepository = MemoRepositoryImpl(stack: stack)
         self.memoRepository = memoRepository
-        self.categoryRepository = CategoryRepositoryImpl.shared
+        self.categoryRepository = CategoryRepositoryImpl(stack: stack)
         self.imageRepository = ImageRepositoryImpl(stack: stack, memoRepository: memoRepository)
     }
 }

--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -18,8 +18,9 @@ struct AppEnvironment {
     let imageRepository: ImageRepositoryImpl
 
     init(stack: CoreDataStack) {
-        self.memoRepository = MemoRepositoryImpl.shared
+        let memoRepository = MemoRepositoryImpl(stack: stack)
+        self.memoRepository = memoRepository
         self.categoryRepository = CategoryRepositoryImpl.shared
-        self.imageRepository = ImageRepositoryImpl(stack: stack, memoRepository: MemoRepositoryImpl.shared)
+        self.imageRepository = ImageRepositoryImpl(stack: stack, memoRepository: memoRepository)
     }
 }

--- a/NoteCard/Global/Application/SceneDelegate.swift
+++ b/NoteCard/Global/Application/SceneDelegate.swift
@@ -26,7 +26,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window?.makeKeyAndVisible()
         self.window?.tintColor = UIColor.currentTheme
         
-        let mainTabBarCon = MainTabBarController()
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
+            fatalError("AppDelegate를 찾을 수 없습니다.")
+        }
+        let mainTabBarCon = MainTabBarController(environment: appDelegate.environment)
         if #available(iOS 18.0, *) {
             mainTabBarCon.mode = .tabSidebar
         }

--- a/NoteCard/Presentation/HomeView/CategoryListTableView/CategoryListViewController.swift
+++ b/NoteCard/Presentation/HomeView/CategoryListTableView/CategoryListViewController.swift
@@ -44,7 +44,18 @@ class CategoryListViewController: UITableViewController {
     var categoryDiffableDataSource: CategoryListTableViewDiffableDataSource!
     var categoryNameChangingTextField: UITextField!
     var saveAction: UIAlertAction!
-    
+
+    private let environment: AppEnvironment
+
+    init(environment: AppEnvironment) {
+        self.environment = environment
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -152,7 +163,7 @@ class CategoryListViewController: UITableViewController {
     }
     
     @objc private func presentCreateCategoryVC() {
-        let createCategoryVC = CreateCategoryViewController()
+        let createCategoryVC = CreateCategoryViewController(environment: environment)
         createCategoryVC.onCategoryCreated = { [weak self] in
             guard let self else { return }
             self.categoryCreated()
@@ -288,7 +299,7 @@ extension CategoryListViewController {
             let deleteAction = UIAlertAction(title: L10n.Common.delete, style: UIAlertAction.Style.destructive) { [weak self] action in
                 guard let self else { fatalError() }
                 Task {
-                    try await CategoryRepositoryImpl.shared.deleteCategory(swipedCell.categoryEntity.toDomain())
+                    try await self.environment.categoryRepository.deleteCategory(swipedCell.categoryEntity.toDomain())
                     self.applySnapshot(animatingDifferences: true, usingReloadData: false)
                     completionHandler(true)
                 }
@@ -310,7 +321,7 @@ extension CategoryListViewController {
 //    UITableViewController 되면서 override 함
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let selectedCategoryEntity = categoryDiffableDataSource.itemIdentifier(for: indexPath) else { return }
-        let memoVC = MemoViewController(memoVCType: .category(selectedCategory: selectedCategoryEntity.toDomain()))
+        let memoVC = MemoViewController(memoVCType: .category(selectedCategory: selectedCategoryEntity.toDomain()), environment: environment)
         memoVC.navigationItem.leftBarButtonItem = nil
         self.navigationController?.pushViewController(memoVC, animated: true)
         

--- a/NoteCard/Presentation/HomeView/CategoryListTableView/CreateCategoryView/CreateCategoryViewController.swift
+++ b/NoteCard/Presentation/HomeView/CategoryListTableView/CreateCategoryView/CreateCategoryViewController.swift
@@ -31,7 +31,18 @@ class CreateCategoryViewController: UIViewController {
     }()
     
     var onCategoryCreated: (() -> Void)? = nil
-    
+
+    private let environment: AppEnvironment
+
+    init(environment: AppEnvironment) {
+        self.environment = environment
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func loadView() {
         self.view = self.createCategoryView
     }
@@ -92,7 +103,7 @@ class CreateCategoryViewController: UIViewController {
         Task {
             do {
                 // try categoryManager.createCategoryEntity(withName: text)
-                try await CategoryRepositoryImpl.shared.create(name: text.trimmingCharacters(in: .whitespacesAndNewlines))
+                try await environment.categoryRepository.create(name: text.trimmingCharacters(in: .whitespacesAndNewlines))
                 onCategoryCreated?()
                 dismiss(animated: true)
             } catch CoreDataError.duplicateCategoryDetected {

--- a/NoteCard/Presentation/HomeView/HomeViewController.swift
+++ b/NoteCard/Presentation/HomeView/HomeViewController.swift
@@ -57,7 +57,18 @@ class HomeViewController: UIViewController {
         for: .NSManagedObjectContextDidSave,
         object: CoreDataStack.shared.backgroundContext
     )
-    
+
+    private let environment: AppEnvironment
+
+    init(environment: AppEnvironment) {
+        self.environment = environment
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func loadView() {
         self.view = homeView
     }
@@ -107,12 +118,12 @@ class HomeViewController: UIViewController {
     }
     
     private func fetchData() async throws {
-        categories = try await CategoryRepositoryImpl.shared.getAllCategories(
+        categories = try await environment.categoryRepository.getAllCategories(
             inOrderOf: .modificationDate,
             isAscending: false
         )
-        favoriteMemos = try await MemoRepositoryImpl.shared.getFavoriteMemos()
-        allMemos = try await MemoRepositoryImpl.shared.getAllMemos()
+        favoriteMemos = try await environment.memoRepository.getFavoriteMemos()
+        allMemos = try await environment.memoRepository.getAllMemos()
     }
     
     private func setupDiffableDataSource() {
@@ -264,14 +275,14 @@ class HomeViewController: UIViewController {
     @objc private func onHeaderButtonTapped(_ sender: UIButton) {
         switch sender.tag {
         case 0:
-            let categoryListVC = CategoryListViewController()
+            let categoryListVC = CategoryListViewController(environment: environment)
             self.navigationController?.pushViewController(categoryListVC, animated: true)
         case 1:
-            let favoriteMemoVC = MemoViewController(memoVCType: .favorite)
+            let favoriteMemoVC = MemoViewController(memoVCType: .favorite, environment: environment)
             favoriteMemoVC.navigationItem.leftBarButtonItem = nil
             self.navigationController?.pushViewController(favoriteMemoVC, animated: true)
         case 2:
-            let allMemoVC = MemoViewController(memoVCType: .all)
+            let allMemoVC = MemoViewController(memoVCType: .all, environment: environment)
             self.navigationController?.pushViewController(allMemoVC, animated: true)
         default:
             fatalError()
@@ -298,12 +309,12 @@ extension HomeViewController: UICollectionViewDelegate {
         if let itemIdentifier = diffableDataSource.itemIdentifier(for: indexPath) {
             switch itemIdentifier {
             case .addCategoryPlaceholder:
-                let createCategoryVC = CreateCategoryViewController()
+                let createCategoryVC = CreateCategoryViewController(environment: environment)
                 let naviCon = UINavigationController(rootViewController: createCategoryVC)
                 present(naviCon, animated: true)
                 return
             case .addMemoPlaceholder:
-                let memoMakingVC = MemoDetailViewController(type: .making(category: nil))
+                let memoMakingVC = MemoDetailViewController(type: .making(category: nil), environment: environment)
                 let naviCon = UINavigationController(rootViewController: memoMakingVC)
                 present(naviCon, animated: true)
                 return
@@ -333,12 +344,12 @@ extension HomeViewController: UICollectionViewDelegate {
         case 0:
             switch CategoryEntityManager.shared.getCategoryEntities(inOrderOf: .modificationDate, isAscending: false).count != 0 {
             case false:
-                let createCategoryVC = CreateCategoryViewController()
+                let createCategoryVC = CreateCategoryViewController(environment: environment)
                 let naviCon = UINavigationController(rootViewController: createCategoryVC)
                 present(naviCon, animated: true)
             case true:
                 let selectedCategory = categories[indexPath.item]
-                let memoVC = MemoViewController(memoVCType: .category(selectedCategory: selectedCategory))
+                let memoVC = MemoViewController(memoVCType: .category(selectedCategory: selectedCategory), environment: environment)
                 self.navigationController?.pushViewController(memoVC, animated: true)
             }
             
@@ -352,6 +363,7 @@ extension HomeViewController: UICollectionViewDelegate {
                 let popupCardViewCotroller = PopupCardViewController(
                     memo: selectedMemo,
                     indexPath: indexPath,
+                    environment: environment
                 )
                 wisp.present(popupCardViewCotroller, collectionView: homeCollectionView, at: indexPath, configuration: config)
             }
@@ -360,6 +372,7 @@ extension HomeViewController: UICollectionViewDelegate {
             let popupCardViewCotroller = PopupCardViewController(
                 memo: selectedMemo,
                 indexPath: indexPath,
+                environment: environment
             )
             wisp.present(popupCardViewCotroller, collectionView: homeCollectionView, at: indexPath, configuration: config)
         default:

--- a/NoteCard/Presentation/MemoDetailView/MemoDetailViewController.swift
+++ b/NoteCard/Presentation/MemoDetailView/MemoDetailViewController.swift
@@ -30,6 +30,7 @@ class MemoDetailViewController: UIViewController {
     
     private let rootView = MemoDetailView()
     private let detailType: MemoDetailType
+    private let environment: AppEnvironment
     private var memo: Memo?
     private var categories: [Domain.Category] = []
     private var selectedCategories: [Domain.Category] = []
@@ -48,8 +49,9 @@ class MemoDetailViewController: UIViewController {
     private let completeBarButtonItem = UIBarButtonItem()
     private let imageBarButtonItem = UIBarButtonItem()
     
-    init(type: MemoDetailType) {
+    init(type: MemoDetailType, environment: AppEnvironment) {
         self.detailType = type
+        self.environment = environment
         if case .editing(let memo, let imageModels) = type {
             self.memo = memo
             self.editableImageModels = imageModels
@@ -83,7 +85,7 @@ class MemoDetailViewController: UIViewController {
         setupDelegates()
         Task {
             do {
-                categories = try await CategoryRepositoryImpl.shared.getAllCategories(
+                categories = try await environment.categoryRepository.getAllCategories(
                     inOrderOf: .modificationDate,
                     isAscending: false
                 )
@@ -272,7 +274,7 @@ private extension MemoDetailViewController {
         
         switch detailType {
         case .editing(let memo, _):
-            try await MemoRepositoryImpl.shared.updateMemoContent(
+            try await environment.memoRepository.updateMemoContent(
                 memo,
                 newTitle: newTitle,
                 newMemoText: newMemoText
@@ -280,8 +282,8 @@ private extension MemoDetailViewController {
             if let newTitle { self.memo?.memoTitle = newTitle }
             if let newMemoText { self.memo?.memoText = newMemoText }
         case .making:
-            let newMemo = try await MemoRepositoryImpl.shared.createNewMemo()
-            try await MemoRepositoryImpl.shared.updateMemoContent(
+            let newMemo = try await environment.memoRepository.createNewMemo()
+            try await environment.memoRepository.updateMemoContent(
                 newMemo,
                 newTitle: newTitle,
                 newMemoText: newMemoText
@@ -303,7 +305,7 @@ private extension MemoDetailViewController {
             debugPrint("카테고리 목록에 변화가 없으므로 DB에 덮어쓰지 않음.")
             return
         }
-        try await MemoRepositoryImpl.shared.replaceCategories(to: memo, newCategories: Set(selectedCategories))
+        try await environment.memoRepository.replaceCategories(to: memo, newCategories: Set(selectedCategories))
     }
     
     func updateImages() async throws {
@@ -311,6 +313,7 @@ private extension MemoDetailViewController {
             debugPrint("메모가 생성되기 전에 이미지 저장 시도!")
             throw CoreDataError.objectNotFound
         }
+        let imageRepository = environment.imageRepository
         try await withThrowingTaskGroup(of: Void.self) { group in
             for (index, item) in editableImageModels.enumerated() {
                 group.addTask {
@@ -320,14 +323,14 @@ private extension MemoDetailViewController {
                          `model`은 `ImageUIModel` 타입
                          `model`을 바탕으로 `ImageEntity`를 불러온 후 이 레코드의 `index`를 `item.offset`으로 업데이트
                          */
-                        try await ImageRepositoryImpl.shared.updateImageIndex(model.info, newIndex: index)
+                        try await imageRepository.updateImageIndex(model.info, newIndex: index)
                     case .pendingAddition(model: let model):
                         /**
                          `model`은 `ImageUITemporaryModel` 타입
                          `model`을 바탕으로 새 이미지 파일과 `ImageEntity`를 생성한 후에 각각 `FileManager`, `CoreData`에 저장.
                          저장 시 index 정보는 `item.offset`
                          */
-                        let _ = try await ImageRepositoryImpl.shared.createImage(
+                        let _ = try await imageRepository.createImage(
                             from: model.pickerResult,
                             for: memo,
                             orderIndex: index,
@@ -338,7 +341,7 @@ private extension MemoDetailViewController {
                          `model`은 `ImageUIModel` 타입
                          model을 바탕으로 `ImageEntity`를 불러온 후 이 이 레코드의 데이터 및 이미지 파일 삭제
                          */
-                        try await ImageRepositoryImpl.shared.deleteImage(model.info)
+                        try await imageRepository.deleteImage(model.info)
                     }
                 }
                 try await group.waitForAll()

--- a/NoteCard/Presentation/MemoSearching/MemoSearchingViewController.swift
+++ b/NoteCard/Presentation/MemoSearching/MemoSearchingViewController.swift
@@ -17,7 +17,18 @@ import Wisp
 class MemoSearchingViewController: UIViewController {
     
     let rootView = MemoSearchingView()
-    
+
+    private let environment: AppEnvironment
+
+    init(environment: AppEnvironment) {
+        self.environment = environment
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     @Published
     private var searchText: String = ""
     private var diffableDataSource: UICollectionViewDiffableDataSource<Int, Memo>!
@@ -81,7 +92,7 @@ private extension MemoSearchingViewController {
             .debounce(for: 0.2, scheduler: RunLoop.main)
             .sink { searchText in
                 Task {
-                    let memoSearchResult = try await MemoRepositoryImpl.shared.searchMemo(searchText: searchText)
+                    let memoSearchResult = try await self.environment.memoRepository.searchMemo(searchText: searchText)
                     self.applySnapshot(with: memoSearchResult)
                 }
             }
@@ -122,6 +133,7 @@ extension MemoSearchingViewController: UICollectionViewDelegate {
         let popupVC = PopupCardViewController(
             memo: selectedMemo,
             indexPath: indexPath,
+            environment: environment
         )
         
         let topInset: CGFloat

--- a/NoteCard/Presentation/MemoView/CategorySelectionView/CategorySelectionViewController.swift
+++ b/NoteCard/Presentation/MemoView/CategorySelectionView/CategorySelectionViewController.swift
@@ -43,8 +43,11 @@ class CategorySelectionViewController: UIViewController {
     }
     var selectedCategorySet: Set<CategoryEntity> = []
     
-    init(selectionType: SelectionType) {
+    private let environment: AppEnvironment
+
+    init(selectionType: SelectionType, environment: AppEnvironment) {
         self.selectionType = selectionType
+        self.environment = environment
         super.init(nibName: nil, bundle: nil)
     }
     required init?(coder: NSCoder) {
@@ -104,8 +107,8 @@ class CategorySelectionViewController: UIViewController {
         
         let selectedCategories: Set<Domain.Category> = Set(self.selectedCategorySet.map { $0.toDomain() })
         Task {
-            try await MemoRepositoryImpl.shared.restore(selectedMemos)
-            try await MemoRepositoryImpl.shared.addCategories(
+            try await environment.memoRepository.restore(selectedMemos)
+            try await environment.memoRepository.addCategories(
                 to: selectedMemos,
                 newCategories: selectedCategories
             )
@@ -132,11 +135,11 @@ class CategorySelectionViewController: UIViewController {
         
         let selectedCategories: Set<Domain.Category> = Set(self.selectedCategorySet.map { $0.toDomain() })
         Task {
-            try await MemoRepositoryImpl.shared.removeCategories(
+            try await environment.memoRepository.removeCategories(
                 to: selectedMemos,
                 newCategories: selectedCategories
             )
-            try await MemoRepositoryImpl.shared.restore(selectedMemos)
+            try await environment.memoRepository.restore(selectedMemos)
         }
         
         memoVC.isEditing = false

--- a/NoteCard/Presentation/MemoView/MemoViewController.swift
+++ b/NoteCard/Presentation/MemoView/MemoViewController.swift
@@ -42,6 +42,7 @@ class MemoViewController: UIViewController {
     }
     
     private let memoVCType: MemoVCType
+    private let environment: AppEnvironment
     private let memoEntityManager = MemoEntityManager.shared
     private let categoryEntityManager = CategoryEntityManager.shared
     
@@ -66,10 +67,11 @@ class MemoViewController: UIViewController {
     
     private var cancellables = Set<AnyCancellable>()
     
-    init(memoVCType: MemoVCType) {
-        
+    init(memoVCType: MemoVCType, environment: AppEnvironment) {
+
         self.memoVCType = memoVCType
-        
+        self.environment = environment
+
         if case let .category(selectedCategory) = memoVCType {
             self.selectedCategory = selectedCategory
         }
@@ -286,7 +288,7 @@ private extension MemoViewController {
     }
     
     func setupObservers() {
-        MemoRepositoryImpl.shared.memoUpdatedPublisher
+        environment.memoRepository.memoUpdatedPublisher
             .sink { [weak self] _ in
                 guard let self else { return }
                 Task {
@@ -332,7 +334,7 @@ private extension MemoViewController {
                 selectedMemos.append(memoArray[indexPath.item])
             }
             Task {
-                try await MemoRepositoryImpl.shared.restore(selectedMemos)
+                try await self.environment.memoRepository.restore(selectedMemos)
                 try await self.updateMemoContents()
             }
         }
@@ -343,14 +345,14 @@ private extension MemoViewController {
     }
     
     func presentCategoriesToAdd() {
-        let categorySelectionVC = CategorySelectionViewController(selectionType: .toAppend)
+        let categorySelectionVC = CategorySelectionViewController(selectionType: .toAppend, environment: environment)
         let naviCon = UINavigationController(rootViewController: categorySelectionVC)
         naviCon.modalPresentationStyle = .pageSheet
         present(naviCon, animated: true)
     }
     
     func presentCategoriesToRemove() {
-        let categorySelectionVC = CategorySelectionViewController(selectionType: .toRemove)
+        let categorySelectionVC = CategorySelectionViewController(selectionType: .toRemove, environment: environment)
         let naviCon = UINavigationController(rootViewController: categorySelectionVC)
         naviCon.modalPresentationStyle = .pageSheet
         present(naviCon, animated: true)
@@ -367,7 +369,7 @@ private extension MemoViewController {
             .map(\.element)
         
         Task {
-            try await MemoRepositoryImpl.shared.setFavorite(selectedMemos, to: true)
+            try await self.environment.memoRepository.setFavorite(selectedMemos, to: true)
             self.setEditing(false, animated: true)
         }
     }
@@ -383,8 +385,8 @@ private extension MemoViewController {
             .map(\.element)
         
         Task {
-            try await MemoRepositoryImpl.shared.setFavorite(selectedMemos, to: false)
-            
+            try await self.environment.memoRepository.setFavorite(selectedMemos, to: false)
+
             guard self.memoVCType == .favorite else { return }
             try await self.updateMemoContents()
             self.setEditing(false, animated: true)
@@ -399,7 +401,7 @@ private extension MemoViewController {
     
     @objc func presentMemoMakingVC() {
         self.view.endEditing(true)
-        let memoMakingVC = MemoDetailViewController(type: .making(category: selectedCategory))
+        let memoMakingVC = MemoDetailViewController(type: .making(category: selectedCategory), environment: environment)
         let naviCon = UINavigationController(rootViewController: memoMakingVC)
         self.present(naviCon, animated: true)
     }
@@ -433,9 +435,9 @@ private extension MemoViewController {
             
             Task {
                 if self.memoVCType == .trash {
-                    try await MemoRepositoryImpl.shared.deleteMemos(selectedMemos)
+                    try await self.environment.memoRepository.deleteMemos(selectedMemos)
                 } else {
-                    try await MemoRepositoryImpl.shared.moveToTrash(selectedMemos)
+                    try await self.environment.memoRepository.moveToTrash(selectedMemos)
                 }
                 try await self.updateMemoContents()
             }
@@ -490,7 +492,8 @@ private extension MemoViewController {
         let popupCardVC = PopupCardViewController(
             memo: selectedMemo,
             indexPath: .init(item: 0, section: 0),
-            editingEnabled: editingEnabled
+            editingEnabled: editingEnabled,
+            environment: environment
         )
         wisp.present(
             popupCardVC,
@@ -590,13 +593,13 @@ extension MemoViewController: UICollectionViewDelegate {
     func fetchMemos() async throws -> [Memo] {
         switch memoVCType {
         case .category, .uncategorized:
-            return try await MemoRepositoryImpl.shared.getAllMemos(inCategory: selectedCategory)
+            return try await environment.memoRepository.getAllMemos(inCategory: selectedCategory)
         case .favorite:
-            return try await MemoRepositoryImpl.shared.getFavoriteMemos()
+            return try await environment.memoRepository.getFavoriteMemos()
         case .all:
-            return try await MemoRepositoryImpl.shared.getAllMemos()
+            return try await environment.memoRepository.getAllMemos()
         case .trash:
-            return try await MemoRepositoryImpl.shared.getAllMemosInTrash()
+            return try await environment.memoRepository.getAllMemosInTrash()
         }
     }
     
@@ -629,7 +632,7 @@ extension MemoViewController: UITextFieldDelegate {
         
         Task {
             do {
-                try await CategoryRepositoryImpl.shared.changeCategoryName(selectedCategory, newName: trimmedNewCategoryName)
+                try await self.environment.categoryRepository.changeCategoryName(selectedCategory, newName: trimmedNewCategoryName)
             } catch {
                 print(error.localizedDescription)
                 let alertCon = UIAlertController(title: L10n.CategoryList.duplicateName, message: L10n.CategoryList.duplicateNameMessage, preferredStyle: UIAlertController.Style.actionSheet)

--- a/NoteCard/Presentation/PopupCardView/PopupCardView.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardView.swift
@@ -57,9 +57,12 @@ final class PopupCardView: UIView {
     
     private(set) var memoTextView: UITextView!
     let memoDateLabel = UILabel()
-    
-    init(memo: Memo) {
+
+    private let environment: AppEnvironment
+
+    init(memo: Memo, environment: AppEnvironment) {
         self.memo = memo
+        self.environment = environment
         super.init(frame: .zero)
         setupUI()
         configureHierarchy()
@@ -191,7 +194,7 @@ final class PopupCardView: UIView {
         if isTextFieldChanged {
             Task {
                 let trimmedTitleText = titleTextField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
-                try await MemoRepositoryImpl.shared.updateMemoContent(memo, newTitle: trimmedTitleText)
+                try await environment.memoRepository.updateMemoContent(memo, newTitle: trimmedTitleText)
                 self.isTextFieldChanged = false
             }
         }
@@ -200,7 +203,7 @@ final class PopupCardView: UIView {
     func updateMemoTextView() {
         if isTextViewChanged {
             Task {
-                try await MemoRepositoryImpl.shared.updateMemoContent(memo, newMemoText: memoTextView.text)
+                try await environment.memoRepository.updateMemoContent(memo, newMemoText: memoTextView.text)
                 self.isTextViewChanged = false
             }
         }

--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -28,15 +28,18 @@ class PopupCardViewController: UIViewController {
     }
     
     private var editingEnabled: Bool
-    
+
+    private let environment: AppEnvironment
+
     private var restoreMemoAction: UIAction!
     private var presentEditingModeAction: UIAction!
     private var deleteMemoAction: UIAction!
     private var cancellables = Set<AnyCancellable>()
     
-    init(memo: Memo, indexPath: IndexPath, editingEnabled: Bool = true) {
+    init(memo: Memo, indexPath: IndexPath, editingEnabled: Bool = true, environment: AppEnvironment) {
         self.memo = memo
-        self.rootView = PopupCardView(memo: self.memo)
+        self.environment = environment
+        self.rootView = PopupCardView(memo: self.memo, environment: environment)
         self.editingEnabled = editingEnabled
         super.init(nibName: nil, bundle: nil)
         
@@ -84,7 +87,7 @@ class PopupCardViewController: UIViewController {
             memoTextViewTapGesture.isEnabled = false
         }
         
-        ImageRepositoryImpl.shared.imageUpdatedPublisher
+        environment.imageRepository.imageUpdatedPublisher
             .filter { [weak self] updateType in
                 guard let self else { return false }
                 return updateType.memoID == self.memo.memoID
@@ -108,7 +111,7 @@ class PopupCardViewController: UIViewController {
             }
             .store(in: &cancellables)
         
-        MemoRepositoryImpl.shared.memoUpdatedPublisher
+        environment.memoRepository.memoUpdatedPublisher
             .filter({ [weak self] updateType in
                 guard let self else { return false }
                 guard case .update(let updatedAttribute) = updateType else { return false }
@@ -119,7 +122,7 @@ class PopupCardViewController: UIViewController {
                 guard let self else { return }
                 Task {
                     do {
-                        let updatedMemo = try await MemoRepositoryImpl.shared.getMemo(id: self.memo.memoID)
+                        let updatedMemo = try await self.environment.memoRepository.getMemo(id: self.memo.memoID)
                         self.memo = updatedMemo
                         self.categories = try await self.fetchCategories()
                         
@@ -187,7 +190,8 @@ private extension PopupCardViewController {
                 guard let self else { return }
                 
                 let memoEditingVC = MemoDetailViewController(
-                    type: .editing(memo: self.memo, images: self.imageUIModels)
+                    type: .editing(memo: self.memo, images: self.imageUIModels),
+                    environment: self.environment
                 )
                 let naviCon = UINavigationController(rootViewController: memoEditingVC)
                 naviCon.modalPresentationStyle = .formSheet
@@ -215,7 +219,7 @@ private extension PopupCardViewController {
         }
         Task {
             do {
-                try await MemoRepositoryImpl.shared.updateMemoContent(memo, newTitle: sender.text)
+                try await environment.memoRepository.updateMemoContent(memo, newTitle: sender.text)
             } catch {
                 print(error.localizedDescription)
             }
@@ -242,7 +246,7 @@ private extension PopupCardViewController {
     @objc func likeButtonTapped() {
         Task {
             do {
-                try await MemoRepositoryImpl.shared.setFavorite(memo, to: !memo.isFavorite)
+                try await environment.memoRepository.setFavorite(memo, to: !memo.isFavorite)
                 rootView.likeButton.isSelected.toggle()
             } catch {
                 print(error.localizedDescription)
@@ -313,7 +317,7 @@ extension PopupCardViewController: UITextViewDelegate {
         }
         Task {
             do {
-                try await MemoRepositoryImpl.shared.updateMemoContent(memo, newMemoText: textView.text)
+                try await environment.memoRepository.updateMemoContent(memo, newMemoText: textView.text)
             } catch {
                 print(error.localizedDescription)
             }
@@ -333,7 +337,7 @@ extension PopupCardViewController: UITextFieldDelegate {
         }
         Task {
             do {
-                try await MemoRepositoryImpl.shared.updateMemoContent(memo, newTitle: trimmedInput)
+                try await environment.memoRepository.updateMemoContent(memo, newTitle: trimmedInput)
             } catch {
                 print(error.localizedDescription)
             }
@@ -364,7 +368,7 @@ extension PopupCardViewController {
 private extension PopupCardViewController {
     
     private func fetchCategories() async throws -> [Domain.Category] {
-        return try await CategoryRepositoryImpl.shared.getAllCategories(
+        return try await environment.categoryRepository.getAllCategories(
             ofMemo: memo,
             inOrderOf: .modificationDate,
             isAscending: false
@@ -380,7 +384,7 @@ private extension PopupCardViewController {
     private func makeImageUIModels() async throws -> [ImageUIModel] {
         var imageUIModels: [ImageUIModel] = []
         
-        let fetchedImageInfoList = try await ImageRepositoryImpl.shared.getAllImageInfo(for: memo)
+        let fetchedImageInfoList = try await environment.imageRepository.getAllImageInfo(for: memo)
         let fetchedThumbnails = try await fetchThumbnailsConcurrently(for: fetchedImageInfoList)
         let fetchedImages = try await fetchImagesConcurrently(for: fetchedImageInfoList)
         
@@ -402,11 +406,12 @@ private extension PopupCardViewController {
     }
     
     private func fetchThumbnailsConcurrently(for imageInfos: [MemoImageInfo]) async throws -> [UIImage] {
+        let imageRepository = environment.imageRepository
         var thumbnailResults: [Int: UIImage] = [:]
         try await withThrowingTaskGroup(of: (Int, UIImage).self) { group in
             for (index, info) in imageInfos.enumerated() {
                 group.addTask {
-                    let thumbnail = try await ImageRepositoryImpl.shared.getThumbnailImage(from: info)
+                    let thumbnail = try await imageRepository.getThumbnailImage(from: info)
                     return (index, thumbnail)
                 }
             }
@@ -418,11 +423,12 @@ private extension PopupCardViewController {
     }
     
     private func fetchImagesConcurrently(for imageInfos: [MemoImageInfo]) async throws -> [UIImage] {
+        let imageRepository = environment.imageRepository
         var imageResults: [Int: UIImage] = [:]
         try await withThrowingTaskGroup(of: (Int, UIImage).self) { group in
             for (index, info) in imageInfos.enumerated() {
                 group.addTask {
-                    let image = try await ImageRepositoryImpl.shared.getImage(from: info)
+                    let image = try await imageRepository.getImage(from: info)
                     return (index, image)
                 }
             }
@@ -450,7 +456,7 @@ extension PopupCardViewController {
         let restoreAction = UIAlertAction(title: L10n.Common.recover, style: .default) { action in
             Task{
                 do {
-                    try await MemoRepositoryImpl.shared.restore(self.memo)
+                    try await self.environment.memoRepository.restore(self.memo)
                     self.dismiss(animated: true)
                 } catch {
                     print(error.localizedDescription)
@@ -477,9 +483,9 @@ extension PopupCardViewController {
             Task {
                 do {
                     if self.memo.isInTrash {
-                        try await MemoRepositoryImpl.shared.deleteMemo(self.memo)
+                        try await self.environment.memoRepository.deleteMemo(self.memo)
                     } else {
-                        try await MemoRepositoryImpl.shared.moveToTrash(self.memo)
+                        try await self.environment.memoRepository.moveToTrash(self.memo)
                     }
                     self.dismiss(animated: true)
                 } catch {

--- a/NoteCard/Presentation/SettingsView/SettingsViewController.swift
+++ b/NoteCard/Presentation/SettingsView/SettingsViewController.swift
@@ -13,7 +13,18 @@ import Shared
 import Combine
 
 class SettingsViewController: UITableViewController {
-    
+
+    private let environment: AppEnvironment
+
+    init(environment: AppEnvironment) {
+        self.environment = environment
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     var settingTitles: [[String]] = [
         
         //design
@@ -328,7 +339,7 @@ extension SettingsViewController {
             targetVC = DarkModeSettingViewController()
             
         case IndexPath(row: 2, section: 1):
-            targetVC = MemoViewController(memoVCType: .trash)
+            targetVC = MemoViewController(memoVCType: .trash, environment: environment)
         case IndexPath(row: 3, section: 1):
             showDeleteAllAlert(indexPath: indexPath)
             

--- a/NoteCard/Presentation/TabBar/MainTabBarController.swift
+++ b/NoteCard/Presentation/TabBar/MainTabBarController.swift
@@ -16,12 +16,15 @@ class MainTabBarController: UITabBarController {
     var previousSelectedIndex: Int = 0
     
     var isUncategorizedMemoVCHasShown: Bool = false
-    
+
+    private let environment: AppEnvironment
+
     // MARK: - Initialize
-    
-    init() {
+
+    init(environment: AppEnvironment) {
+        self.environment = environment
         super.init(nibName: nil, bundle: nil)
-        
+
         setTabBarDesign()
         initialViewControllersSetting()
     }
@@ -57,7 +60,7 @@ class MainTabBarController: UITabBarController {
     /// https://developer.apple.com/documentation/uikit/uitabbarcontroller#overview
     private func initialViewControllersSetting() {
         // tab 0: 홈 화면
-        let homeNaviCon = UINavigationController(rootViewController: HomeViewController())
+        let homeNaviCon = UINavigationController(rootViewController: HomeViewController(environment: environment))
         homeNaviCon.tabBarItem = UITabBarItem(
             title: "홈 화면",
             image: UIImage(systemName: "house"),
@@ -65,7 +68,7 @@ class MainTabBarController: UITabBarController {
         )
         
         // tab 1: 카테고리 없음.
-        let uncategorizedMemoVC = MemoViewController(memoVCType: .uncategorized)
+        let uncategorizedMemoVC = MemoViewController(memoVCType: .uncategorized, environment: environment)
         let noCategoriesCardNaviCon = UINavigationController(rootViewController: uncategorizedMemoVC)
         noCategoriesCardNaviCon.navigationController?.toolbar.tintColor = .currentTheme
         noCategoriesCardNaviCon.tabBarItem = UITabBarItem(
@@ -83,7 +86,7 @@ class MainTabBarController: UITabBarController {
         )
         
         // tab 3: 메모 검색
-        let memoSearchingVC = MemoSearchingViewController()
+        let memoSearchingVC = MemoSearchingViewController(environment: environment)
         let memoSearchingNaviCon = UINavigationController(rootViewController: memoSearchingVC)
         memoSearchingNaviCon.tabBarItem = UITabBarItem(
             title: L10n.TabBar.searchMemo,
@@ -92,7 +95,7 @@ class MainTabBarController: UITabBarController {
         )
         
         // tab 4: 설정(UISplitViewController)
-        let settingsVC = SettingsViewController()
+        let settingsVC = SettingsViewController(environment: environment)
         let settingsNaviCon = UINavigationController(rootViewController: settingsVC)
         
         let emptyDetailVC = SettingsPlaceholderViewController()
@@ -140,9 +143,9 @@ extension MainTabBarController: UITabBarControllerDelegate {
         guard viewController is ThirdTabViewController else {
             return true
         }
-        let memoMakingVC = MemoDetailViewController(type: .making(category: nil))
+        let memoMakingVC = MemoDetailViewController(type: .making(category: nil), environment: environment)
         let memoMakingNaviCon = UINavigationController(rootViewController: memoMakingVC)
-        
+
         memoMakingNaviCon.modalPresentationStyle = .formSheet
         tabBarController.present(memoMakingNaviCon, animated: true)
         return false

--- a/Projects/Data/Sources/Repositories/CategoryRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/CategoryRepositoryImpl.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CoreData
 import Domain
 import Shared
 
@@ -15,10 +16,11 @@ extension Date: ComparableValue {}
 
 public actor CategoryRepositoryImpl: CategoryRepository {
     
-    public static let shared = CategoryRepositoryImpl()
-    private init() { }
-    
-    private let context = CoreDataStack.shared.backgroundContext
+    private let context: NSManagedObjectContext
+
+    public init(stack: CoreDataStack) {
+        self.context = stack.backgroundContext
+    }
     
     private func categoryNameEqual(to name: String) -> NSPredicate {
         return NSPredicate(format: "name == %@", name as CVarArg)

--- a/Projects/Data/Sources/Repositories/ImageRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/ImageRepositoryImpl.swift
@@ -32,10 +32,13 @@ public actor ImageRepositoryImpl: ImageRepository {
         }
     }
     
-    public static let shared = ImageRepositoryImpl()
-    private init() { }
-    
-    private let context = CoreDataStack.shared.backgroundContext
+    private let context: NSManagedObjectContext
+    private let memoRepository: MemoRepositoryImpl
+
+    public init(stack: CoreDataStack, memoRepository: MemoRepositoryImpl) {
+        self.context = stack.backgroundContext
+        self.memoRepository = memoRepository
+    }
     
     // MARK: - Subjects, Publisher
     
@@ -58,7 +61,7 @@ public actor ImageRepositoryImpl: ImageRepository {
         let thumbnailData = try ImageFileHandler.createThumbnailData(from: originalData)
         
         // MemoEntity 불러오기(후에 ImageEntity에서 생성자의 매개변수로 넣기 위함)
-        let memoEntity = try await MemoRepositoryImpl.shared.fetchMemoEntity(id: memo.memoID)
+        let memoEntity = try await memoRepository.fetchMemoEntity(id: memo.memoID)
         
         let createdMemoInfo =  try await context.perform { [unowned self] in
             // 코어데이터에 저장할 데이터

--- a/Projects/Data/Sources/Repositories/MemoRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/MemoRepositoryImpl.swift
@@ -51,10 +51,11 @@ public actor MemoRepositoryImpl: MemoRepository {
         case update(content: UpdateAttribute)
     }
     
-    public static let shared = MemoRepositoryImpl()
-    private init() { }
-    
-    private let context = CoreDataStack.shared.backgroundContext
+    private let context: NSManagedObjectContext
+
+    public init(stack: CoreDataStack) {
+        self.context = stack.backgroundContext
+    }
     
     @UserDefault<String>(key: .orderCriterion, defaultValue: OrderCriterion.modificationDate.rawValue)
     private var orderCriterion: String


### PR DESCRIPTION
## 배경
- `MemoRepositoryImpl` / `CategoryRepositoryImpl` / `ImageRepositoryImpl`이 `static let shared` 싱글톤이라, protocol로 추상화해두고도 화면이 concrete 타입과 전역 상태에 직접 묶여 있었음
- 싱글톤을 제거하고 생성자 주입(DI)으로 전환해 의존 관계를 명시화하고 테스트 가능성을 확보

## 변경사항
- RepositoryImpl 3종의 `static let shared` 제거, `init(stack:)` 생성자 주입으로 전환
- `ImageRepositoryImpl`의 `MemoRepositoryImpl` 의존성(`fetchMemoEntity` 호출)도 생성자 주입으로 처리
- `AppEnvironment` 추가: 공유 의존성 묶음. `AppDelegate`가 프로세스 수명 동안 소유
- `SceneDelegate`가 `AppDelegate`의 environment를 `MainTabBarController`에 주입, VC 계층 전체로 생성자 주입 전달
- 모든 `RepositoryImpl.shared` 호출부를 주입된 인스턴스 경유로 교체

## 테스트 방법
- `tuist generate --no-open`
- `xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- `xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard-Eng -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- `xcodebuild test -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- 4개 commit 각각 독립적으로 컴파일 통과 검증 완료

## 리뷰 노트
- commit 순서대로 흐름이 읽히도록 4분할: ① AppEnvironment 도입 + 배선(동작 무변경, 기존 .shared를 감쌈) → ② Image → ③ Memo → ④ Category 싱글톤 제거
- `ImageRepositoryImpl`이 `MemoRepositoryImpl`에 의존하므로 Image를 Memo보다 먼저 처리 (생성자 주입은 구조적으로 생성 시점 순환을 방지)
- `CoreDataStack.shared`는 이번 범위에서 유지 — 레거시 `EntityManager` 3종이 의존 중이라 제거 불가. EntityManager 제거는 별도 에픽 예정
- VC는 concrete `RepositoryImpl` 타입을 주입받음 — Domain 프로토콜에 Combine publisher가 없어 protocol 추상화는 보류 (후속 과제)

🤖 Generated with [Claude Code](https://claude.com/claude-code)