### PR TITLE
feat: Firebase Crashlytics·Amplitude SDK 의존성 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,18 @@ jobs:
           echo "${{ secrets.ASC_KEY_CONTENT }}" > /Users/runner/.appstoreconnect/AuthKey.p8
           chmod 600 /Users/runner/.appstoreconnect/AuthKey.p8
 
+      # Configs/Secrets.xcconfig는 .gitignored — 릴리스 빌드용으로 여기서 생성한다.
+      # 키가 없으면 출시 앱의 분석(Amplitude)이 NoOp으로 비활성되므로 필수.
+      - name: Inject Amplitude API key (Secrets.xcconfig)
+        run: |
+          echo "AMPLITUDE_API_KEY = ${{ secrets.AMPLITUDE_API_KEY }}" > Configs/Secrets.xcconfig
+
+      # GoogleService-Info.plist도 .gitignored — base64 secret에서 복원한다.
+      # 없으면 출시 앱의 Crashlytics가 비활성되므로 필수.
+      - name: Inject GoogleService-Info.plist
+        run: |
+          echo "${{ secrets.GOOGLE_SERVICE_INFO_PLIST }}" | base64 --decode > NoteCard/GoogleService-Info.plist
+
       # ────────────────────────────────────────────────────────────
       # Branch handling: create new release branch on schedule/dispatch
       # main is never modified — branch is created first, bump happens on it.

--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,10 @@ fastlane/README.md.bak
 .env
 .env.local
 *.p8
+Configs/Secrets.xcconfig
+# Firebase 설정 파일. 키는 앱 바이너리에 포함되어 비밀은 아니지만,
+# public repo 스크래핑을 피하려 저장소 밖에 둔다. 릴리스 CI가 주입한다.
+GoogleService-Info.plist
 
 # Bundler
 vendor/bundle/

--- a/Configs/App.xcconfig
+++ b/Configs/App.xcconfig
@@ -1,0 +1,13 @@
+// App.xcconfig
+//
+// App 타겟(NoteCard / NoteCard-Eng)의 configuration base.
+// 버전 정보(Version.xcconfig)와 비공개 키(Secrets.xcconfig)를 한곳에 모은다.
+// Tuist는 Project.swift에서 이 파일을 App 타겟 configuration의 xcconfig로 참조한다.
+
+#include "Version.xcconfig"
+
+// Amplitude 프로젝트 API Key.
+// 기본값은 빈 문자열 — 실제 값은 Configs/Secrets.xcconfig(미커밋)가 덮어쓴다.
+// 키가 비어 있으면 앱은 분석을 비활성(NoOp)으로 동작한다.
+AMPLITUDE_API_KEY =
+#include? "Secrets.xcconfig"

--- a/Configs/Secrets.example.xcconfig
+++ b/Configs/Secrets.example.xcconfig
@@ -1,0 +1,9 @@
+// Secrets.example.xcconfig
+//
+// 이 파일을 같은 디렉터리에 `Secrets.xcconfig`로 복사한 뒤 실제 키를 채운다.
+//   cp Configs/Secrets.example.xcconfig Configs/Secrets.xcconfig
+// Secrets.xcconfig는 .gitignore 대상이라 저장소에 커밋되지 않는다.
+// CI(릴리스)에서는 GitHub Secrets로부터 Secrets.xcconfig를 생성한다.
+
+// amplitude.com → Settings → Projects 에서 발급한 API Key.
+AMPLITUDE_API_KEY = your_amplitude_api_key_here

--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -3,7 +3,10 @@
 //  NoteCard
 //
 
+import Foundation
 import Data
+import AnalyticsInterface
+import AnalyticsImpl
 
 /// 앱 전체에서 공유되는 의존성 묶음.
 ///
