### PR TITLE
refactor(di): CoreDataStack 싱글톤 제거

### DIFF
--- a/NoteCard/Global/Application/AppDelegate.swift
+++ b/NoteCard/Global/Application/AppDelegate.swift
@@ -17,7 +17,7 @@ import CoreData
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     /// 앱 전체가 공유하는 의존성. 프로세스 수명 동안 하나만 존재한다.
-    let environment = AppEnvironment(stack: .shared)
+    let environment = AppEnvironment()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.

--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -13,14 +13,17 @@ import Data
 /// Combine publisher 이벤트도 화면 간에 끊김 없이 전달된다.
 struct AppEnvironment {
 
+    let coreDataStack: CoreDataStack
     let memoRepository: MemoRepositoryImpl
     let categoryRepository: CategoryRepositoryImpl
     let imageRepository: ImageRepositoryImpl
 
-    init(stack: CoreDataStack) {
-        let memoRepository = MemoRepositoryImpl(stack: stack)
+    init() {
+        let coreDataStack = CoreDataStack()
+        self.coreDataStack = coreDataStack
+        let memoRepository = MemoRepositoryImpl(stack: coreDataStack)
         self.memoRepository = memoRepository
-        self.categoryRepository = CategoryRepositoryImpl(stack: stack)
-        self.imageRepository = ImageRepositoryImpl(stack: stack, memoRepository: memoRepository)
+        self.categoryRepository = CategoryRepositoryImpl(stack: coreDataStack)
+        self.imageRepository = ImageRepositoryImpl(stack: coreDataStack, memoRepository: memoRepository)
     }
 }

--- a/NoteCard/Global/Application/SceneDelegate.swift
+++ b/NoteCard/Global/Application/SceneDelegate.swift
@@ -134,7 +134,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
 
         // Save changes in the application's managed object context when the application transitions to the background.
-        CoreDataStack.shared.saveContext()
+        (UIApplication.shared.delegate as? AppDelegate)?.environment.coreDataStack.saveContext()
     }
     
     

--- a/NoteCard/Presentation/HomeView/HomeViewController.swift
+++ b/NoteCard/Presentation/HomeView/HomeViewController.swift
@@ -53,9 +53,9 @@ class HomeViewController: UIViewController {
     private var diffableDataSource: DiffableDataSource!
     
     private var cancellables: Set<AnyCancellable> = []
-    private let coreDataChangePublisher = NotificationCenter.default.publisher(
+    private lazy var coreDataChangePublisher = NotificationCenter.default.publisher(
         for: .NSManagedObjectContextDidSave,
-        object: CoreDataStack.shared.backgroundContext
+        object: environment.coreDataStack.backgroundContext
     )
 
     private let environment: AppEnvironment

--- a/Projects/Data/Sources/CoreData/CoreDataStack.swift
+++ b/Projects/Data/Sources/CoreData/CoreDataStack.swift
@@ -13,8 +13,7 @@ import Foundation
 
 public final class CoreDataStack: ObservableObject {
 
-    public static let shared = CoreDataStack()
-    private init() { }
+    public init() { }
 
     // MARK: - Core Data stack
 


### PR DESCRIPTION
## 배경
- `CoreDataStack`은 데이터 계층에 마지막으로 남아 있던 싱글톤
- 앞선 작업(RepositoryImpl DI 전환 → EntityManager 제거)에서 못 없앴던 이유는 EntityManager 싱글톤이 `CoreDataStack.shared`에 의존했기 때문 — EntityManager가 사라지며 그 매듭이 풀림
- 데이터 접근 경로 전체를 싱글톤 없이 생성자 주입으로 일원화

## 변경사항
- `CoreDataStack`의 `static let shared` 제거, `init()`을 public으로 공개
- `AppEnvironment`가 `CoreDataStack`을 직접 1개 생성·소유하도록 변경 (`init(stack:)` → `init()`, `coreDataStack` 프로퍼티 추가)
- `AppDelegate`는 `AppEnvironment()`만 생성
- `HomeViewController` / `SceneDelegate`의 `CoreDataStack.shared` 접근을 `environment.coreDataStack` 경유로 교체

## 테스트 방법
- `tuist generate --no-open`
- `xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- `xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard-Eng -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- `xcodebuild test -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- 시뮬레이터 수동 확인: 앱 실행 → 메모 생성/저장 → 백그라운드 전환(saveContext) 정상 동작 확인 완료

## 리뷰 노트
- `NSPersistentContainer`는 프로세스당 1개여야 하는데, `AppEnvironment`가 `CoreDataStack`을 정확히 하나 생성하고 `AppDelegate`가 그 `AppEnvironment` 하나를 소유 — 인스턴스 수는 그대로 1개, 접근 방식만 전역 싱글톤에서 주입으로 전환
- 화면 동작 변경 없음 (앱 진입점 배선만 변경)
- 이로써 데이터 계층의 모든 싱글톤(RepositoryImpl 3종 + CoreDataStack) 제거 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)