### PR TITLE
chore(sync): Sign in with Apple capability + Firebase 동기화 SDK 설정

### DIFF
--- a/NoteCard/NoteCard.entitlements
+++ b/NoteCard/NoteCard.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/Project.swift
+++ b/Project.swift
@@ -93,6 +93,7 @@ let project = Project(
             infoPlist: .file(path: "NoteCard/Info.plist"),
             sources: appSources,
             resources: appResources,
+            entitlements: .file(path: "NoteCard/NoteCard.entitlements"),
             dependencies: appDependencies,
             settings: .settings(
                 base: appTargetBaseSettings,
@@ -125,6 +126,7 @@ let project = Project(
             infoPlist: .file(path: "NoteCard/Info.plist"),
             sources: appSources,
             resources: appResources,
+            entitlements: .file(path: "NoteCard/NoteCard.entitlements"),
             dependencies: appDependencies,
             settings: .settings(
                 base: appTargetBaseSettings,

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -9,6 +9,9 @@ let packageSettings = PackageSettings(
         "Wisp": .staticFramework,
         "FirebaseCrashlytics": .staticFramework,
         "FirebaseAnalytics": .staticFramework,
+        "FirebaseAuth": .staticFramework,
+        "FirebaseFirestore": .staticFramework,
+        "FirebaseStorage": .staticFramework,
         "AmplitudeSwift": .staticFramework,
     ]
 )


### PR DESCRIPTION
## 배경
- Firestore 기반 메모 동기화 v1 작업의 첫 단계 인프라 설정 PR.
- 이후 Sign in with Apple UI 통합과 Firestore 동기화 로직 구현의 기반.

## 변경사항
- `NoteCard.entitlements` 신설 — `com.apple.developer.applesignin` Default
- `Project.swift`의 `NoteCard`·`NoteCard-Eng` 두 앱 타겟에 entitlements 참조 추가
- `Tuist/Package.swift`의 productTypes에 `FirebaseAuth`·`FirebaseFirestore`·`FirebaseStorage` 추가 (static framework)

## 테스트 방법
- `tuist generate --no-open && xcodebuild build ...` 통과 (Debug, Simulator)
- 동작 변화 없음 — 수동 동작 확인 불필요

## 리뷰 노트
- 실제 Firebase API 호출은 다음 PR에서 진행 — 이 PR은 빌드 설정만 변경
- Sign in with Apple capability를 켰지만 UI 통합은 아직 없음 — 다음 PR
- Apple Developer Portal에서 App ID 두 개(`.com.minsung.NoteCard`, `.eng`)에 Sign in with Apple capability 활성화는 수동으로 완료됨
- Manual signing을 쓰는 Release 빌드는 capability 변경에 따라 `fastlane match appstore`로 프로필 재발급 필요 — 다음 TestFlight 업로드 직전에 진행
- Firebase 콘솔에서 Firestore(Seoul·Production mode)·Storage·Authentication(Apple provider) 활성화는 사전에 완료됨
- 새 `GoogleService-Info.plist`는 .gitignore 대상이라 별도로 로컬·CI에 배치 필요