### PR TITLE
test: Data·Shared 레이어 단위/통합 테스트 도입

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -26,6 +26,10 @@ let projectBaseSettings: SettingsDictionary = [
     "DEVELOPMENT_TEAM": .string(developmentTeam),
     "SWIFT_VERSION": "5.0",
     "TARGETED_DEVICE_FAMILY": "1,2",
+    // static framework 안의 Obj-C 카테고리(예: NSManagedObject 서브클래스의
+    // @NSManaged 프로퍼티)가 링커 dead-stripping으로 제거되지 않도록 강제 로드.
+    // 누락 시 Core Data가 동적 접근자를 만들지 못해 런타임 크래시한다.
+    "OTHER_LDFLAGS": ["$(inherited)", "-ObjC"],
 ]
 
 let appTargetBaseSettings: SettingsDictionary = infoPlistKeys.merging([

--- a/Projects/Core/Shared/Tests/SharedUtilityTests.swift
+++ b/Projects/Core/Shared/Tests/SharedUtilityTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+import Combine
+@testable import Shared
+
+/// `@UserDefault` 프로퍼티 래퍼의 동작 검증.
+///
+/// 래퍼는 `UserDefaults.standard`를 직접 사용하므로, 전역 상태를 건드린 뒤
+/// tearDown에서 원래 값으로 복원해 테스트 간 격리를 보장한다.
+final class UserDefaultWrapperTests: XCTestCase {
+
+    private let key = UserDefaultsKey.dateFormat
+    private var savedValue: Any?
+
+    override func setUp() {
+        super.setUp()
+        savedValue = UserDefaults.standard.object(forKey: key.rawValue)
+        UserDefaults.standard.removeObject(forKey: key.rawValue)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.set(savedValue, forKey: key.rawValue)
+        super.tearDown()
+    }
+
+    func test_저장된_값이_없으면_기본값을_반환한다() {
+        // given: 저장된 값이 없는 상태 (setUp에서 키 제거됨)
+        let wrapper = UserDefault<String>(key: key, defaultValue: "fallback")
+
+        // when / then
+        XCTAssertEqual(wrapper.wrappedValue, "fallback")
+    }
+
+    func test_값을_저장하면_그_값을_반환한다() {
+        // given
+        var wrapper = UserDefault<String>(key: key, defaultValue: "fallback")
+
+        // when
+        wrapper.wrappedValue = "stored"
+
+        // then
+        XCTAssertEqual(wrapper.wrappedValue, "stored")
+    }
+
+    func test_같은_키를_보는_다른_래퍼도_저장된_값을_읽는다() {
+        // given: 한 래퍼로 값을 저장하면
+        var writer = UserDefault<String>(key: key, defaultValue: "fallback")
+        writer.wrappedValue = "shared-value"
+
+        // when: 같은 키를 보는 다른 래퍼는
+        let reader = UserDefault<String>(key: key, defaultValue: "fallback")
+
+        // then: 같은 값을 읽는다
+        XCTAssertEqual(reader.wrappedValue, "shared-value")
+    }
+}
+
+
+/// `OrderSettingManager`의 동작 검증.
+///
+/// `@MainActor` 싱글톤이므로 테스트 클래스도 `@MainActor`로 둔다.
+@MainActor
+final class OrderSettingManagerTests: XCTestCase {
+
+    private let criterionKey = "orderCriterion"
+    private let ascendingKey = "isOrderAscending"
+    private var savedCriterion: Any?
+    private var savedAscending: Any?
+
+    override func setUp() {
+        super.setUp()
+        savedCriterion = UserDefaults.standard.object(forKey: criterionKey)
+        savedAscending = UserDefaults.standard.object(forKey: ascendingKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.set(savedCriterion, forKey: criterionKey)
+        UserDefaults.standard.set(savedAscending, forKey: ascendingKey)
+        super.tearDown()
+    }
+
+    func test_정렬_기준을_설정하면_UserDefaults에_저장된다() {
+        // when
+        OrderSettingManager.shared.setOrderCriterion(.creationDate)
+
+        // then
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: criterionKey),
+            OrderCriterion.creationDate.rawValue
+        )
+    }
+
+    func test_정렬_기준을_설정하면_변경_이벤트가_방출된다() {
+        // given: 변경 이벤트 구독
+        var emitCount = 0
+        let cancellable = OrderSettingManager.shared.orderSettingChangedPublisher
+            .sink { emitCount += 1 }
+        defer { cancellable.cancel() }
+
+        // when
+        OrderSettingManager.shared.setOrderCriterion(.modificationDate)
+
+        // then
+        XCTAssertEqual(emitCount, 1)
+    }
+
+    func test_정렬_방향을_설정하면_저장되고_변경_이벤트가_방출된다() {
+        // given
+        var emitCount = 0
+        let cancellable = OrderSettingManager.shared.orderSettingChangedPublisher
+            .sink { emitCount += 1 }
+        defer { cancellable.cancel() }
+
+        // when
+        OrderSettingManager.shared.setIsOrderAscending(true)
+
+        // then
+        XCTAssertEqual(UserDefaults.standard.bool(forKey: ascendingKey), true)
+        XCTAssertEqual(emitCount, 1)
+    }
+}
+
+
+/// `Date` 포맷팅 확장의 동작 검증.
+///
+/// 시각 표기는 로케일·`isTimeFormat24` 설정에 따라 달라지므로, 검증은
+/// 로케일과 무관하게 결정적인 "오늘 / 어제 / 그 외" 분기에 집중한다.
+final class DateFormattingTests: XCTestCase {
+
+    func test_오늘_날짜는_오늘_라벨로_시작한다() {
+        // given / when
+        let result = Date().getCreationDateInString()
+
+        // then
+        XCTAssertTrue(result.hasPrefix(L10n.Date.today))
+    }
+
+    func test_어제_날짜는_어제_라벨로_시작한다() {
+        // given
+        let yesterday = Calendar(identifier: .gregorian)
+            .date(byAdding: .day, value: -1, to: Date())!
+
+        // when
+        let result = yesterday.getCreationDateInString()
+
+        // then
+        XCTAssertTrue(result.hasPrefix(L10n.Date.yesterday))
+    }
+
+    func test_오래된_날짜는_오늘도_어제도_아닌_일반_형식을_쓴다() {
+        // given: 1970년 (오늘도 어제도 아닌 날짜)
+        let oldDate = Date(timeIntervalSince1970: 0)
+
+        // when
+        let result = oldDate.getCreationDateInString()
+
+        // then: today/yesterday 라벨 대신 일반 날짜 형식이 쓰인다
+        XCTAssertFalse(result.hasPrefix(L10n.Date.today))
+        XCTAssertFalse(result.hasPrefix(L10n.Date.yesterday))
+    }
+
+    func test_수정일_문자열도_오늘이면_오늘_라벨로_시작한다() {
+        // given / when
+        let result = Date().getModificationDateString()
+
+        // then
+        XCTAssertTrue(result.hasPrefix(L10n.Date.today))
+    }
+}

--- a/Projects/Data/Sources/CoreData/CoreDataStack.swift
+++ b/Projects/Data/Sources/CoreData/CoreDataStack.swift
@@ -13,7 +13,15 @@ import Foundation
 
 public final class CoreDataStack: ObservableObject {
 
-    public init() { }
+    private let inMemory: Bool
+
+    /// - Parameter inMemory: `true`이면 디스크 대신 휘발성 저장소를 사용한다.
+    ///   store type 자체는 SQLite를 유지하되 파일 경로만 `/dev/null`로 두어,
+    ///   predicate·정렬 동작이 프로덕션과 100% 동일하면서 디스크에는 아무것도
+    ///   남기지 않는다. 단위 테스트에서 격리된 빈 저장소를 매번 새로 만들 때 사용.
+    public init(inMemory: Bool = false) {
+        self.inMemory = inMemory
+    }
 
     // MARK: - Core Data stack
 
@@ -32,6 +40,11 @@ public final class CoreDataStack: ObservableObject {
             fatalError("Failed to locate NoteCardCoreData.momd in Data bundle.")
         }
         let container = NSPersistentContainer(name: "NoteCardCoreData", managedObjectModel: model)
+        if inMemory {
+            container.persistentStoreDescriptions = [
+                NSPersistentStoreDescription(url: URL(fileURLWithPath: "/dev/null"))
+            ]
+        }
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
             if let error = error as NSError? {
                 // Replace this implementation with code to handle the error appropriately.

--- a/Projects/Data/Tests/CategoryRepositoryTests.swift
+++ b/Projects/Data/Tests/CategoryRepositoryTests.swift
@@ -1,0 +1,213 @@
+import XCTest
+import Domain
+@testable import Data
+
+/// `CategoryRepositoryImpl`의 동작(behavior)을 검증하는 통합 테스트.
+///
+/// 공개 API를 통해 관찰 가능한 결과만 검증하며, 저장소는 매 테스트마다
+/// `/dev/null` SQLite로 새로 만들어 격리한다.
+final class CategoryRepositoryTests: XCTestCase {
+
+    private var stack: CoreDataStack!
+    private var sut: CategoryRepositoryImpl!
+    private var memoRepository: MemoRepositoryImpl!
+
+    override func setUp() {
+        super.setUp()
+        stack = CoreDataStack(inMemory: true)
+        sut = CategoryRepositoryImpl(stack: stack)
+        memoRepository = MemoRepositoryImpl(stack: stack)
+    }
+
+    override func tearDown() {
+        sut = nil
+        memoRepository = nil
+        stack = nil
+        super.tearDown()
+    }
+
+    // MARK: - 생성
+
+    func test_카테고리를_생성하면_전체_목록에서_조회된다() async throws {
+        // when
+        try await sut.create(name: "업무")
+
+        // then
+        let names = try await allCategoryNames()
+        XCTAssertEqual(names, ["업무"])
+    }
+
+    func test_중복된_이름으로_카테고리를_생성하면_에러를_던진다() async throws {
+        // given: 이미 존재하는 카테고리
+        try await sut.create(name: "업무")
+
+        // when / then: 같은 이름으로 다시 만들면 에러를 던진다
+        do {
+            try await sut.create(name: "업무")
+            XCTFail("중복된 이름의 카테고리 생성 시 에러를 던져야 한다")
+        } catch {
+            // 에러 발생 — 통과
+        }
+    }
+
+    func test_중복된_이름으로_생성을_시도해도_카테고리가_늘어나지_않는다() async throws {
+        // given
+        try await sut.create(name: "업무")
+
+        // when: 중복 생성을 시도하면 (에러 발생)
+        _ = try? await sut.create(name: "업무")
+
+        // then: 카테고리는 여전히 1개뿐이다
+        let names = try await allCategoryNames()
+        XCTAssertEqual(names, ["업무"])
+    }
+
+    // MARK: - 조회
+
+    func test_생성한_모든_카테고리가_조회된다() async throws {
+        // given
+        try await sut.create(name: "업무")
+        try await sut.create(name: "개인")
+        try await sut.create(name: "공부")
+
+        // when
+        let names = try await allCategoryNames()
+
+        // then
+        XCTAssertEqual(Set(names), ["업무", "개인", "공부"])
+    }
+
+    func test_메모별_조회시_그_메모에_연결된_카테고리만_반환된다() async throws {
+        // given: 메모에 업무 카테고리만 연결
+        try await sut.create(name: "업무")
+        try await sut.create(name: "개인")
+        let work = try await category(named: "업무")
+        let memo = try await memoRepository.createNewMemo()
+        try await memoRepository.addCategories(to: memo, newCategories: [work])
+
+        // when
+        let linked = try await sut.getAllCategories(
+            ofMemo: memo,
+            inOrderOf: .modificationDate,
+            isAscending: false
+        )
+
+        // then
+        XCTAssertEqual(linked.map(\.name), ["업무"])
+    }
+
+    // MARK: - 검색
+
+    func test_검색은_대소문자를_구분하지_않는_부분_문자열로_매칭한다() async throws {
+        // given
+        try await sut.create(name: "Work")
+        try await sut.create(name: "Personal")
+
+        // when: 소문자 부분 문자열로 검색하면
+        let results = try await sut.searchCategory("work", inOrderOf: .name, isAscending: true)
+
+        // then: 대소문자 구분 없이 매칭된다
+        XCTAssertEqual(results.map(\.name), ["Work"])
+    }
+
+    func test_일치하는_카테고리가_없으면_검색_결과가_비어있다() async throws {
+        // given
+        try await sut.create(name: "업무")
+
+        // when
+        let results = try await sut.searchCategory("존재하지않음", inOrderOf: .name, isAscending: true)
+
+        // then
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    // MARK: - 수정
+
+    func test_카테고리_이름을_변경할_수_있다() async throws {
+        // given
+        try await sut.create(name: "업무")
+        let work = try await category(named: "업무")
+
+        // when
+        try await sut.changeCategoryName(work, newName: "회사")
+
+        // then
+        let names = try await allCategoryNames()
+        XCTAssertEqual(names, ["회사"])
+    }
+
+    func test_이미_존재하는_이름으로_변경하면_에러를_던진다() async throws {
+        // given: 두 개의 카테고리
+        try await sut.create(name: "업무")
+        try await sut.create(name: "개인")
+        let personal = try await category(named: "개인")
+
+        // when / then: 이미 존재하는 이름으로 바꾸려 하면 에러를 던진다
+        do {
+            try await sut.changeCategoryName(personal, newName: "업무")
+            XCTFail("이미 존재하는 이름으로 변경 시 에러를 던져야 한다")
+        } catch {
+            // 에러 발생 — 통과
+        }
+    }
+
+    // MARK: - 삭제
+
+    func test_카테고리를_삭제하면_전체_목록에서_사라진다() async throws {
+        // given
+        try await sut.create(name: "업무")
+        let work = try await category(named: "업무")
+
+        // when
+        try await sut.deleteCategory(work)
+
+        // then
+        let names = try await allCategoryNames()
+        XCTAssertTrue(names.isEmpty)
+    }
+
+    // MARK: - 메모 개수
+
+    func test_memoCount는_카테고리에_속한_메모_수를_반환한다() async throws {
+        // given: 한 카테고리에 메모 2개를 연결
+        try await sut.create(name: "업무")
+        let work = try await category(named: "업무")
+        let memo1 = try await memoRepository.createNewMemo()
+        let memo2 = try await memoRepository.createNewMemo()
+        try await memoRepository.addCategories(to: memo1, newCategories: [work])
+        try await memoRepository.addCategories(to: memo2, newCategories: [work])
+
+        // when
+        let count = try await sut.memoCount(of: work)
+
+        // then
+        XCTAssertEqual(count, 2)
+    }
+
+    func test_메모가_없는_카테고리의_memoCount는_0이다() async throws {
+        // given
+        try await sut.create(name: "업무")
+        let work = try await category(named: "업무")
+
+        // when
+        let count = try await sut.memoCount(of: work)
+
+        // then
+        XCTAssertEqual(count, 0)
+    }
+
+    // MARK: - 헬퍼
+
+    private func allCategoryNames() async throws -> [String] {
+        try await sut.getAllCategories(inOrderOf: .modificationDate, isAscending: false)
+            .map(\.name)
+    }
+
+    private func category(named name: String) async throws -> Domain.Category {
+        let categories = try await sut.getAllCategories(
+            inOrderOf: .modificationDate,
+            isAscending: false
+        )
+        return try XCTUnwrap(categories.first { $0.name == name })
+    }
+}

--- a/Projects/Data/Tests/ImageFileHandlerTests.swift
+++ b/Projects/Data/Tests/ImageFileHandlerTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+import UIKit
+@testable import Data
+
+/// `ImageFileHandler`의 순수 함수와 파일 시스템 동작을 검증한다.
+///
+/// 썸네일 리사이즈와 명시적 URL을 받는 save/load/delete만 다룬다.
+/// `getDirectory` / `getFileURL`은 실제 documentDirectory에 의존하므로,
+/// base directory 주입이 가능해진 뒤 별도 작업에서 다룬다.
+final class ImageFileHandlerTests: XCTestCase {
+
+    // MARK: - 썸네일 리사이즈
+
+    func test_최대_크기보다_큰_이미지는_썸네일에서_축소된다() throws {
+        // given: 800x400 이미지, 최대 변 400
+        let source = makeImage(size: CGSize(width: 800, height: 400))
+
+        // when
+        let thumbnail = try ImageFileHandler.createThumbnailImage(from: source, maxPixelSize: 400)
+
+        // then: 긴 변이 400으로 줄고 종횡비(2:1)가 유지된다
+        XCTAssertEqual(thumbnail.size.width, 400, accuracy: 0.5)
+        XCTAssertEqual(thumbnail.size.height, 200, accuracy: 0.5)
+    }
+
+    func test_최대_크기보다_작은_이미지는_썸네일에서_크기가_유지된다() throws {
+        // given: 최대 변보다 작은 이미지
+        let source = makeImage(size: CGSize(width: 100, height: 80))
+
+        // when
+        let thumbnail = try ImageFileHandler.createThumbnailImage(from: source, maxPixelSize: 400)
+
+        // then: 크기가 그대로 유지된다
+        XCTAssertEqual(thumbnail.size.width, 100, accuracy: 0.5)
+        XCTAssertEqual(thumbnail.size.height, 80, accuracy: 0.5)
+    }
+
+    func test_썸네일_Data는_다시_이미지로_디코딩된다() throws {
+        // given
+        let source = makeImage(size: CGSize(width: 600, height: 600))
+
+        // when
+        let data = try ImageFileHandler.createThumbnailData(from: source, maxPixelSize: 200)
+
+        // then
+        XCTAssertFalse(data.isEmpty)
+        XCTAssertNotNil(UIImage(data: data))
+    }
+
+    // MARK: - 파일 시스템 작업
+
+    func test_저장한_파일을_같은_경로에서_이미지로_불러올_수_있다() throws {
+        // given
+        let directory = try makeTemporaryDirectory()
+        let id = UUID()
+        let data = try ImageFileHandler.createThumbnailData(
+            from: makeImage(size: CGSize(width: 50, height: 50))
+        )
+
+        // when: 저장한 뒤 같은 경로에서 로드하면
+        try ImageFileHandler.save(data: data, to: directory, with: id, fileExtension: "jpeg")
+        let fileURL = directory.appendingPathComponent(id.uuidString).appendingPathExtension("jpeg")
+        let loaded = try ImageFileHandler.loadUIImage(from: fileURL)
+
+        // then
+        XCTAssertGreaterThan(loaded.size.width, 0)
+    }
+
+    func test_존재하지_않는_파일을_불러오면_에러를_던진다() {
+        // given: 존재하지 않는 파일 경로
+        let missingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("jpeg")
+
+        // when / then
+        XCTAssertThrowsError(try ImageFileHandler.loadUIImage(from: missingURL))
+    }
+
+    func test_저장된_파일을_삭제할_수_있다() throws {
+        // given: 저장된 파일
+        let directory = try makeTemporaryDirectory()
+        let id = UUID()
+        let data = try ImageFileHandler.createThumbnailData(
+            from: makeImage(size: CGSize(width: 50, height: 50))
+        )
+        try ImageFileHandler.save(data: data, to: directory, with: id, fileExtension: "jpeg")
+        let fileURL = directory.appendingPathComponent(id.uuidString).appendingPathExtension("jpeg")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
+
+        // when
+        try ImageFileHandler.delete(at: fileURL)
+
+        // then
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
+    func test_존재하지_않는_파일을_삭제해도_에러를_던지지_않는다() {
+        // given: 존재하지 않는 파일 경로
+        let missingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("jpeg")
+
+        // when / then: 없는 파일을 삭제해도 에러를 던지지 않는다
+        XCTAssertNoThrow(try ImageFileHandler.delete(at: missingURL))
+    }
+
+    // MARK: - 헬퍼
+
+    private func makeImage(size: CGSize) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { rendererContext in
+            UIColor.systemBlue.setFill()
+            rendererContext.fill(CGRect(origin: .zero, size: size))
+        }
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url)
+        }
+        return url
+    }
+}

--- a/Projects/Data/Tests/ImageRepositoryTests.swift
+++ b/Projects/Data/Tests/ImageRepositoryTests.swift
@@ -1,0 +1,206 @@
+import XCTest
+import UIKit
+import Domain
+@testable import Data
+
+/// `ImageRepositoryImpl`의 동작을 검증하는 통합 테스트.
+///
+/// `createImage`는 `PHPickerResult`를 인자로 받는데 이 타입은 공개 이니셜라이저가
+/// 없어 단위 테스트에서 생성할 수 없으므로 제외한다. 나머지 메서드는 in-memory
+/// CoreDataStack과(파일이 필요한 경우) 임시 파일로 검증한다.
+final class ImageRepositoryTests: XCTestCase {
+
+    private var stack: CoreDataStack!
+    private var memoRepository: MemoRepositoryImpl!
+    private var sut: ImageRepositoryImpl!
+
+    override func setUp() {
+        super.setUp()
+        stack = CoreDataStack(inMemory: true)
+        memoRepository = MemoRepositoryImpl(stack: stack)
+        sut = ImageRepositoryImpl(stack: stack, memoRepository: memoRepository)
+    }
+
+    override func tearDown() {
+        sut = nil
+        memoRepository = nil
+        stack = nil
+        super.tearDown()
+    }
+
+    // MARK: - 이미지 목록 조회
+
+    func test_메모에_속한_모든_이미지가_조회된다() async throws {
+        // given: 이미지 3개를 가진 메모
+        let (memoID, imageIDs) = insertMemo(imageCount: 3)
+
+        // when
+        let infos = try await sut.getAllImageInfo(for: memoStub(id: memoID))
+
+        // then
+        XCTAssertEqual(Set(infos.map(\.id)), Set(imageIDs))
+    }
+
+    func test_이미지는_orderIndex_오름차순으로_반환된다() async throws {
+        // given: orderIndex 0, 1, 2 순으로 삽입된 이미지들
+        let (memoID, imageIDs) = insertMemo(imageCount: 3)
+
+        // when
+        let infos = try await sut.getAllImageInfo(for: memoStub(id: memoID))
+
+        // then: orderIndex 오름차순으로 반환된다
+        XCTAssertEqual(infos.map(\.id), imageIDs)
+    }
+
+    func test_다른_메모의_이미지는_조회되지_않는다() async throws {
+        // given: 서로 다른 두 메모
+        let (_, _) = insertMemo(imageCount: 2)
+        let (memoB, imagesB) = insertMemo(imageCount: 1)
+
+        // when
+        let infos = try await sut.getAllImageInfo(for: memoStub(id: memoB))
+
+        // then: 조회한 메모의 이미지만 반환
+        XCTAssertEqual(infos.map(\.id), imagesB)
+    }
+
+    func test_이미지가_없는_메모는_빈_목록을_반환한다() async throws {
+        // given
+        let (memoID, _) = insertMemo(imageCount: 0)
+
+        // when
+        let infos = try await sut.getAllImageInfo(for: memoStub(id: memoID))
+
+        // then
+        XCTAssertTrue(infos.isEmpty)
+    }
+
+    // MARK: - 이미지 순서 변경
+
+    func test_이미지의_orderIndex를_변경할_수_있다() async throws {
+        // given: orderIndex 0인 이미지
+        let (memoID, imageIDs) = insertMemo(imageCount: 2)
+        let target = imageInfoStub(id: imageIDs[0], memoID: memoID, orderIndex: 0)
+
+        // when: 인덱스를 5로 변경
+        try await sut.updateImageIndex(target, newIndex: 5)
+
+        // then
+        let infos = try await sut.getAllImageInfo(for: memoStub(id: memoID))
+        let updated = infos.first { $0.id == imageIDs[0] }
+        XCTAssertEqual(updated?.orderIndex, 5)
+    }
+
+    func test_존재하지_않는_이미지의_인덱스_변경시_에러를_던진다() async throws {
+        // given: 저장소에 없는 이미지
+        let ghost = imageInfoStub(id: UUID(), memoID: UUID(), orderIndex: 0)
+
+        // when / then
+        do {
+            try await sut.updateImageIndex(ghost, newIndex: 1)
+            XCTFail("존재하지 않는 이미지에 대해 에러를 던져야 한다")
+        } catch {
+            // 에러 발생 — 통과
+        }
+    }
+
+    // MARK: - 이미지 삭제
+
+    func test_이미지_삭제시_레코드와_파일이_모두_제거된다() async throws {
+        // given: 이미지 1개 + 원본/썸네일 파일을 실제로 디스크에 생성
+        let memoID = UUID()
+        let imageID = UUID()
+        let thumbnailID = UUID()
+        insertMemo(memoID: memoID, imageSpecs: [(orderIndex: 0, id: imageID, thumbID: thumbnailID)])
+
+        let directory = try ImageFileHandler.getDirectory(for: memoID)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        let originalURL = fileURL(in: directory, id: imageID)
+        let thumbnailURL = fileURL(in: directory, id: thumbnailID)
+        let imageData = try ImageFileHandler.createThumbnailData(from: makeImage())
+        try imageData.write(to: originalURL)
+        try imageData.write(to: thumbnailURL)
+
+        let info = imageInfoStub(id: imageID, thumbnailID: thumbnailID, memoID: memoID, orderIndex: 0)
+
+        // when
+        try await sut.deleteImage(info)
+
+        // then: 파일과 Core Data 레코드가 모두 사라진다
+        XCTAssertFalse(FileManager.default.fileExists(atPath: originalURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: thumbnailURL.path))
+        let remaining = try await sut.getAllImageInfo(for: memoStub(id: memoID))
+        XCTAssertTrue(remaining.isEmpty)
+    }
+
+    // MARK: - 헬퍼
+
+    private func insertMemo(imageCount: Int) -> (memoID: UUID, imageIDs: [UUID]) {
+        let imageIDs = (0..<imageCount).map { _ in UUID() }
+        let specs = imageIDs.enumerated().map {
+            (orderIndex: $0.offset, id: $0.element, thumbID: UUID())
+        }
+        let memoID = UUID()
+        insertMemo(memoID: memoID, imageSpecs: specs)
+        return (memoID, imageIDs)
+    }
+
+    private func insertMemo(
+        memoID: UUID,
+        imageSpecs: [(orderIndex: Int, id: UUID, thumbID: UUID)]
+    ) {
+        let context = stack.backgroundContext
+        context.performAndWait {
+            let memoEntity = MemoEntity(context: context)
+            memoEntity.memoID = memoID
+            for spec in imageSpecs {
+                _ = ImageEntity(
+                    uuid: spec.id,
+                    thumbnailUUID: spec.thumbID,
+                    temporaryOrderIndex: Int64(spec.orderIndex),
+                    orderIndex: Int64(spec.orderIndex),
+                    isTemporaryAppended: false,
+                    fileExtension: "jpeg",
+                    memo: memoEntity,
+                    context: context
+                )
+            }
+            try? context.save()
+        }
+    }
+
+    /// Repository는 `Memo`에서 `memoID`만 사용하므로 나머지 필드는 더미로 채운다.
+    private func memoStub(id: UUID) -> Memo {
+        Memo(
+            memoID: id, creationDate: .now, modificationDate: .now, deletedDate: nil,
+            isFavorite: false, isInTrash: false, memoText: "", memoTitle: "",
+            categories: [], images: []
+        )
+    }
+
+    private func imageInfoStub(
+        id: UUID,
+        thumbnailID: UUID = UUID(),
+        memoID: UUID,
+        orderIndex: Int
+    ) -> MemoImageInfo {
+        MemoImageInfo(
+            id: id, thumbnailID: thumbnailID,
+            temporaryOrderIndex: orderIndex, orderIndex: orderIndex,
+            memoID: memoID, isTemporaryDeleted: false, isTemporaryAppended: false,
+            fileExtension: "jpeg"
+        )
+    }
+
+    private func fileURL(in directory: URL, id: UUID) -> URL {
+        directory.appendingPathComponent(id.uuidString).appendingPathExtension("jpeg")
+    }
+
+    private func makeImage() -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 30, height: 30))
+        return renderer.image { rendererContext in
+            UIColor.systemBlue.setFill()
+            rendererContext.fill(CGRect(x: 0, y: 0, width: 30, height: 30))
+        }
+    }
+}

