### PR TITLE
refactor(domain): CurrentUserIDProvider 프로토콜 및 익명 default 구현 추가

### DIFF
--- a/Projects/Domain/Sources/Identity/CurrentUserIDProvider.swift
+++ b/Projects/Domain/Sources/Identity/CurrentUserIDProvider.swift
@@ -1,0 +1,39 @@
+//
+//  CurrentUserIDProvider.swift
+//  NoteCard
+//
+
+import Combine
+import Foundation
+
+/// 현재 로그인된 사용자의 ID를 노출하는 추상화.
+///
+/// Auth SDK(예: Firebase Auth)와 Data 레이어 사이의 의존 방향을 끊기 위한 통로.
+/// Data 레이어(저장소 분리 코디네이터 등)는 *누가 어떻게* 로그인을 처리하는지 모르고,
+/// 이 프로토콜을 통해 "현재 사용자 ID" 정보만 받는다.
+public protocol CurrentUserIDProvider: AnyObject, Sendable {
+
+    /// 현재 사용자 ID. `nil`이면 로그아웃(익명) 상태.
+    var currentUserID: String? { get }
+
+    /// 사용자 ID 변경 스트림. 구독 시점에 현재 값을 즉시 emit하고,
+    /// 이후 사용자 변경(로그인·로그아웃·계정 전환)마다 새 값을 emit한다. 완료 신호 없음.
+    var currentUserIDPublisher: AnyPublisher<String?, Never> { get }
+}
+
+/// 인증 기능이 연결되기 전이거나, 사용자가 한 번도 로그인하지 않은 환경에서 쓰는 default 구현.
+///
+/// 항상 `nil`을 반환하고 publisher는 nil을 한 번 emit한 채 유지된다.
+/// 실제 인증 연동은 후속 PR(Auth 인프라 적용 시점)에 별도 구현체로 교체된다.
+public final class AnonymousUserIDProvider: CurrentUserIDProvider, @unchecked Sendable {
+
+    private let subject = CurrentValueSubject<String?, Never>(nil)
+
+    public init() {}
+
+    public var currentUserID: String? { subject.value }
+
+    public var currentUserIDPublisher: AnyPublisher<String?, Never> {
+        subject.eraseToAnyPublisher()
+    }
+}

--- a/Projects/Domain/Tests/CurrentUserIDProviderTests.swift
+++ b/Projects/Domain/Tests/CurrentUserIDProviderTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+import Combine
+@testable import Domain
+
+/// `AnonymousUserIDProvider`가 익명(미로그인) 상태의 default 동작을 충족하는지 검증.
+final class CurrentUserIDProviderTests: XCTestCase {
+
+    func test_anonymous_provider의_currentUserID는_nil이다() {
+        let provider = AnonymousUserIDProvider()
+        XCTAssertNil(provider.currentUserID)
+    }
+
+    func test_anonymous_provider의_publisher는_구독_즉시_nil을_emit한다() {
+        // given
+        let provider = AnonymousUserIDProvider()
+
+        // when
+        var didReceive = false
+        var receivedValue: String?
+        let cancellable = provider.currentUserIDPublisher.sink { value in
+            didReceive = true
+            receivedValue = value
+        }
+        defer { cancellable.cancel() }
+
+        // then
+        XCTAssertTrue(didReceive, "CurrentValueSubject 기반이므로 구독 즉시 값을 받아야 한다.")
+        XCTAssertNil(receivedValue)
+    }
+}


### PR DESCRIPTION
## 배경
- 멀티 Apple ID 환경에서의 사용자 간 데이터 격리 인프라(A~G)의 sub-phase B.
- Auth SDK와 Data 레이어 사이의 의존 방향을 끊기 위한 통로 추상화. Data 레이어는 *누가 어떻게* 로그인을 처리하는지 모르고, 이 프로토콜을 통해 "현재 사용자 ID"만 받는다.

## 변경사항
- Domain 모듈에 `Identity/CurrentUserIDProvider.swift` 신설
  - `CurrentUserIDProvider` 프로토콜 — `currentUserID: String?`, `currentUserIDPublisher: AnyPublisher<String?, Never>`
  - `AnonymousUserIDProvider` 클래스 — 항상 nil 반환, publisher는 `CurrentValueSubject` 기반으로 nil을 한 번 emit한 채 유지
- `CurrentUserIDProviderTests` 신설 — `AnonymousUserIDProvider` 동작 회귀 테스트 2종

## 테스트 방법
- `tuist test` 전체 통과 확인
- 동작 변화 없음 — 이번 PR은 새 abstraction만 추가, 어떤 호출부도 아직 사용하지 않음

## 리뷰 노트
- 실제 Firebase Auth 연동 구현체는 후속 PR(Auth 인프라 적용 시점)에서 별도 모듈로 추가될 예정. 그때 이 프로토콜을 채택하고 `AppEnvironment`가 익명 → 실 구현체로 교체.
- 다음 sub-phase C는 이 provider를 받아 사용자별 store를 vending하는 `UserScopedDataLayer` 코디네이터.
- 사용자별 데이터 격리 sub-phase A~G 중 B. A(#31) 머지 완료.