### PR TITLE
refactor(data): CoreDataStack에 storeURL 파라미터 추가

### DIFF
--- a/Projects/Data/Sources/CoreData/CoreDataStack.swift
+++ b/Projects/Data/Sources/CoreData/CoreDataStack.swift
@@ -14,13 +14,21 @@ import Foundation
 public final class CoreDataStack: ObservableObject {
 
     private let inMemory: Bool
+    private let storeURL: URL?
 
-    /// - Parameter inMemory: `true`이면 디스크 대신 휘발성 저장소를 사용한다.
-    ///   store type 자체는 SQLite를 유지하되 파일 경로만 `/dev/null`로 두어,
-    ///   predicate·정렬 동작이 프로덕션과 100% 동일하면서 디스크에는 아무것도
-    ///   남기지 않는다. 단위 테스트에서 격리된 빈 저장소를 매번 새로 만들 때 사용.
-    public init(inMemory: Bool = false) {
+    /// - Parameters:
+    ///   - inMemory: `true`이면 디스크 대신 휘발성 저장소를 사용한다.
+    ///     store type 자체는 SQLite를 유지하되 파일 경로만 `/dev/null`로 두어,
+    ///     predicate·정렬 동작이 프로덕션과 100% 동일하면서 디스크에는 아무것도
+    ///     남기지 않는다. 단위 테스트에서 격리된 빈 저장소를 매번 새로 만들 때 사용.
+    ///   - storeURL: SQLite 파일을 둘 위치. `nil`이면 `NSPersistentContainer`의
+    ///     기본 위치(`Library/Application Support/`)에 컨테이너 이름으로 저장된다.
+    ///     사용자별 store 분리(같은 모델로 여러 stack 인스턴스를 다른 파일에 운용)
+    ///     용도. 부모 디렉터리는 호출자가 미리 존재하도록 보장해야 한다 — Core Data는
+    ///     디렉터리를 자동 생성하지 않는다. `inMemory`가 `true`이면 무시된다.
+    public init(inMemory: Bool = false, storeURL: URL? = nil) {
         self.inMemory = inMemory
+        self.storeURL = storeURL
     }
 
     // MARK: - Core Data stack
@@ -43,6 +51,10 @@ public final class CoreDataStack: ObservableObject {
         if inMemory {
             container.persistentStoreDescriptions = [
                 NSPersistentStoreDescription(url: URL(fileURLWithPath: "/dev/null"))
+            ]
+        } else if let storeURL {
+            container.persistentStoreDescriptions = [
+                NSPersistentStoreDescription(url: storeURL)
             ]
         }
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in

--- a/Projects/Data/Tests/CoreDataStackTests.swift
+++ b/Projects/Data/Tests/CoreDataStackTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+import Domain
+@testable import Data
+
+/// `CoreDataStack`의 `storeURL` 파라미터가 기대대로 동작하는지 검증.
+/// 사용자별 store 파일 분리(다중 Apple ID 격리)를 위한 기반.
+final class CoreDataStackTests: XCTestCase {
+
+    private var tempDirectory: URL!
+
+    override func setUpWithError() throws {
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CoreDataStackTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDirectory)
+    }
+
+    func test_storeURL_지정시_해당_위치에_SQLite_파일이_생성된다() async throws {
+        // given
+        let url = tempDirectory.appendingPathComponent("Custom.sqlite")
+        let stack = CoreDataStack(storeURL: url)
+
+        // when: lazy 컨테이너 로드 트리거
+        _ = stack.backgroundContext
+
+        // then
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: url.path),
+            "SQLite 파일이 \(url.path)에 생성돼야 한다."
+        )
+    }
+
+    func test_서로_다른_storeURL의_두_stack은_데이터가_격리된다() async throws {
+        // given: 같은 모델·같은 프로세스에서 두 개의 stack을 다른 URL로
+        let urlA = tempDirectory.appendingPathComponent("UserA.sqlite")
+        let urlB = tempDirectory.appendingPathComponent("UserB.sqlite")
+        let stackA = CoreDataStack(storeURL: urlA)
+        let stackB = CoreDataStack(storeURL: urlB)
+        let repoA = MemoRepositoryImpl(stack: stackA)
+        let repoB = MemoRepositoryImpl(stack: stackB)
+
+        // when: A에만 메모 생성
+        _ = try await repoA.createNewMemo()
+
+        // then: A에는 1개, B에는 0개
+        let inA = try await repoA.getAllMemos()
+        let inB = try await repoB.getAllMemos()
+        XCTAssertEqual(inA.count, 1)
+        XCTAssertTrue(inB.isEmpty, "다른 stack에는 A의 메모가 보이면 안 된다.")
+    }
+}


### PR DESCRIPTION
## 배경
- 멀티 Apple ID 환경에서의 사용자 간 데이터 격리를 위한 선행 인프라 리팩터링의 첫 sub-phase.
- 최종 목표: 사용자별 별도 `.sqlite` 파일 분리. 이번 PR은 그 기반이 되는 `CoreDataStack`의 URL 파라미터화만 담당.

## 변경사항
- `CoreDataStack.init`에 `storeURL: URL?` 파라미터 추가
  - `nil`(기본값)이면 기존 동작 그대로 — Core Data 기본 위치 사용
  - 명시하면 해당 위치에 SQLite 파일 생성·열기
  - `inMemory`와 동시 지정 시 `inMemory` 우선, `storeURL` 무시
- `CoreDataStackTests` 신설
  - 커스텀 URL 지정 시 해당 위치에 파일이 생성되는지 검증
  - 서로 다른 URL의 두 stack이 데이터 격리되는지 회귀 테스트

## 테스트 방법
- `tuist test` 전체 통과 확인
- 동작 변화 없음 (기존 호출부는 모두 `inMemory:` 또는 인자 없음 형태라 영향 없음)

## 리뷰 노트
- 이번 PR은 *부모 디렉터리 자동 생성을 하지 않습니다* — 호출자가 보장해야 함. 사용자별 store 경로 계산·디렉터리 생성은 후속 sub-phase C에서 추가.
- 사용자별 데이터 격리 인프라(전체 sub-phase A~G) 중 첫 단계. 각 sub-phase가 독립 PR로 진행될 예정이며, 이번 PR이 머지돼도 앱 동작은 동일.
- 이미 main에 있는 Firebase 동기화 SDK / Sign in with Apple capability는 어떤 타겟도 link하지 않아 binary에 포함되지 않음 — 다음 출시는 현재 main 그대로 빌드해도 사용자 입장에서 직전 출시와 동일하게 동작.