--- a/Projects/Data/Tests/MappingTests.swift
+++ b/Projects/Data/Tests/MappingTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+import CoreData
+import Domain
+@testable import Data
+
+/// Entity ↔ Domain 변환(`toDomain` / `toEntity`)의 동작을 검증한다.
+///
+/// 매핑 누락은 사용자 데이터 손실로 이어지므로, 모든 필드와 관계가
+/// 빠짐없이 옮겨지는지 직접 확인한다. 엔티티 생성·접근은 모두
+/// background context 큐 위에서 수행한다.
+final class MappingTests: XCTestCase {
+
+    private var stack: CoreDataStack!
+    private var context: NSManagedObjectContext!
+
+    override func setUp() {
+        super.setUp()
+        stack = CoreDataStack(inMemory: true)
+        context = stack.backgroundContext
+    }
+
+    override func tearDown() {
+        context = nil
+        stack = nil
+        super.tearDown()
+    }
+
+    // MARK: - MemoEntity → Memo
+
+    func test_MemoEntity_변환시_모든_단일값_필드가_복사된다() {
+        context.performAndWait {
+            // given
+            let entity = MemoEntity(context: context)
+            entity.memoTitle = "제목"
+            entity.memoText = "본문"
+            entity.isFavorite = true
+            entity.isInTrash = true
+
+            // when
+            let memo = entity.toDomain()
+
+            // then
+            XCTAssertEqual(memo.memoID, entity.memoID)
+            XCTAssertEqual(memo.memoTitle, "제목")
+            XCTAssertEqual(memo.memoText, "본문")
+            XCTAssertTrue(memo.isFavorite)
+            XCTAssertTrue(memo.isInTrash)
+            XCTAssertEqual(memo.creationDate, entity.creationDate)
+            XCTAssertEqual(memo.modificationDate, entity.modificationDate)
+        }
+    }
+
+    func test_MemoEntity_변환시_카테고리_관계가_매핑된다() {
+        context.performAndWait {
+            // given
+            let memoEntity = MemoEntity(context: context)
+            let categoryEntity = CategoryEntity(context: context)
+            categoryEntity.name = "업무"
+            memoEntity.addToCategories(categoryEntity)
+
+            // when
+            let memo = memoEntity.toDomain()
+
+            // then
+            XCTAssertEqual(memo.categories.map(\.name), ["업무"])
+        }
+    }
+
+    func test_MemoEntity_변환시_이미지_관계가_매핑된다() {
+        context.performAndWait {
+            // given
+            let memoEntity = MemoEntity(context: context)
+            let imageID = UUID()
+            let imageEntity = ImageEntity(
+                uuid: imageID,
+                thumbnailUUID: UUID(),
+                temporaryOrderIndex: 0,
+                orderIndex: 0,
+                isTemporaryAppended: false,
+                fileExtension: "heic",
+                memo: memoEntity,
+                context: context
+            )
+            memoEntity.addToImages(imageEntity)
+
+            // when
+            let memo = memoEntity.toDomain()
+
+            // then
+            XCTAssertEqual(memo.images.map(\.id), [imageID])
+        }
+    }
+
+    func test_관계가_없는_MemoEntity는_빈_집합으로_변환된다() {
+        context.performAndWait {
+            // given
+            let entity = MemoEntity(context: context)
+
+            // when
+            let memo = entity.toDomain()
+
+            // then
+            XCTAssertTrue(memo.categories.isEmpty)
+            XCTAssertTrue(memo.images.isEmpty)
+        }
+    }
+
+    // MARK: - CategoryEntity → Category
+
+    func test_CategoryEntity_변환시_이름과_날짜가_복사된다() {
+        context.performAndWait {
+            // given
+            let entity = CategoryEntity(context: context)
+            entity.name = "개인"
+
+            // when
+            let category = entity.toDomain()
+
+            // then
+            XCTAssertEqual(category.name, "개인")
+            XCTAssertEqual(category.creationDate, entity.creationDate)
+            XCTAssertEqual(category.modificationDate, entity.modificationDate)
+        }
+    }
+
+    // MARK: - ImageEntity → MemoImageInfo
+
+    func test_ImageEntity_변환시_소속_메모ID를_포함한_모든_필드가_복사된다() {
+        context.performAndWait {
+            // given
+            let memoEntity = MemoEntity(context: context)
+            let imageID = UUID()
+            let thumbnailID = UUID()
+            let entity = ImageEntity(
+                uuid: imageID,
+                thumbnailUUID: thumbnailID,
+                temporaryOrderIndex: 3,
+                orderIndex: 5,
+                isTemporaryAppended: true,
+                fileExtension: "jpeg",
+                memo: memoEntity,
+                context: context
+            )
+
+            // when
+            let info = entity.toDomain()
+
+            // then
+            XCTAssertEqual(info.id, imageID)
+            XCTAssertEqual(info.thumbnailID, thumbnailID)
+            XCTAssertEqual(info.temporaryOrderIndex, 3)
+            XCTAssertEqual(info.orderIndex, 5)
+            XCTAssertTrue(info.isTemporaryAppended)
+            XCTAssertEqual(info.fileExtension, "jpeg")
+            XCTAssertEqual(info.memoID, memoEntity.memoID)
+        }
+    }
+
+    // MARK: - Category → CategoryEntity
+
+    func test_같은_이름의_엔티티가_없으면_새_CategoryEntity를_만든다() {
+        context.performAndWait {
+            // given: 컨텍스트에 같은 이름의 엔티티가 없음
+            let category = Domain.Category(name: "신규", creationDate: .now, modificationDate: .now)
+
+            // when
+            let entity = category.toEntity(in: context)
+
+            // then
+            XCTAssertEqual(entity.name, "신규")
+        }
+    }
+
+    func test_같은_이름의_엔티티가_있으면_기존_것을_재사용한다() {
+        context.performAndWait {
+            // given: 이미 "업무" CategoryEntity가 컨텍스트에 존재
+            let existing = CategoryEntity(context: context)
+            existing.name = "업무"
+            try? context.save()
+
+            // when: 같은 이름의 Domain 모델을 엔티티로 변환하면
+            let category = Domain.Category(name: "업무", creationDate: .now, modificationDate: .now)
+            let entity = category.toEntity(in: context)
+
+            // then: 새로 만들지 않고 기존 엔티티를 그대로 돌려준다
+            XCTAssertTrue(entity === existing)
+        }
+    }
+}