@@ -17,6 +20,7 @@ struct AppEnvironment {
     let memoRepository: MemoRepositoryImpl
     let categoryRepository: CategoryRepositoryImpl
     let imageRepository: ImageRepositoryImpl
+    let analytics: Analytics
 
     init() {
         let coreDataStack = CoreDataStack()
@@ -25,5 +29,23 @@ struct AppEnvironment {
         self.memoRepository = memoRepository
         self.categoryRepository = CategoryRepositoryImpl(stack: coreDataStack)
         self.imageRepository = ImageRepositoryImpl(stack: coreDataStack, memoRepository: memoRepository)
+        self.analytics = Self.setUpAnalytics()
+    }
+
+    /// Crashlytics를 켜고(가능하면) Amplitude 기반 `Analytics`를 만든다.
+    ///
+    /// Firebase 설정 파일(`GoogleService-Info.plist`)이나 Amplitude API Key가
+    /// 빌드에 포함돼 있지 않으면 해당 기능만 조용히 비활성된다 — 키 없이도
+    /// 앱은 정상 동작한다.
+    private static func setUpAnalytics() -> Analytics {
+        if Bundle.main.url(forResource: "GoogleService-Info", withExtension: "plist") != nil {
+            AnalyticsBootstrap.startCrashReporting()
+        }
+
+        let apiKey = Bundle.main.object(forInfoDictionaryKey: "AmplitudeAPIKey") as? String ?? ""
+        guard !apiKey.isEmpty else {
+            return AnalyticsBootstrap.makeNoOpAnalytics()
+        }
+        return AnalyticsBootstrap.makeAnalytics(amplitudeAPIKey: apiKey)
     }
 }

--- a/NoteCard/Info.plist
+++ b/NoteCard/Info.plist
@@ -19,5 +19,7 @@
 			</array>
 		</dict>
 	</dict>
+	<key>AmplitudeAPIKey</key>
+	<string>$(AMPLITUDE_API_KEY)</string>
 </dict>
 </plist>

--- a/Project.swift
+++ b/Project.swift
@@ -47,6 +47,10 @@ let appResources: ResourceFileElements = [
     "NoteCard/Base.lproj/Main.storyboard",
     "NoteCard/ko.lproj/**",
     "NoteCard/en.lproj/**",
+    // Firebase 설정 파일. .gitignore 대상이라 로컬/CI에 직접 둬야 한다.
+    // 파일이 없으면 glob이 비어 경고만 나고 빌드는 통과하며, 런타임에
+    // Crashlytics가 비활성된다 (AppEnvironment.setUpAnalytics 참고).
+    "NoteCard/GoogleService-Info.plist",
 ]
 
 let appSources: SourceFilesList = ["NoteCard/**/*.swift"]
@@ -97,13 +101,13 @@ let project = Project(
                         "APP_DISPLAY_NAME": "NoteCard(Dev)",
                         "CODE_SIGN_STYLE": "Automatic",
                         "PROVISIONING_PROFILE_SPECIFIER": "",
-                    ], xcconfig: "Configs/Version.xcconfig"),
+                    ], xcconfig: "Configs/App.xcconfig"),
                     .release(name: "Release", settings: [
                         "APP_DISPLAY_NAME": "NoteCard",
                         "CODE_SIGN_STYLE": "Manual",
                         "CODE_SIGN_IDENTITY": "Apple Distribution",
                         "PROVISIONING_PROFILE_SPECIFIER": "match AppStore com.minsung.NoteCard",
-                    ], xcconfig: "Configs/Version.xcconfig"),
+                    ], xcconfig: "Configs/App.xcconfig"),
                 ]
             )
         ),
@@ -129,12 +133,12 @@ let project = Project(
                         "APP_DISPLAY_NAME": "NoteCard-Eng",
                         "CODE_SIGN_STYLE": "Automatic",
                         "PROVISIONING_PROFILE_SPECIFIER": "",
-                    ], xcconfig: "Configs/Version.xcconfig"),
+                    ], xcconfig: "Configs/App.xcconfig"),
                     .release(name: "Release", settings: [
                         "APP_DISPLAY_NAME": "NoteCard-Eng",
                         "CODE_SIGN_STYLE": "Automatic",
                         "PROVISIONING_PROFILE_SPECIFIER": "",
-                    ], xcconfig: "Configs/Version.xcconfig"),
+                    ], xcconfig: "Configs/App.xcconfig"),
                 ]
             )
         ),

--- a/Projects/Core/AnalyticsImpl/Project.swift
+++ b/Projects/Core/AnalyticsImpl/Project.swift
@@ -8,5 +8,8 @@ let project = Project.module(
     resources: nil,
     dependencies: [
         .module(.analyticsInterface),
+        .external(name: "FirebaseCrashlytics"),
+        .external(name: "FirebaseAnalytics"),
+        .external(name: "AmplitudeSwift"),
     ]
 )

--- a/Projects/Core/AnalyticsImpl/Sources/AmplitudeAnalytics.swift
+++ b/Projects/Core/AnalyticsImpl/Sources/AmplitudeAnalytics.swift
@@ -1,0 +1,22 @@
+import Foundation
+import AmplitudeSwift
+import AnalyticsInterface
+
+/// Amplitude SDK를 감싼 `Analytics` 구현.
+///
+/// 제품 이벤트(퍼널·리텐션 분석용)를 Amplitude로 전송한다. Amplitude SDK
+/// 의존은 이 타입 안에만 갇혀 있고, App·Feature 레이어는 `Analytics`
+/// 프로토콜만 바라본다 — SDK 교체 시 이 파일만 바꾸면 된다.
+public final class AmplitudeAnalytics: Analytics, @unchecked Sendable {
+
+    private let amplitude: Amplitude
+
+    public init(apiKey: String) {
+        amplitude = Amplitude(configuration: Configuration(apiKey: apiKey))
+    }
+
+    // AmplitudeSwift에도 `AnalyticsEvent` 타입이 있어 모듈명으로 한정한다.
+    public func log(_ event: AnalyticsInterface.AnalyticsEvent) {
+        amplitude.track(eventType: event.name, eventProperties: event.properties)
+    }
+}

