### PR TITLE
refactor: MemoRepository 추상화 보강 및 AppEnvironment 의존성 타입 전환

### DIFF
--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import Data
+import Domain
 import AnalyticsInterface
 import AnalyticsImpl
 
@@ -17,7 +18,7 @@ import AnalyticsImpl
 struct AppEnvironment {
 
     let coreDataStack: CoreDataStack
-    let memoRepository: MemoRepositoryImpl
+    let memoRepository: MemoRepository
     let categoryRepository: CategoryRepositoryImpl
     let imageRepository: ImageRepositoryImpl
     let analytics: Analytics

--- a/NoteCard/Presentation/MemoSearching/MemoSearchingViewController.swift
+++ b/NoteCard/Presentation/MemoSearching/MemoSearchingViewController.swift
@@ -98,7 +98,7 @@ private extension MemoSearchingViewController {
             .debounce(for: 0.2, scheduler: RunLoop.main)
             .sink { searchText in
                 Task {
-                    let memoSearchResult = try await self.environment.memoRepository.searchMemo(searchText: searchText)
+                    let memoSearchResult = try await self.environment.memoRepository.searchMemo(searchText: searchText, inCategory: nil)
                     self.applySnapshot(with: memoSearchResult)
                 }
             }

--- a/NoteCard/Presentation/PopupCardView/PopupCardView.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardView.swift
@@ -194,7 +194,7 @@ final class PopupCardView: UIView {
         if isTextFieldChanged {
             Task {
                 let trimmedTitleText = titleTextField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
-                try await environment.memoRepository.updateMemoContent(memo, newTitle: trimmedTitleText)
+                try await environment.memoRepository.updateMemoContent(memo, newTitle: trimmedTitleText, newMemoText: nil)
                 self.isTextFieldChanged = false
             }
         }
@@ -203,7 +203,7 @@ final class PopupCardView: UIView {
     func updateMemoTextView() {
         if isTextViewChanged {
             Task {
-                try await environment.memoRepository.updateMemoContent(memo, newMemoText: memoTextView.text)
+                try await environment.memoRepository.updateMemoContent(memo, newTitle: nil, newMemoText: memoTextView.text)
                 self.isTextViewChanged = false
             }
         }

--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -221,7 +221,7 @@ private extension PopupCardViewController {
         }
         Task {
             do {
-                try await environment.memoRepository.updateMemoContent(memo, newTitle: sender.text)
+                try await environment.memoRepository.updateMemoContent(memo, newTitle: sender.text, newMemoText: nil)
             } catch {
                 print(error.localizedDescription)
             }
@@ -319,7 +319,7 @@ extension PopupCardViewController: UITextViewDelegate {
         }
         Task {
             do {
-                try await environment.memoRepository.updateMemoContent(memo, newMemoText: textView.text)
+                try await environment.memoRepository.updateMemoContent(memo, newTitle: nil, newMemoText: textView.text)
             } catch {
                 print(error.localizedDescription)
             }
@@ -339,7 +339,7 @@ extension PopupCardViewController: UITextFieldDelegate {
         }
         Task {
             do {
-                try await environment.memoRepository.updateMemoContent(memo, newTitle: trimmedInput)
+                try await environment.memoRepository.updateMemoContent(memo, newTitle: trimmedInput, newMemoText: nil)
             } catch {
                 print(error.localizedDescription)
             }

--- a/Projects/Data/Sources/Repositories/MemoRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/MemoRepositoryImpl.swift
@@ -29,28 +29,6 @@ public enum MemoEntityError: LocalizedError {
 
 public actor MemoRepositoryImpl: MemoRepository {
     
-    public enum MemoUpdateType: Equatable {
-        public enum UpdateAttribute: Equatable {
-            case favorite(memoIDs: [UUID])
-            case titleText(memoIDs: [UUID])
-            case category(memoIDs: [UUID])
-
-            public var memoIDs: [UUID] {
-                switch self {
-                case .favorite(let memoIDs): return memoIDs
-                case .titleText(let memoIDs): return memoIDs
-                case .category(let memoIDs): return memoIDs
-                }
-            }
-        }
-        
-        case create
-        case trash
-        case delete
-        case restore
-        case update(content: UpdateAttribute)
-    }
-    
     private let context: NSManagedObjectContext
 
     public init(stack: CoreDataStack) {

--- a/Projects/Data/Tests/MemoRepositoryTests.swift
+++ b/Projects/Data/Tests/MemoRepositoryTests.swift
@@ -390,7 +390,7 @@ final class MemoRepositoryTests: XCTestCase {
 
     func test_메모를_생성하면_퍼블리셔로_생성_이벤트가_방출된다() async throws {
         // given: 업데이트 이벤트 구독
-        var received: [MemoRepositoryImpl.MemoUpdateType] = []
+        var received: [MemoUpdateType] = []
         let cancellable = sut.memoUpdatedPublisher.sink { received.append($0) }
         defer { cancellable.cancel() }
 

--- a/Projects/Domain/Sources/Repositories/MemoRepository.swift
+++ b/Projects/Domain/Sources/Repositories/MemoRepository.swift
@@ -5,27 +5,32 @@
 //  Created by 김민성 on 8/27/25.
 //
 
+import Combine
 import Foundation
 import Shared
 
-public protocol MemoRepository: Actor {
-    
+public protocol MemoRepository: Sendable {
+
+    var memoUpdatedPublisher: AnyPublisher<MemoUpdateType, Never> { get }
+
     func createNewMemo() async throws -> Memo
-    
+
     func getMemo(id: UUID) async throws -> Memo
     func getAllMemos() async throws -> [Memo]
     func getAllMemos(inCategory category: Category?) async throws -> [Memo]
     func getAllMemosInTrash() async throws -> [Memo]
-    
+
     func searchMemo(searchText: String, inCategory category: Category?) async throws -> [Memo]
     func getFavoriteMemos() async throws -> [Memo]
-    
+
     func moveToTrash(_ memo: Memo) async throws
+    func moveToTrash(_ memos: [Memo]) async throws
     func deleteMemo(_ memo: Memo) async throws
     func deleteMemos(_ memos: [Memo]) async throws
-    
+
     func restore(_ memo: Memo) async throws
-    
+    func restore(_ memos: [Memo]) async throws
+
     func replaceCategories(to: Memo, newCategories: Set<Category>) async throws
     func replaceCategories(to: [Memo], newCategories: Set<Category>) async throws
     func addCategories(to: Memo, newCategories: Set<Category>) async throws
@@ -33,6 +38,7 @@ public protocol MemoRepository: Actor {
     func removeCategories(to: Memo, newCategories: Set<Category>) async throws
     func removeCategories(to: [Memo], newCategories: Set<Category>) async throws
     func setFavorite(_ memo: Memo, to value: Bool) async throws
+    func setFavorite(_ memos: [Memo], to value: Bool) async throws
     func updateMemoContent(_ memo: Memo, newTitle: String?, newMemoText: String?) async throws
-    
+
 }

--- a/Projects/Domain/Sources/Repositories/MemoUpdateType.swift
+++ b/Projects/Domain/Sources/Repositories/MemoUpdateType.swift
@@ -1,0 +1,29 @@
+//
+//  MemoUpdateType.swift
+//  NoteCard
+//
+
+import Foundation
+
+/// `MemoRepository`가 발행하는 메모 변경 이벤트의 종류.
+public enum MemoUpdateType: Equatable {
+    public enum UpdateAttribute: Equatable {
+        case favorite(memoIDs: [UUID])
+        case titleText(memoIDs: [UUID])
+        case category(memoIDs: [UUID])
+
+        public var memoIDs: [UUID] {
+            switch self {
+            case .favorite(let memoIDs): return memoIDs
+            case .titleText(let memoIDs): return memoIDs
+            case .category(let memoIDs): return memoIDs
+            }
+        }
+    }
+
+    case create
+    case trash
+    case delete
+    case restore
+    case update(content: UpdateAttribute)
+}


### PR DESCRIPTION
## 배경
- `AppEnvironment`가 Repository를 구체 타입(`MemoRepositoryImpl`)으로 보유 중이라, 이를 주입받는 화면 코드도 구체 타입에 결합돼 있음.
- 화면이 추상화(프로토콜)에 의존하도록 전환하기 위한 사전 작업으로, `MemoRepository` 프로토콜이 구현체의 공개 API를 온전히 노출하도록 보강.

## 변경사항
- `MemoRepository` 프로토콜 보강
  - 프로토콜 제약을 `Actor`에서 `Sendable`로 변경 — 구현체를 actor로 강제하지 않으면서 스레드 안전 보장은 유지
  - 구현체에만 있던 `memoUpdatedPublisher`를 프로토콜 요구사항으로 추가
  - 구현체에만 있던 배열 일괄 처리 메서드 3종(`moveToTrash`·`restore`·`setFavorite`)을 프로토콜에 추가
  - `MemoUpdateType`을 `MemoRepositoryImpl` 중첩 타입에서 `Domain` 모듈 최상위 타입으로 이동
- `AppEnvironment.memoRepository` 속성 타입을 `MemoRepositoryImpl`(구체)에서 `MemoRepository`(프로토콜)로 전환
- 프로토콜은 기본값 인자를 가질 수 없어, 구체 타입의 기본값에 의존하던 호출부 6곳에 인자를 명시 (`searchMemo` 1곳, `updateMemoContent` 5곳)

## 테스트 방법
- `tuist test` 전체 통과 확인
- 메모 검색, 메모 제목·본문 수정, 메모 카드 동작 수동 확인

## 리뷰 노트
- `categoryRepository`·`imageRepository`는 이번 범위에서 제외 — 동일한 프로토콜 타입 전환을 후속 PR로 진행 예정
- `MemoRepository.swift`는 파일 전체 재작성 과정에서 빈 줄의 trailing whitespace가 정리됨. 의미상 변경은 import 추가·프로토콜 제약 변경·메서드 4개 추가뿐