--- a/Projects/Data/Tests/MemoRepositoryOrderingTests.swift
+++ b/Projects/Data/Tests/MemoRepositoryOrderingTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+import Domain
+@testable import Data
+
+/// `MemoRepositoryImpl`의 정렬 동작을 검증하는 통합 테스트.
+///
+/// 정렬 기준(`orderCriterion`)과 방향(`isOrderAscending`)은 `UserDefaults.standard`에서
+/// 읽어오므로, 각 테스트는 원하는 값을 직접 설정한다. 전역 상태를 건드리는 만큼
+/// setUp에서 기존 값을 저장하고 tearDown에서 복원해 테스트 간 격리를 보장한다.
+final class MemoRepositoryOrderingTests: XCTestCase {
+
+    private var stack: CoreDataStack!
+    private var sut: MemoRepositoryImpl!
+
+    // MemoRepositoryImpl이 정렬 설정을 읽는 UserDefaults 키
+    // (Shared의 UserDefaultsKey.orderCriterion / .isOrderAscending rawValue와 동일)
+    private let criterionKey = "orderCriterion"
+    private let ascendingKey = "isOrderAscending"
+    private var savedCriterion: Any?
+    private var savedAscending: Any?
+
+    override func setUp() {
+        super.setUp()
+        savedCriterion = UserDefaults.standard.object(forKey: criterionKey)
+        savedAscending = UserDefaults.standard.object(forKey: ascendingKey)
+        stack = CoreDataStack(inMemory: true)
+        sut = MemoRepositoryImpl(stack: stack)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.set(savedCriterion, forKey: criterionKey)
+        UserDefaults.standard.set(savedAscending, forKey: ascendingKey)
+        sut = nil
+        stack = nil
+        super.tearDown()
+    }
+
+    /// 정렬 기준은 `NSSortDescriptor`에 그대로 쓰이므로 MemoEntity 속성명("creationDate"
+    /// 또는 "modificationDate")이어야 한다.
+    private func configureOrdering(criterion: String, ascending: Bool) {
+        UserDefaults.standard.set(criterion, forKey: criterionKey)
+        UserDefaults.standard.set(ascending, forKey: ascendingKey)
+    }
+
+    func test_생성일_오름차순으로_정렬할_수_있다() async throws {
+        // given: 생성 순서대로 메모 3개 (creationDate 오름차순)
+        let first = try await sut.createNewMemo()
+        let second = try await sut.createNewMemo()
+        let third = try await sut.createNewMemo()
+        configureOrdering(criterion: "creationDate", ascending: true)
+
+        // when
+        let all = try await sut.getAllMemos()
+
+        // then
+        XCTAssertEqual(all.map(\.memoID), [first.memoID, second.memoID, third.memoID])
+    }
+
+    func test_생성일_내림차순으로_정렬할_수_있다() async throws {
+        // given
+        let first = try await sut.createNewMemo()
+        let second = try await sut.createNewMemo()
+        let third = try await sut.createNewMemo()
+        configureOrdering(criterion: "creationDate", ascending: false)
+
+        // when
+        let all = try await sut.getAllMemos()
+
+        // then: 최신 생성 메모가 맨 앞
+        XCTAssertEqual(all.map(\.memoID), [third.memoID, second.memoID, first.memoID])
+    }
+
+    func test_수정일_기준_정렬은_생성일_정렬과_독립적으로_동작한다() async throws {
+        // given: 생성 순서는 first < second < third
+        let first = try await sut.createNewMemo()
+        let second = try await sut.createNewMemo()
+        let third = try await sut.createNewMemo()
+        // first를 가장 마지막에 수정 → modificationDate는 first가 가장 최신이 된다
+        try await sut.updateMemoContent(first, newTitle: "수정됨", newMemoText: nil)
+        configureOrdering(criterion: "modificationDate", ascending: false)
+
+        // when
+        let all = try await sut.getAllMemos()
+
+        // then: modificationDate 내림차순 → first가 맨 앞 (creationDate 정렬이라면 맨 뒤였을 것)
+        XCTAssertEqual(all.map(\.memoID), [first.memoID, third.memoID, second.memoID])
+    }
+
+    func test_즐겨찾기_목록도_설정된_정렬_순서를_따른다() async throws {
+        // given
+        let first = try await sut.createNewMemo()
+        let second = try await sut.createNewMemo()
+        try await sut.setFavorite(first, to: true)
+        try await sut.setFavorite(second, to: true)
+        configureOrdering(criterion: "creationDate", ascending: true)
+
+        // when
+        let favorites = try await sut.getFavoriteMemos()
+
+        // then
+        XCTAssertEqual(favorites.map(\.memoID), [first.memoID, second.memoID])
+    }
+}

