### PR TITLE
feat: Amplitude 분석 이벤트 계측

### DIFF
--- a/NoteCard/Global/Analytics/AnalyticsEvent+NoteCard.swift
+++ b/NoteCard/Global/Analytics/AnalyticsEvent+NoteCard.swift
@@ -1,0 +1,64 @@
+import AnalyticsInterface
+
+/// NoteCard에서 발생하는 분석 이벤트 카탈로그.
+///
+/// 이벤트 이름·파라미터를 한곳에 모아, 호출부가 여러 곳이어도 정의는 단일
+/// 출처로 유지한다. 새 이벤트는 여기에 팩토리 메서드로 추가한다.
+///
+/// ⚠️ 파라미터에는 사용자 데이터(메모 제목·본문, 카테고리 이름, 검색어 등)를
+/// 절대 담지 않는다 — 카운트·불리언·enum 같은 메타데이터만 전송한다.
+extension AnalyticsEvent {
+
+    /// `screen_view` 이벤트의 화면 이름.
+    enum Screen: String {
+        case home
+        case memoList = "memo_list"
+        case memoCard = "memo_card"
+        case memoEditor = "memo_editor"
+        case search
+        case settings
+    }
+
+    static func screenView(_ screen: Screen) -> AnalyticsEvent {
+        AnalyticsEvent(name: "screen_view", properties: ["screen_name": screen.rawValue])
+    }
+
+    static func memoCreated(imageCount: Int, categoryCount: Int, hasTitle: Bool) -> AnalyticsEvent {
+        AnalyticsEvent(
+            name: "memo_created",
+            properties: memoProperties(imageCount: imageCount, categoryCount: categoryCount, hasTitle: hasTitle)
+        )
+    }
+
+    static func memoEdited(imageCount: Int, categoryCount: Int, hasTitle: Bool) -> AnalyticsEvent {
+        AnalyticsEvent(
+            name: "memo_edited",
+            properties: memoProperties(imageCount: imageCount, categoryCount: categoryCount, hasTitle: hasTitle)
+        )
+    }
+
+    /// 메모 저장 실패. `mode`는 `"making"` 또는 `"editing"`.
+    static func memoSaveFailed(mode: String) -> AnalyticsEvent {
+        AnalyticsEvent(name: "memo_save_failed", properties: ["mode": mode])
+    }
+
+    static func memoMovedToTrash(count: Int) -> AnalyticsEvent {
+        AnalyticsEvent(name: "memo_moved_to_trash", properties: ["count": String(count)])
+    }
+
+    static func memoDeleted(count: Int) -> AnalyticsEvent {
+        AnalyticsEvent(name: "memo_deleted", properties: ["count": String(count)])
+    }
+
+    private static func memoProperties(
+        imageCount: Int,
+        categoryCount: Int,
+        hasTitle: Bool
+    ) -> [String: String] {
+        [
+            "image_count": String(imageCount),
+            "category_count": String(categoryCount),
+            "has_title": String(hasTitle),
+        ]
+    }
+}

--- a/NoteCard/Presentation/HomeView/HomeViewController.swift
+++ b/NoteCard/Presentation/HomeView/HomeViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 김민성 on 2023/11/02.
 //
 
+import AnalyticsInterface
 import Combine
 import Data
 import Domain
@@ -73,9 +74,14 @@ class HomeViewController: UIViewController {
         self.view = homeView
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        environment.analytics.log(.screenView(.home))
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         setupNaviBar()
         setupDiffableDataSource()
         Task {

--- a/NoteCard/Presentation/MemoDetailView/MemoDetailViewController.swift
+++ b/NoteCard/Presentation/MemoDetailView/MemoDetailViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 김민성 on 9/11/25.
 //
 
+import AnalyticsInterface
 import Combine
 import Data
 import Domain
@@ -101,10 +102,15 @@ class MemoDetailViewController: UIViewController {
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        
+
         rootView.prepareForDismissal()
     }
-    
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        environment.analytics.log(.screenView(.memoEditor))
+    }
+
 }
 
 
@@ -138,8 +144,10 @@ private extension MemoDetailViewController {
                         debugPrint("이미지 정보에 변화가 없으므로 이미지 정보 업데이트하지 않음.")
                     }
                     try await self.updateCategories()
+                    self.logSaveSuccess()
                 } catch {
                     assertionFailure("에러 발생: \(error.localizedDescription)")
+                    self.logSaveFailure()
                 }
                 self.dismiss(animated: true)
             }
@@ -349,6 +357,32 @@ private extension MemoDetailViewController {
         }
     }
     
