### PR TITLE
test: Core Data 마이그레이션 회귀 테스트 도입

### DIFF
--- a/Projects/Data/Tests/MappingTests.swift
+++ b/Projects/Data/Tests/MappingTests.swift
@@ -186,4 +186,22 @@ final class MappingTests: XCTestCase {
             XCTAssertTrue(entity === existing)
         }
     }
+
+    // MARK: - 양방향 관계
+
+    func test_메모에_카테고리를_추가하면_카테고리도_그_메모를_가리킨다() {
+        context.performAndWait {
+            // given
+            let memoEntity = MemoEntity(context: context)
+            let categoryEntity = CategoryEntity(context: context)
+            categoryEntity.name = "업무"
+
+            // when: 메모 쪽에서만 카테고리를 연결해도
+            memoEntity.addToCategories(categoryEntity)
+
+            // then: 역방향(카테고리 → 메모)이 자동으로 함께 연결된다
+            XCTAssertTrue(categoryEntity.memoSet.contains(memoEntity))
+            XCTAssertEqual(categoryEntity.memoSet.count, 1)
+        }
+    }
 }

--- a/Projects/Data/Tests/MigrationTests.swift
+++ b/Projects/Data/Tests/MigrationTests.swift
@@ -2,51 +2,188 @@ import XCTest
 import CoreData
 @testable import Data
 
-/// Heavyweight Core Data 마이그레이션 회귀 테스트.
+/// Core Data 마이그레이션 회귀 테스트.
 ///
-/// 사용자 fixture(.sqlite) 의존성이 있어 현재는 XCTSkip된 상태로 둠.
-/// Tuist 마이그레이션 후 검증 절차:
-/// 1. v2.1.x 빌드로 시뮬레이터에서 데이터 생성 (메모 N개, 카테고리, 이미지 포함)
-/// 2. 시뮬레이터의 App 컨테이너에서 NoteCardCoreData.sqlite, -wal, -shm 3파일을
-///    `Projects/Data/Tests/Fixtures/v3/` 아래로 복사
-/// 3. 이 파일 상단의 `fixtureURL`을 활성화하고 `XCTSkip`을 제거한 뒤
-///    `xcodebuild test -scheme NoteCard -only-testing:DataTests/MigrationTests`
+/// 옛 모델(`NoteCardCoreData` v1)로 store를 만들어 합성 데이터를 채운 뒤,
+/// 현재 모델로 자동 마이그레이션하며 다시 열어 데이터가 보존되는지 검증한다.
 ///