--- a/Projects/Data/Tests/MemoRepositoryTests.swift
+++ b/Projects/Data/Tests/MemoRepositoryTests.swift
@@ -1,0 +1,520 @@
+import XCTest
+import Combine
+import Domain
+@testable import Data
+
+/// `MemoRepositoryImpl`의 동작(behavior)을 검증하는 통합 테스트.
+///
+/// 구현 세부사항(predicate, context 상태)이 아니라 Repository의 공개 API를 통해
+/// 관찰 가능한 결과만 검증한다. 저장소는 매 테스트마다 `/dev/null` SQLite로 새로
+/// 만들어 완전히 격리된 빈 상태에서 시작한다.
+final class MemoRepositoryTests: XCTestCase {
+
+    private var stack: CoreDataStack!
+    private var sut: MemoRepositoryImpl!
+    private var categoryRepository: CategoryRepositoryImpl!
+
+    override func setUp() {
+        super.setUp()
+        stack = CoreDataStack(inMemory: true)
+        sut = MemoRepositoryImpl(stack: stack)
+        categoryRepository = CategoryRepositoryImpl(stack: stack)
+    }
+
+    override func tearDown() {
+        sut = nil
+        categoryRepository = nil
+        stack = nil
+        super.tearDown()
+    }
+
+    // MARK: - 생성
+
+    func test_메모를_생성하면_전체_목록에서_조회된다() async throws {
+        // when: 메모를 새로 만들면
+        let created = try await sut.createNewMemo()
+
+        // then: 전체 메모 목록에서 그 메모가 조회된다
+        let all = try await sut.getAllMemos()
+        XCTAssertEqual(all.map(\.memoID), [created.memoID])
+    }
+
+    func test_새로_생성된_메모는_즐겨찾기도_휴지통도_아니다() async throws {
+        // when
+        let created = try await sut.createNewMemo()
+
+        // then: 새 메모는 즐겨찾기/휴지통 상태가 아니며 제목·본문이 비어 있다
+        XCTAssertFalse(created.isFavorite)
+        XCTAssertFalse(created.isInTrash)
+        XCTAssertTrue(created.memoTitle.isEmpty)
+        XCTAssertTrue(created.memoText.isEmpty)
+    }
+
+    // MARK: - 조회
+
+    func test_ID로_조회하면_해당_메모를_반환한다() async throws {
+        // given
+        let created = try await sut.createNewMemo()
+
+        // when
+        let fetched = try await sut.getMemo(id: created.memoID)
+
+        // then
+        XCTAssertEqual(fetched.memoID, created.memoID)
+    }
+
+    func test_존재하지_않는_ID로_조회하면_에러를_던진다() async throws {
+        // when / then: 존재하지 않는 ID로 조회하면 에러를 던진다
+        do {
+            _ = try await sut.getMemo(id: UUID())
+            XCTFail("존재하지 않는 ID로 조회 시 에러를 던져야 한다")
+        } catch {
+            // 에러 발생 — 통과
+        }
+    }
+
+    func test_전체_조회시_휴지통_메모는_제외된다() async throws {
+        // given: 일반 메모 1개와 휴지통으로 보낸 메모 1개
+        let kept = try await sut.createNewMemo()
+        let trashed = try await sut.createNewMemo()
+        try await sut.moveToTrash(trashed)
+
+        // when
+        let all = try await sut.getAllMemos()
+
+        // then: 휴지통 메모는 제외된다
+        XCTAssertEqual(all.map(\.memoID), [kept.memoID])
+    }
+
+    func test_휴지통_조회시_휴지통에_있는_메모만_반환된다() async throws {
+        // given
+        _ = try await sut.createNewMemo()
+        let trashed = try await sut.createNewMemo()
+        try await sut.moveToTrash(trashed)
+
+        // when
+        let trash = try await sut.getAllMemosInTrash()
+
+        // then
+        XCTAssertEqual(trash.map(\.memoID), [trashed.memoID])
+    }
+
+    func test_카테고리_nil로_조회하면_카테고리_없는_메모만_반환된다() async throws {
+        // given: 카테고리 없는 메모 1개, 카테고리에 속한 메모 1개
+        let uncategorized = try await sut.createNewMemo()
+        let categorized = try await sut.createNewMemo()
+        let work = try await makeCategory(named: "업무")
+        try await sut.addCategories(to: categorized, newCategories: [work])
+
+        // when: category 인자에 nil을 주면
+        let results = try await sut.getAllMemos(inCategory: nil)
+
+        // then: 아무 카테고리에도 속하지 않은 메모만 반환된다
+        XCTAssertEqual(results.map(\.memoID), [uncategorized.memoID])
+    }
+
+    func test_특정_카테고리로_조회하면_그_카테고리의_메모만_반환된다() async throws {
+        // given
+        let categorized = try await sut.createNewMemo()
+        _ = try await sut.createNewMemo()
+        let work = try await makeCategory(named: "업무")
+        try await sut.addCategories(to: categorized, newCategories: [work])
+
+        // when
+        let results = try await sut.getAllMemos(inCategory: work)
+
+        // then
+        XCTAssertEqual(results.map(\.memoID), [categorized.memoID])
+    }
+
+    // MARK: - 검색
+
+    func test_빈_검색어로_검색하면_결과가_없다() async throws {
+        // given
+        let memo = try await sut.createNewMemo()
+        try await sut.updateMemoContent(memo, newTitle: "제목", newMemoText: "본문")
+
+        // when: 빈 검색어로 검색하면
+        let results = try await sut.searchMemo(searchText: "", inCategory: nil)
+
+        // then: 결과가 없다
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func test_제목으로_메모를_검색할_수_있다() async throws {
+        // given
+        let memo = try await sut.createNewMemo()
+        try await sut.updateMemoContent(memo, newTitle: "장보기 목록", newMemoText: nil)
+
+        // when
+        let results = try await sut.searchMemo(searchText: "장보기", inCategory: nil)
+
+        // then
+        XCTAssertEqual(results.map(\.memoID), [memo.memoID])
+    }
+
+    func test_본문으로_메모를_검색할_수_있다() async throws {
+        // given
+        let memo = try await sut.createNewMemo()
+        try await sut.updateMemoContent(memo, newTitle: nil, newMemoText: "우유와 계란을 사야 한다")
+
+        // when
+        let results = try await sut.searchMemo(searchText: "계란", inCategory: nil)
+
+        // then
+        XCTAssertEqual(results.map(\.memoID), [memo.memoID])
+    }
+
+    func test_검색은_대소문자를_구분하지_않는다() async throws {
+        // given
+        let memo = try await sut.createNewMemo()
+        try await sut.updateMemoContent(memo, newTitle: "Hello World", newMemoText: nil)
+
+        // when: 소문자로 검색해도
+        let results = try await sut.searchMemo(searchText: "hello", inCategory: nil)
+
+        // then: 대소문자 구분 없이 매칭된다
+        XCTAssertEqual(results.map(\.memoID), [memo.memoID])
+    }
+
+    func test_검색_결과에서_휴지통_메모는_제외된다() async throws {
+        // given: 검색어를 포함하지만 휴지통에 있는 메모
+        let memo = try await sut.createNewMemo()
+        try await sut.updateMemoContent(memo, newTitle: "검색대상", newMemoText: nil)
+        try await sut.moveToTrash(memo)
+
+        // when
+        let results = try await sut.searchMemo(searchText: "검색대상", inCategory: nil)
+
+        // then: 휴지통 메모는 검색되지 않는다
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    // MARK: - 즐겨찾기
+
+    func test_즐겨찾기로_지정하면_즐겨찾기_목록에_나타난다() async throws {
+        // given
+        let memo = try await sut.createNewMemo()
+
+        // when
+        try await sut.setFavorite(memo, to: true)
+
+        // then
+        let favorites = try await sut.getFavoriteMemos()
+        XCTAssertEqual(favorites.map(\.memoID), [memo.memoID])
+    }
+
+    func test_즐겨찾기를_해제하면_즐겨찾기_목록에서_사라진다() async throws {
+        // given: 즐겨찾기로 지정된 메모
+        let memo = try await sut.createNewMemo()
+        try await sut.setFavorite(memo, to: true)
+
+        // when: 즐겨찾기를 해제하면
+        try await sut.setFavorite(memo, to: false)
+
+        // then
+        let favorites = try await sut.getFavoriteMemos()
+        XCTAssertTrue(favorites.isEmpty)
+    }
+
+    func test_즐겨찾기_목록에서_휴지통_메모는_제외된다() async throws {
+        // given: 즐겨찾기였다가 휴지통으로 보낸 메모
+        let memo = try await sut.createNewMemo()
+        try await sut.setFavorite(memo, to: true)
+        try await sut.moveToTrash(memo)
+
+        // when
+        let favorites = try await sut.getFavoriteMemos()
+
+        // then
+        XCTAssertTrue(favorites.isEmpty)
+    }
+
+    // MARK: - 삭제 (휴지통)
+
+    func test_휴지통으로_보내면_전체_목록에서_사라진다() async throws {
+        // given
+        let memo = try await sut.createNewMemo()
+
+        // when
+        try await sut.moveToTrash(memo)
+
+        // then
+        let all = try await sut.getAllMemos()
+        XCTAssertTrue(all.isEmpty)
+    }
+
+    func test_휴지통으로_보내면_휴지통_목록에_나타난다() async throws {
+        // given
+        let memo = try await sut.createNewMemo()
+
+        // when
+        try await sut.moveToTrash(memo)
+
+        // then
+        let trash = try await sut.getAllMemosInTrash()
+        XCTAssertEqual(trash.map(\.memoID), [memo.memoID])
+    }
+
+    func test_휴지통으로_보내면_즐겨찾기가_해제된다() async throws {
+        // given: 즐겨찾기로 지정된 메모
+        let memo = try await sut.createNewMemo()
+        try await sut.setFavorite(memo, to: true)
+
+        // when
+        try await sut.moveToTrash(memo)
+
+        // then: 휴지통으로 가면 즐겨찾기 상태가 해제된다
+        let trashed = try await sut.getAllMemosInTrash().first
+        XCTAssertEqual(trashed?.isFavorite, false)
+    }
+
+    func test_휴지통으로_보내면_카테고리_연결이_끊긴다() async throws {
+        // given: 카테고리에 속한 메모
+        let memo = try await sut.createNewMemo()
+        let work = try await makeCategory(named: "업무")
+        try await sut.addCategories(to: memo, newCategories: [work])
+
+        // when
+        try await sut.moveToTrash(memo)
+
+        // then: 휴지통 메모는 더 이상 카테고리에 속하지 않는다
+        let trashed = try await sut.getAllMemosInTrash().first
+        XCTAssertEqual(trashed?.categories.isEmpty, true)
+    }
+
+    // MARK: - 삭제 (영구)
+
+    func test_휴지통의_메모를_영구_삭제하면_완전히_사라진다() async throws {
+        // given: 휴지통에 있는 메모
+        let memo = try await sut.createNewMemo()
+        try await sut.moveToTrash(memo)
+
+        // when
+        try await sut.deleteMemo(memo)
+
+        // then: 휴지통에서도 사라진다
+        let trash = try await sut.getAllMemosInTrash()
+        XCTAssertTrue(trash.isEmpty)
+    }
+
+    func test_휴지통에_없는_메모는_영구_삭제해도_그대로_남는다() async throws {
+        // given: 휴지통에 없는 일반 메모
+        let memo = try await sut.createNewMemo()
+
+        // when: 휴지통에 없는 메모에 hard delete를 시도해도
+        try await sut.deleteMemo(memo)
+
+        // then: 메모는 그대로 남아 있다
+        let all = try await sut.getAllMemos()
+        XCTAssertEqual(all.map(\.memoID), [memo.memoID])
+    }
+
+    // MARK: - 복원
+
+    func test_복원하면_휴지통_메모가_전체_목록으로_돌아온다() async throws {
+        // given: 휴지통에 있는 메모
+        let memo = try await sut.createNewMemo()
+        try await sut.moveToTrash(memo)
+
+        // when
+        try await sut.restore(memo)
+
+        // then: 전체 목록으로 복원되고 휴지통에서는 사라진다
+        let all = try await sut.getAllMemos()
+        XCTAssertEqual(all.map(\.memoID), [memo.memoID])
+        let trash = try await sut.getAllMemosInTrash()
+        XCTAssertTrue(trash.isEmpty)
+    }
+
+    // MARK: - 수정
+
+    func test_메모_수정시_제목과_본문이_변경된다() async throws {
+        // given
+        let memo = try await sut.createNewMemo()
+
+        // when
+        try await sut.updateMemoContent(memo, newTitle: "새 제목", newMemoText: "새 본문")
+
+        // then
+        let updated = try await sut.getMemo(id: memo.memoID)
+        XCTAssertEqual(updated.memoTitle, "새 제목")
+        XCTAssertEqual(updated.memoText, "새 본문")
+    }
+
+    func test_메모_수정시_nil로_둔_필드는_기존_값이_유지된다() async throws {
+        // given: 제목과 본문이 채워진 메모
+        let memo = try await sut.createNewMemo()
+        try await sut.updateMemoContent(memo, newTitle: "원래 제목", newMemoText: "원래 본문")
+
+        // when: 본문만 갱신하고 제목은 nil로 두면
+        try await sut.updateMemoContent(memo, newTitle: nil, newMemoText: "수정된 본문")
+
+        // then: 제목은 유지되고 본문만 바뀐다
+        let updated = try await sut.getMemo(id: memo.memoID)
+        XCTAssertEqual(updated.memoTitle, "원래 제목")
+        XCTAssertEqual(updated.memoText, "수정된 본문")
+    }
+
+    func test_카테고리_교체시_기존_것은_사라지고_새것만_남는다() async throws {
+        // given: 업무 카테고리에 속한 메모
+        let memo = try await sut.createNewMemo()
+        let work = try await makeCategory(named: "업무")
+        try await sut.addCategories(to: memo, newCategories: [work])
+
+        // when: 카테고리를 개인으로 교체하면
+        let personal = try await makeCategory(named: "개인")
+        try await sut.replaceCategories(to: memo, newCategories: [personal])
+
+        // then: 기존 카테고리는 사라지고 새 카테고리만 남는다
+        let updated = try await sut.getMemo(id: memo.memoID)
+        XCTAssertEqual(updated.categories.map(\.name), ["개인"])
+    }
+
+    func test_카테고리_제거시_해당_카테고리만_연결_해제된다() async throws {
+        // given: 두 카테고리에 속한 메모
+        let memo = try await sut.createNewMemo()
+        let work = try await makeCategory(named: "업무")
+        let personal = try await makeCategory(named: "개인")
+        try await sut.addCategories(to: memo, newCategories: [work, personal])
+
+        // when: 한 카테고리를 제거하면
+        try await sut.removeCategories(to: memo, newCategories: [work])
+
+        // then: 나머지 카테고리만 남는다
+        let updated = try await sut.getMemo(id: memo.memoID)
+        XCTAssertEqual(updated.categories.map(\.name), ["개인"])
+    }
+
+    // MARK: - 이벤트 퍼블리셔
+
+    func test_메모를_생성하면_퍼블리셔로_생성_이벤트가_방출된다() async throws {
+        // given: 업데이트 이벤트 구독
+        var received: [MemoRepositoryImpl.MemoUpdateType] = []
+        let cancellable = sut.memoUpdatedPublisher.sink { received.append($0) }
+        defer { cancellable.cancel() }
+
+        // when
+        _ = try await sut.createNewMemo()
+
+        // then
+        XCTAssertEqual(received, [.create])
+    }
+
+    // MARK: - 배열 일괄 처리
+
+    func test_여러_메모를_한번에_휴지통으로_보낸다() async throws {
+        // given
+        let memo1 = try await sut.createNewMemo()
+        let memo2 = try await sut.createNewMemo()
+
+        // when
+        try await sut.moveToTrash([memo1, memo2])
+
+        // then
+        let all = try await sut.getAllMemos()
+        XCTAssertTrue(all.isEmpty)
+        let trash = try await sut.getAllMemosInTrash()
+        XCTAssertEqual(Set(trash.map(\.memoID)), [memo1.memoID, memo2.memoID])
+    }
+
+    func test_여러_메모를_한번에_복원한다() async throws {
+        // given: 휴지통에 있는 메모 2개
+        let memo1 = try await sut.createNewMemo()
+        let memo2 = try await sut.createNewMemo()
+        try await sut.moveToTrash([memo1, memo2])
+
+        // when
+        try await sut.restore([memo1, memo2])
+
+        // then
+        let all = try await sut.getAllMemos()
+        XCTAssertEqual(Set(all.map(\.memoID)), [memo1.memoID, memo2.memoID])
+    }
+
+    func test_여러_휴지통_메모를_한번에_영구_삭제한다() async throws {
+        // given: 휴지통에 있는 메모 2개
+        let memo1 = try await sut.createNewMemo()
+        let memo2 = try await sut.createNewMemo()
+        try await sut.moveToTrash([memo1, memo2])
+
+        // when
+        try await sut.deleteMemos([memo1, memo2])
+
+        // then
+        let trash = try await sut.getAllMemosInTrash()
+        XCTAssertTrue(trash.isEmpty)
+    }
+
+    func test_여러_메모를_한번에_즐겨찾기로_지정한다() async throws {
+        // given
+        let memo1 = try await sut.createNewMemo()
+        let memo2 = try await sut.createNewMemo()
+
+        // when
+        try await sut.setFavorite([memo1, memo2], to: true)
+
+        // then
+        let favorites = try await sut.getFavoriteMemos()
+        XCTAssertEqual(Set(favorites.map(\.memoID)), [memo1.memoID, memo2.memoID])
+    }
+
+    func test_여러_메모에_카테고리를_한번에_추가한다() async throws {
+        // given
+        let memo1 = try await sut.createNewMemo()
+        let memo2 = try await sut.createNewMemo()
+        let work = try await makeCategory(named: "업무")
+
+        // when
+        try await sut.addCategories(to: [memo1, memo2], newCategories: [work])
+
+        // then
+        let inWork = try await sut.getAllMemos(inCategory: work)
+        XCTAssertEqual(Set(inWork.map(\.memoID)), [memo1.memoID, memo2.memoID])
+    }
+
+    func test_여러_메모의_카테고리를_한번에_교체한다() async throws {
+        // given: 두 메모가 업무 카테고리에 속함
+        let memo1 = try await sut.createNewMemo()
+        let memo2 = try await sut.createNewMemo()
+        let work = try await makeCategory(named: "업무")
+        try await sut.addCategories(to: [memo1, memo2], newCategories: [work])
+
+        // when: 카테고리를 개인으로 교체하면
+        let personal = try await makeCategory(named: "개인")
+        try await sut.replaceCategories(to: [memo1, memo2], newCategories: [personal])
+
+        // then: 모든 메모가 개인 카테고리로 이동하고 업무에는 남지 않는다
+        let inPersonal = try await sut.getAllMemos(inCategory: personal)
+        XCTAssertEqual(Set(inPersonal.map(\.memoID)), [memo1.memoID, memo2.memoID])
+        let inWork = try await sut.getAllMemos(inCategory: work)
+        XCTAssertTrue(inWork.isEmpty)
+    }
+
+    func test_여러_메모에서_카테고리를_한번에_제거한다() async throws {
+        // given
+        let memo1 = try await sut.createNewMemo()
+        let memo2 = try await sut.createNewMemo()
+        let work = try await makeCategory(named: "업무")
+        try await sut.addCategories(to: [memo1, memo2], newCategories: [work])
+
+        // when
+        try await sut.removeCategories(to: [memo1, memo2], newCategories: [work])
+
+        // then
+        let inWork = try await sut.getAllMemos(inCategory: work)
+        XCTAssertTrue(inWork.isEmpty)
+    }
+
+    // MARK: - 헬퍼
+
+    /// 카테고리를 생성하고 그에 대응하는 Domain 모델을 돌려준다.
+    private func makeCategory(named name: String) async throws -> Domain.Category {
+        try await categoryRepository.create(name: name)
+        let categories = try await categoryRepository.getAllCategories(
+            inOrderOf: .modificationDate,
+            isAscending: false
+        )
+        return try XCTUnwrap(categories.first { $0.name == name })
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/ProjectTemplates.swift
+++ b/Tuist/ProjectDescriptionHelpers/ProjectTemplates.swift
@@ -46,7 +46,11 @@ public extension Project {
                     deploymentTargets: .iOS("15.0"),
                     infoPlist: .default,
                     sources: ["Tests/**"],
-                    dependencies: [.target(name: module.rawValue)]
+                    dependencies: [.target(name: module.rawValue)],
+                    // static framework 안의 Obj-C 카테고리(NSManagedObject 서브클래스의
+                    // @NSManaged 프로퍼티 등)가 링커 dead-stripping으로 제거되지 않도록
+                    // 강제 로드. 누락 시 Core Data 동적 접근자 생성 실패로 크래시한다.
+                    settings: .settings(base: ["OTHER_LDFLAGS": ["$(inherited)", "-ObjC"]])
                 )
             )
         }


### PR DESCRIPTION
## 배경
- 프로젝트에 테스트 코드가 사실상 없던 상태에서, Data·Shared 레이어부터 단위/통합 테스트를 본격 도입한다.
- 테스트 작성 과정에서 발견한 빌드 결함(`ImageEntity` 크래시)도 함께 수정한다.

## 변경사항
- **`CoreDataStack(inMemory:)` 추가** — `/dev/null` SQLite store 옵션. 매 테스트마다 격리된 빈 저장소를 생성. 기본값 `false`라 프로덕션 동작은 불변.
- **`-ObjC` 링커 플래그 추가** — static framework 안의 Obj-C 카테고리(NSManagedObject 서브클래스의 `@NSManaged` 프로퍼티)가 링커 dead-stripping으로 제거되어, `ImageEntity` 직접 사용 시 Core Data 동적 접근자 생성 실패로 크래시하던 문제 해결. 앱/테스트 타겟에 적용.
- **Data 통합 테스트 74개** — Memo/Category Repository의 CRUD·검색·정렬·배열 일괄 처리, Entity↔Domain 매핑, `ImageFileHandler`·`ImageRepositoryImpl`. 모두 in-memory store 기반 BDD 스타일.
- **Shared 유틸리티 테스트 11개** — `@UserDefault` 래퍼, `OrderSettingManager`, `Date` 포맷팅.
- 테스트 함수명은 한국어 문장형으로 작성 (테스트 결과 화면 가독성).

## 테스트 방법
- `xcodebuild test -workspace NoteCard.xcworkspace -scheme Data -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` → 74개 통과 (Migration 1개 skip).
- `xcodebuild test ... -scheme Shared ...` → 11개 통과.
- `xcodebuild build ... -scheme NoteCard ...` → `-ObjC` 적용 후 앱 정상 빌드.

## 리뷰 노트
- `-ObjC`는 빌드 인프라 변경 — `ProjectTemplates.swift`의 `module()` 헬퍼(테스트 타겟)와 앱 `Project.swift`에 적용. **Core Data 모델·마이그레이션과 무관**한 순수 링커 플래그.
- 미커버 범위: `ImageRepositoryImpl.createImage`(`PHPickerResult` 생성 불가), Core Data 마이그레이션 회귀 테스트(v3 `.sqlite` fixture 미확보 — 모델 변경 시점에 활성화 예정).
- known-issue(이번 PR 범위 외): `CategoryRepositoryImpl.updateModificationDate`가 `context.save()`를 호출하지 않음.
- 후속 작업 예고: `UserDefaults` 의존성 주입 리팩터링 — 현재 일부 테스트는 `UserDefaults.standard`를 save/restore하는 차선책을 쓴다. 주입 가능하게 바꿔 전용 suite로 격리할 계획(별도 작업).

🤖 Generated with [Claude Code](https://claude.com/claude-code)