### PR TITLE
refactor: CategoryRepository·ImageRepository를 프로토콜 타입으로 전환

### DIFF
--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -20,7 +20,7 @@ struct AppEnvironment {
     let coreDataStack: CoreDataStack
     let memoRepository: MemoRepository
     let categoryRepository: CategoryRepository
-    let imageRepository: ImageRepositoryImpl
+    let imageRepository: ImageRepository
     let analytics: Analytics
 
     init() {

--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -19,7 +19,7 @@ struct AppEnvironment {
 
     let coreDataStack: CoreDataStack
     let memoRepository: MemoRepository
-    let categoryRepository: CategoryRepositoryImpl
+    let categoryRepository: CategoryRepository
     let imageRepository: ImageRepositoryImpl
     let analytics: Analytics
 

--- a/NoteCard/Presentation/MemoDetailView/MemoDetailViewController.swift
+++ b/NoteCard/Presentation/MemoDetailView/MemoDetailViewController.swift
@@ -341,6 +341,8 @@ private extension MemoDetailViewController {
                         let _ = try await imageRepository.createImage(
                             from: model.pickerResult,
                             for: memo,
+                            originalImageID: nil,
+                            thumbnailID: nil,
                             orderIndex: index,
                             isTemporary: false
                         )

--- a/Projects/Data/Sources/Repositories/ImageRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/ImageRepositoryImpl.swift
@@ -15,23 +15,6 @@ import UniformTypeIdentifiers
 
 public actor ImageRepositoryImpl: ImageRepository {
     
-    public enum ImageUpdateType: Equatable {
-        case create(memoID: UUID)
-        case delete(memoID: UUID)
-        case update(memoID: UUID)
-        
-        public var memoID: UUID {
-            switch self {
-            case .create(let memoID):
-                return memoID
-            case .delete(let memoID):
-                return memoID
-            case .update(let memoID):
-                return memoID
-            }
-        }
-    }
-    
     private let context: NSManagedObjectContext
     private let memoRepository: MemoRepositoryImpl
 

--- a/Projects/Domain/Sources/Repositories/CategoryRepository.swift
+++ b/Projects/Domain/Sources/Repositories/CategoryRepository.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Shared
 
-public protocol CategoryRepository {
+public protocol CategoryRepository: Sendable {
     
     func create(name: String) async throws
     

--- a/Projects/Domain/Sources/Repositories/ImageRepository.swift
+++ b/Projects/Domain/Sources/Repositories/ImageRepository.swift
@@ -5,12 +5,16 @@
 //  Created by 김민성 on 9/10/25.
 //
 
+import Combine
 import PhotosUI
 import Shared
 import UIKit
 
 // MARK: - Repository Protocol
-public protocol ImageRepository {
+public protocol ImageRepository: Sendable {
+
+    var imageUpdatedPublisher: AnyPublisher<ImageUpdateType, Never> { get }
+
     func createImage(
         from pickerResult: PHPickerResult,
         for memo: Memo,

--- a/Projects/Domain/Sources/Repositories/ImageUpdateType.swift
+++ b/Projects/Domain/Sources/Repositories/ImageUpdateType.swift
@@ -1,0 +1,24 @@
+//
+//  ImageUpdateType.swift
+//  NoteCard
+//
+
+import Foundation
+
+/// `ImageRepository`가 발행하는 이미지 변경 이벤트의 종류.
+public enum ImageUpdateType: Equatable {
+    case create(memoID: UUID)
+    case delete(memoID: UUID)
+    case update(memoID: UUID)
+
+    public var memoID: UUID {
+        switch self {
+        case .create(let memoID):
+            return memoID
+        case .delete(let memoID):
+            return memoID
+        case .update(let memoID):
+            return memoID
+        }
+    }
+}


### PR DESCRIPTION
## 배경
- 직전 PR(#28)에서 `AppEnvironment.memoRepository`를 프로토콜 타입으로 전환한 데 이은 후속 작업.
- 나머지 두 Repository(`categoryRepository`, `imageRepository`)도 동일하게 프로토콜 타입으로 전환하여 `AppEnvironment`가 구현체가 아닌 추상화에 의존하도록 마무리.

## 변경사항
- `CategoryRepository` 프로토콜에 `Sendable` 제약 추가 (프로토콜 타입으로 보유·전달할 때의 스레드 안전 보장)
- `ImageRepository` 프로토콜 보강
  - `Sendable` 제약 추가
  - 구현체에만 있던 `imageUpdatedPublisher`를 프로토콜 요구사항으로 노출
  - `ImageUpdateType`을 `ImageRepositoryImpl` 중첩 타입에서 `Domain` 모듈 최상위 타입으로 이동
- `AppEnvironment`의 속성 타입 전환
  - `categoryRepository`: `CategoryRepositoryImpl`(구체) → `CategoryRepository`(프로토콜)
  - `imageRepository`: `ImageRepositoryImpl`(구체) → `ImageRepository`(프로토콜)
- 프로토콜은 기본값 인자를 가질 수 없어, `createImage` 호출부 1곳에 `originalImageID`·`thumbnailID` 인자를 명시

## 테스트 방법
- `tuist test` 전체 통과 확인
- 이미지 추가·삭제·순서 변경, 카테고리 생성·이름 변경·삭제 수동 확인

## 리뷰 노트
- 커밋은 라운드별로 2개로 분리 (`refactor(di): ...categoryRepository...`, `refactor(di): ...imageRepository...`)
- `imageRepository`의 publisher 노출·`ImageUpdateType` 이동은 #28의 `memoRepository`에서 한 작업과 동일한 패턴
- 이로써 `AppEnvironment`의 세 Repository 속성이 모두 프로토콜 타입으로 전환 완료됨