+}
+
+
+// MARK: - 분석 이벤트
+private extension MemoDetailViewController {
+
+    var isMakingMemo: Bool {
+        if case .making = detailType { return true }
+        return false
+    }
+
+    func logSaveSuccess() {
+        let imageCount = editableImageModels.filter { !$0.isPendingDeleted }.count
+        let categoryCount = (rootView.categoryListCollectionView.indexPathsForSelectedItems ?? []).count
+        let hasTitle = !((rootView.titleTextField.text ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        let event: AnalyticsEvent = isMakingMemo
+            ? .memoCreated(imageCount: imageCount, categoryCount: categoryCount, hasTitle: hasTitle)
+            : .memoEdited(imageCount: imageCount, categoryCount: categoryCount, hasTitle: hasTitle)
+        environment.analytics.log(event)
+    }
+
+    func logSaveFailure() {
+        environment.analytics.log(.memoSaveFailed(mode: isMakingMemo ? "making" : "editing"))
+    }
+
 }
 
 

--- a/NoteCard/Presentation/MemoSearching/MemoSearchingViewController.swift
+++ b/NoteCard/Presentation/MemoSearching/MemoSearchingViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 김민성 on 8/6/25.
 //
 
+import AnalyticsInterface
 import Combine
 import Data
 import Domain
@@ -38,9 +39,14 @@ class MemoSearchingViewController: UIViewController {
         view = rootView
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        environment.analytics.log(.screenView(.search))
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         setupNaviBar()
         setupDiffableDataSource()
         setupDelegates()

--- a/NoteCard/Presentation/MemoView/MemoViewController.swift
+++ b/NoteCard/Presentation/MemoView/MemoViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 김민성 on 2023/11/02.
 //
 
+import AnalyticsInterface
 import Combine
 import Data
 import Domain
@@ -87,6 +88,11 @@ class MemoViewController: UIViewController {
         self.view = MemoView()
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        environment.analytics.log(.screenView(.memoList))
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -434,8 +440,10 @@ private extension MemoViewController {
             Task {
                 if self.memoVCType == .trash {
                     try await self.environment.memoRepository.deleteMemos(selectedMemos)
+                    self.environment.analytics.log(.memoDeleted(count: selectedMemos.count))
                 } else {
                     try await self.environment.memoRepository.moveToTrash(selectedMemos)
+                    self.environment.analytics.log(.memoMovedToTrash(count: selectedMemos.count))
                 }
                 try await self.updateMemoContents()
             }

--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 김민성 on 2023/11/02.
 //
 
+import AnalyticsInterface
 import Combine
 import Data
 import Domain
@@ -140,7 +141,8 @@ class PopupCardViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+        environment.analytics.log(.screenView(.memoCard))
+
         UIView.animate(
             withDuration: 0.2,
             delay: 0,
@@ -484,8 +486,10 @@ extension PopupCardViewController {
                 do {
                     if self.memo.isInTrash {
                         try await self.environment.memoRepository.deleteMemo(self.memo)
+                        self.environment.analytics.log(.memoDeleted(count: 1))
                     } else {
                         try await self.environment.memoRepository.moveToTrash(self.memo)
+                        self.environment.analytics.log(.memoMovedToTrash(count: 1))
                     }
                     self.dismiss(animated: true)
                 } catch {

--- a/NoteCard/Presentation/SettingsView/SettingsViewController.swift
+++ b/NoteCard/Presentation/SettingsView/SettingsViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 김민성 on 2023/11/16.
 //
 
+import AnalyticsInterface
 import UIKit
 import Data
 import Domain
@@ -60,6 +61,11 @@ class SettingsViewController: UITableViewController {
     private var totalMemoCount = 0
     private var totalCategoryCount = 0
     private var trashMemoCount = 0
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        environment.analytics.log(.screenView(.settings))
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Projects/Core/AnalyticsImpl/Sources/AmplitudeAnalytics.swift
+++ b/Projects/Core/AnalyticsImpl/Sources/AmplitudeAnalytics.swift
@@ -12,7 +12,14 @@ public final class AmplitudeAnalytics: Analytics, @unchecked Sendable {
     private let amplitude: Amplitude
 
     public init(apiKey: String) {
-        amplitude = Amplitude(configuration: Configuration(apiKey: apiKey))
+        // dev 빌드의 이벤트가 실사용 지표를 오염시키지 않도록 Amplitude를 opt-out한다.
+        // (Crashlytics를 DEBUG에서 끄는 AnalyticsBootstrap의 정책과 동일.)
+        #if DEBUG
+        let optOut = true
+        #else
+        let optOut = false
+        #endif
+        amplitude = Amplitude(configuration: Configuration(apiKey: apiKey, optOut: optOut))
     }
 
     // AmplitudeSwift에도 `AnalyticsEvent` 타입이 있어 모듈명으로 한정한다.


### PR DESCRIPTION
## 배경
- 분석/로깅 SDK는 #23으로 도입 완료. 이번 PR은 실제 제품 이벤트를 계측한다.

## 변경사항
- 이벤트 카탈로그, `AnalyticsEvent+NoteCard.swift` 에 작성
  - `memo_created` / `memo_edited` / `memo_save_failed` — 메모 저장 성공·실패
  - `memo_moved_to_trash` / `memo_deleted` — 휴지통 이동·영구삭제
  - `screen_view` — 6개 주요 화면 (home / memo_list / memo_card / memo_editor / search / settings)
- DEBUG 빌드는 Amplitude 설정 시 opt-out 처리 (실사용 지표만 기록하기 위함)
- 파라미터는 메타데이터(카운트·불리언)만, 사용자 데이터(제목·본문·검색어)는 제외

## 테스트 방법
- `tuist test` — 전체 모듈 테스트 통과
- 시뮬레이터 빌드·실행 시 크래시 없이 정상 동작

## 리뷰 노트
- `SceneDelegate`의 휴지통 자동정리 `deleteMemo`는 사용자 동작이 아니라 로깅에서 제외

🤖 Generated with [Claude Code](https://claude.com/claude-code)