### PR TITLE
ci: 전체 모듈 테스트 자동 실행 (tuist test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    name: Compile check (simulator)
+    name: Build & test (all modules)
     runs-on: macos-15
     timeout-minutes: 30
 
@@ -52,22 +52,12 @@ jobs:
           tuist install
           tuist generate --no-open
 
-      - name: Build for iOS Simulator (Debug)
+      - name: Test — 전체 모듈 테스트 (자동 순회)
         run: |
           set -euo pipefail
-          xcodebuild build \
-            -workspace NoteCard.xcworkspace \
-            -scheme NoteCard \
-            -configuration Debug \
-            -destination 'generic/platform=iOS Simulator' \
-            CODE_SIGNING_ALLOWED=NO
-
-      - name: Test (Domain / Shared / NoteCard)
-        run: |
-          set -euo pipefail
-          xcodebuild test \
-            -workspace NoteCard.xcworkspace \
-            -scheme NoteCard \
-            -configuration Debug \
-            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
-            CODE_SIGNING_ALLOWED=NO
+          # 스킴을 지정하지 않은 `tuist test`는 Tuist가 생성한 워크스페이스 스킴
+          # (NoteCard-Workspace)의 모든 testable 타겟을 테스트한다. 각 모듈의
+          # 의존 그래프를 함께 빌드하므로 앱 컴파일 검증도 겸한다.
+          # module(hasTests: true)로 새 모듈이 추가되면 Tuist가 스킴을
+          # 재생성하므로 CI 수정 없이 자동으로 포함된다.
+          tuist test --device "iPhone 17 Pro" -- CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
## 배경
- 기존 CI의 테스트 스텝은 `xcodebuild test -scheme NoteCard`였는데, `NoteCard` 스킴의 TestAction에는 `NoteCardTests`만 들어 있어 `DataTests`(74) / `SharedTests`(11) / `DomainTests`(2)가 CI에서 실행되지 않았다.
- 모듈이 늘어날 때마다 CI를 수동으로 고치지 않도록, 모든 모듈의 테스트를 자동 순회하는 방식으로 전환한다.

## 변경사항
- 테스트 스텝을 `tuist test`(스킴 미지정)로 교체 — Tuist가 생성하는 `NoteCard-Workspace` 스킴의 모든 testable 타겟을 테스트.
- `module(hasTests: true)`로 새 모듈이 추가되면 Tuist가 스킴을 재생성하므로 **CI 수정 없이 자동 포함**된다.
- 별도 `xcodebuild build` 스텝 제거 — `tuist test`가 의존 그래프(앱 포함)를 함께 빌드해 컴파일 검증을 겸한다.
- 잡 이름을 `Compile check (simulator)` → `Build & test (all modules)`로 변경.

## 테스트 방법
- 로컬에서 `tuist test --device "iPhone 17 Pro"` 실행 → DataTests 74 / SharedTests 11 / DomainTests 2 / NoteCardTests 1, 합계 88개 통과 (Migration 1개 skip).
- 이 브랜치 push 시 CI가 실행되어 동일 결과를 검증.

## 리뷰 노트
- `tuist test`는 테스트 의존 그래프에 없는 `NoteCard-Eng` 타겟은 빌드하지 않는다. 기존 CI도 `-Eng`는 빌드하지 않았으므로 동작 차이는 없다.
- CI는 `branches-ignore: [main, release/**]`라 main에서는 돌지 않는다(기존과 동일) — feature/PR 브랜치에서만 실행된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)