--- a/Projects/Core/AnalyticsImpl/Sources/AnalyticsBootstrap.swift
+++ b/Projects/Core/AnalyticsImpl/Sources/AnalyticsBootstrap.swift
@@ -1,0 +1,39 @@
+import Foundation
+import FirebaseCore
+import FirebaseCrashlytics
+import AnalyticsInterface
+
+/// 분석/로깅 SDK의 조립 지점. App composition root에서 한 번만 호출한다.
+///
+/// Firebase(Crashlytics)와 Amplitude는 서로 독립적인 기능이므로 따로 노출한다.
+/// 어느 쪽이든 설정(plist / API Key)이 없으면 해당 기능만 비활성되고 나머지는
+/// 정상 동작한다. Firebase·Amplitude SDK 의존은 이 모듈 안에만 갇혀 있어,
+/// App·Feature 레이어는 `Analytics` 프로토콜만 바라본다.
+public enum AnalyticsBootstrap {
+
+    /// Crashlytics 크래시 수집을 시작한다.
+    ///
+    /// `FirebaseApp.configure()`는 번들의 `GoogleService-Info.plist`를 읽으므로,
+    /// 호출 전에 해당 파일이 앱 리소스에 포함돼 있는지 확인해야 한다.
+    public static func startCrashReporting() {
+        FirebaseApp.configure()
+
+        // Debug 빌드의 크래시는 실사용 지표를 오염시키므로 수집하지 않는다.
+        #if DEBUG
+        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(false)
+        #else
+        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(true)
+        #endif
+    }
+
+    /// Amplitude 기반 `Analytics` 구현을 만든다.
+    /// - Parameter amplitudeAPIKey: Amplitude 프로젝트 API Key.
+    public static func makeAnalytics(amplitudeAPIKey: String) -> Analytics {
+        AmplitudeAnalytics(apiKey: amplitudeAPIKey)
+    }
+
+    /// 분석 비활성(테스트·프리뷰·키 부재) 시 사용할 no-op 구현.
+    public static func makeNoOpAnalytics() -> Analytics {
+        NoOpAnalytics()
+    }
+}

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,6 +1,159 @@
 {
   "pins" : [
     {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
+    {
+      "identity" : "amplitude-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/Amplitude-Swift.git",
+      "state" : {
+        "revision" : "e7db15db0de857a0e47827d750f44a6a6d6c8e1a",
+        "version" : "1.18.2"
+      }
+    },
+    {
+      "identity" : "amplitudecore-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/AmplitudeCore-Swift.git",
+      "state" : {
+        "revision" : "d9d24b79d4fcb4f1d1dcbc50ae20430afd22ebd0",
+        "version" : "1.4.5"
+      }
+    },
+    {
+      "identity" : "analytics-connector-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/analytics-connector-ios.git",
+      "state" : {
+        "revision" : "4adbfe85486e6dcdcdca5fa9362097ffe5ec712b",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "fdc352fabaf5916e7faa1f96ad02b1957e93e5a5",
+        "version" : "11.15.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "a2d0f1f1666de591eb1a811f40b1706f5c63a2ed",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "45ce435e9406d3c674dd249a042b932bee006f60",
+        "version" : "11.15.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "c756a29784521063b6a1202907e2cc47f41b667c",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "f6506eaa86ed2e01cb0ae14a75035b7fdbf0918f",
+        "version" : "1.38.0"
+      }
+    },
+    {
       "identity" : "wisp",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/WispKit/Wisp.git",

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -7,6 +7,9 @@ import ProjectDescription
 let packageSettings = PackageSettings(
     productTypes: [
         "Wisp": .staticFramework,
+        "FirebaseCrashlytics": .staticFramework,
+        "FirebaseAnalytics": .staticFramework,
+        "AmplitudeSwift": .staticFramework,
     ]
 )
 #endif
@@ -15,5 +18,7 @@ let package = Package(
     name: "NoteCard",
     dependencies: [
         .package(url: "https://github.com/WispKit/Wisp.git", from: "1.10.1"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.0.0"),
+        .package(url: "https://github.com/amplitude/Amplitude-Swift.git", from: "1.0.0"),
     ]
 )


### PR DESCRIPTION
## 변경사항
- Firebase Crashlytics(크래시 리포팅)와 Amplitude(제품 이벤트 분석) SDK 도입
- SDK는 `AnalyticsImpl` 모듈에 격리 — App·Feature 레이어는 `Analytics` 프로토콜만 의존
- API Key·Firebase 설정 파일은 gitignore + CI(Secrets) 주입으로 관리
- 설정 부재 시 graceful 폴백 (NoOp 분석) — 키 없이도 빌드/실행 정상

## 테스트 방법
- `tuist test` — 전체 모듈 테스트 통과
- 시뮬레이터 실행 시 크래시 없이 정상 동작

## 리뷰 노트
- 이벤트 instrumentation, dSYM 업로드는 후속 작업으로 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)