-/// 검증 의도: Data 모듈로 옮긴 후에도 Heavyweight Migration이 자동으로 작동하여
-/// 기존 사용자 데이터가 손실 없이 새 모델로 변환되는지 확인.
+/// 별도 fixture 파일을 커밋하지 않고 v1 `.mom`을 코드로 로드해 store를
+/// 생성하므로, 실제 사용자 데이터가 저장소에 들어갈 일이 없고, 모델이
+/// 바뀌어 마이그레이션이 깨지면 CI가 자동으로 잡아낸다.
+///
+/// v1 → v2 변경 내역: `ImageEntity`에 `fileExtension`(String, 기본값 "jpeg")
+/// 속성 추가. 속성 추가 + 기본값이라 lightweight migration으로 자동 추론된다.
 final class MigrationTests: XCTestCase {
 
-    func test_v3_sqlite_migrates_to_latest_without_data_loss() throws {
-        throw XCTSkip("v3 fixture .sqlite 미확보 — 사용자가 시뮬레이터에서 추출 후 활성화.")
+    private var tempDirectory: URL!
 
-        // 활성화 예시 (fixture 확보 후):
-        // let bundle = Bundle(for: type(of: self))
-        // guard let fixtureURL = bundle.url(forResource: "v3_seed", withExtension: "sqlite") else {
-        //     XCTFail("v3_seed.sqlite missing in test bundle")
-        //     return
-        // }
-        // let tmpDir = FileManager.default.temporaryDirectory
-        //     .appending(path: UUID().uuidString)
-        // try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
-        // let dstURL = tmpDir.appending(path: "NoteCardCoreData.sqlite")
-        // try FileManager.default.copyItem(at: fixtureURL, to: dstURL)
-        //
-        // let modelURL = Bundle(for: CoreDataStack.self)
-        //     .url(forResource: "NoteCardCoreData", withExtension: "momd")!
-        // let model = NSManagedObjectModel(contentsOf: modelURL)!
-        // let container = NSPersistentContainer(name: "NoteCardCoreData", managedObjectModel: model)
-        // let desc = NSPersistentStoreDescription(url: dstURL)
-        // desc.shouldMigrateStoreAutomatically = true
-        // desc.shouldInferMappingModelAutomatically = true
-        // container.persistentStoreDescriptions = [desc]
-        // let exp = expectation(description: "load")
-        // container.loadPersistentStores { _, error in
-        //     XCTAssertNil(error)
-        //     exp.fulfill()
-        // }
-        // wait(for: [exp], timeout: 10)
-        // let request = MemoEntity.fetchRequest()
-        // let fetched = try container.viewContext.fetch(request)
-        // XCTAssertGreaterThan(fetched.count, 0, "Migration should preserve memo entities")
+    override func setUpWithError() throws {
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDirectory {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
+        tempDirectory = nil
+    }
+
+    // MARK: - Tests
+
+    func test_v1_store가_데이터_손실_없이_현재_모델로_마이그레이션된다() throws {
+        // given: v1 모델로 시드한 store를 현재 모델로 마이그레이션해서 연다
+        let context = try seedV1StoreAndMigrate().viewContext
+
+        // then: 메모 / 카테고리 / 이미지 개수가 모두 보존된다
+        XCTAssertEqual(try count(of: "MemoEntity", in: context), 3)
+        XCTAssertEqual(try count(of: "CategoryEntity", in: context), 2)
+        XCTAssertEqual(try count(of: "ImageEntity", in: context), 1)
+
+        // and: 메모의 내용·상태·카테고리 연결이 그대로 유지된다
+        let meeting = try XCTUnwrap(memo(titled: "회의 메모", in: context))
+        XCTAssertEqual(meeting.value(forKey: "memoText") as? String, "3시 디자인 리뷰")
+        XCTAssertEqual(meeting.value(forKey: "isFavorite") as? Bool, true)
+        let categoryNames = (meeting.value(forKey: "categories") as? Set<NSManagedObject>)?
+            .compactMap { $0.value(forKey: "name") as? String }
+        XCTAssertEqual(categoryNames, ["업무"])
+
+        // and: 휴지통 메모의 상태도 유지된다
+        let trashed = try XCTUnwrap(memo(titled: "삭제된 메모", in: context))
+        XCTAssertEqual(trashed.value(forKey: "isInTrash") as? Bool, true)
+    }
+
+    func test_마이그레이션시_v2에_추가된_ImageEntity_fileExtension에_기본값이_채워진다() throws {
+        // given: v1에는 fileExtension 속성이 없는 ImageEntity를 시드 후 마이그레이션
+        let context = try seedV1StoreAndMigrate().viewContext
+
+        // when: v2에서 추가된 fileExtension 속성을 읽으면
+        let image = try XCTUnwrap(
+            context.fetch(NSFetchRequest<NSManagedObject>(entityName: "ImageEntity")).first
+        )
+
+        // then: 모델에 정의된 기본값 "jpeg"이 채워져 있다
+        XCTAssertEqual(image.value(forKey: "fileExtension") as? String, "jpeg")
+    }
+
+    // MARK: - Seed & migrate
+
+    /// v1 모델로 store를 만들어 합성 데이터를 채운 뒤, 현재 모델로 자동
+    /// 마이그레이션하며 다시 열어 그 컨테이너를 돌려준다.
+    private func seedV1StoreAndMigrate() throws -> NSPersistentContainer {
+        let storeURL = tempDirectory.appendingPathComponent("NoteCardCoreData.sqlite")
+        try seedV1Store(at: storeURL)
+        return try openContainer(at: storeURL, with: try currentModel(), migrating: true)
+    }
+
+    private func seedV1Store(at storeURL: URL) throws {
+        let container = try openContainer(at: storeURL, with: try v1Model(), migrating: false)
+        let context = container.viewContext
+
+        let work = insert("CategoryEntity", into: context, values: [
+            "name": "업무", "creationDate": Date(), "modificationDate": Date(),
+        ])
+        insert("CategoryEntity", into: context, values: [
+            "name": "개인", "creationDate": Date(), "modificationDate": Date(),
+        ])
+
+        let meeting = insert("MemoEntity", into: context, values: [
+            "memoID": UUID(), "creationDate": Date(), "modificationDate": Date(),
+            "memoTitle": "회의 메모", "memoText": "3시 디자인 리뷰",
+            "isFavorite": true, "isInTrash": false,
+        ])
+        meeting.mutableSetValue(forKey: "categories").add(work)
+
+        insert("MemoEntity", into: context, values: [
+            "memoID": UUID(), "creationDate": Date(), "modificationDate": Date(),
+            "memoTitle": "삭제된 메모", "memoText": "휴지통 본문",
+            "isFavorite": false, "isInTrash": true, "deletedDate": Date(),
+        ])
+        insert("MemoEntity", into: context, values: [
+            "memoID": UUID(), "creationDate": Date(), "modificationDate": Date(),
+            "memoTitle": "일반 메모", "memoText": "본문3",
+            "isFavorite": false, "isInTrash": false,
+        ])
+
+        let image = insert("ImageEntity", into: context, values: [
+            "uuid": UUID(), "thumbnailUUID": UUID(),
+            "orderIndex": Int64(0), "temporaryOrderIndex": Int64(0),
+            "isTemporaryAppended": false, "isTemporaryDeleted": false,
+        ])
+        image.setValue(meeting, forKey: "memo")
+
+        try context.save()
+
+        // 같은 .sqlite 파일을 다음 컨테이너가 열 수 있도록 store를 분리한다.
+        let coordinator = container.persistentStoreCoordinator
+        for store in coordinator.persistentStores {
+            try coordinator.remove(store)
+        }
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func insert(
+        _ entityName: String,
+        into context: NSManagedObjectContext,
+        values: [String: Any]
+    ) -> NSManagedObject {
+        let object = NSEntityDescription.insertNewObject(forEntityName: entityName, into: context)
+        for (key, value) in values {
+            object.setValue(value, forKey: key)
+        }
+        return object
+    }
+
+    private func openContainer(
+        at storeURL: URL,
+        with model: NSManagedObjectModel,
+        migrating: Bool
+    ) throws -> NSPersistentContainer {
+        let container = NSPersistentContainer(name: "NoteCardCoreData", managedObjectModel: model)
+        let description = NSPersistentStoreDescription(url: storeURL)
+        description.shouldAddStoreAsynchronously = false
+        description.shouldMigrateStoreAutomatically = migrating
+        description.shouldInferMappingModelAutomatically = migrating
+        container.persistentStoreDescriptions = [description]
+
+        var loadError: Error?
+        container.loadPersistentStores { _, error in loadError = error }
+        if let loadError { throw loadError }
+        return container
+    }
+
+    /// `NoteCardCoreData.momd` 안의 특정 버전 `.mom`을 로드한다.
+    /// `momFileName`이 nil이면 `.momd` 자체를 로드해 현재 버전 모델을 얻는다.
+    private func model(momFileName: String?) throws -> NSManagedObjectModel {
+        let momdURL = try XCTUnwrap(
+            DataResources.bundle.url(forResource: "NoteCardCoreData", withExtension: "momd"),
+            "NoteCardCoreData.momd를 Data 리소스 번들에서 찾을 수 없음"
+        )
+        let modelURL = momFileName.map { momdURL.appendingPathComponent($0) } ?? momdURL
+        return try XCTUnwrap(
+            NSManagedObjectModel(contentsOf: modelURL),
+            "모델 로드 실패: \(modelURL.lastPathComponent)"
+        )
+    }
+
+    private func v1Model() throws -> NSManagedObjectModel {
+        try model(momFileName: "NoteCardCoreData.mom")
+    }
+
+    private func currentModel() throws -> NSManagedObjectModel {
+        try model(momFileName: nil)
+    }
+
+    private func count(of entityName: String, in context: NSManagedObjectContext) throws -> Int {
+        try context.count(for: NSFetchRequest<NSManagedObject>(entityName: entityName))
+    }
+
+    private func memo(titled title: String, in context: NSManagedObjectContext) throws -> NSManagedObject? {
+        let request = NSFetchRequest<NSManagedObject>(entityName: "MemoEntity")
+        request.predicate = NSPredicate(format: "memoTitle == %@", title)
+        return try context.fetch(request).first
     }
 }


### PR DESCRIPTION
## 배경
- NoteCard는 App Store 출시 상태로, 옛 모델 버전 데이터를 가진 사용자가 새 빌드를 받으면 Core Data 자동 마이그레이션이 실행된다. 이 경로가 깨지면 사용자 메모가 손실될 수 있다.
- Tuist 도입 과정에서 Core Data 코드가 크게 바뀌었으나 마이그레이션 자체는 검증된 적이 없어, 회귀 테스트로 안전망을 마련한다.

## 변경사항
- `MigrationTests.swift` — `XCTSkip` placeholder를 실제 테스트로 교체.
  - `NoteCardCoreData` v1 `.mom`을 코드로 로드해 합성 데이터로 store를 시드한 뒤, 현재 모델로 자동 마이그레이션하며 다시 열어 검증.
  - 메모/카테고리/이미지 보존, 관계 유지, v2에서 추가된 `ImageEntity.fileExtension` 기본값 적용을 assert.
- `MappingTests.swift` — 메모↔카테고리 inverse relationship 테스트 1개 추가 (메모 쪽 연결 시 카테고리의 `memoSet`도 자동 갱신되는지).

## 테스트 방법
- `xcodebuild test -workspace NoteCard.xcworkspace -scheme Data -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` → DataTests 76개 통과 (MigrationTests 2, MappingTests 9 포함).
- CI(`tuist test`)에서도 자동 실행됨.

## 리뷰 노트
- 마이그레이션 테스트는 **바이너리 fixture 파일 없이** v1 모델을 코드로 로드하는 방식 — 실제/합성 데이터 모두 저장소에 커밋되지 않고, 옛 커밋 빌드도 불필요. 모델 변경 시 CI가 자동으로 마이그레이션 깨짐을 검출한다.
- v1→v2는 `ImageEntity.fileExtension`(기본값 있는 속성) 추가뿐이라 lightweight migration으로 자동 추론된다.
- `MappingTests`의 역방향 관계 테스트는 엄밀히는 이 브랜치 주제(마이그레이션)와 별개지만, 마이그레이션 테스트 리뷰 중 발견한 관계 검증 공백을 메우는 작은 추가라 같은 PR에 포함했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)