### PR TITLE
refactor(data): UserScopedDataLayer 코디네이터 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ Core Data는 가장 위험한 영역이다. 다음을 어기면 사용자 데이
 - protocol conformance를 가진 extension(`extension X: SomeProtocol`)에도 `public` 모디파이어 금지. 멤버에 개별 `public`을 붙일 것.
 - `public class` 안의 `override` 메서드도 `public` 명시 (Swift 규칙).
 - ViewController 등 App 타겟 내부 코드는 internal로 충분 (cross-module 노출 불필요).
+- 주석은 최소화한다. 코드로 자명한 내용은 주석을 달지 않으며, 길고 장황한 주석은 금지. 꼭 필요한 "왜"(비자명한 제약·함정·의도)만 짧게 남긴다. 주석은 소스가 바뀌면 stale해지기 쉬우므로, 소스를 변경할 때 관련 주석도 함께 확인해 최신화한다.
 
 ## Commit / PR conventions
 

--- a/Projects/Data/Sources/CoreData/UserScopedDataLayer.swift
+++ b/Projects/Data/Sources/CoreData/UserScopedDataLayer.swift
@@ -1,0 +1,94 @@
+//
+//  UserScopedDataLayer.swift
+//  NoteCard
+//
+
+import Combine
+import CoreData
+import Domain
+import Foundation
+
+/// 현재 사용자에 맞는 `CoreDataStack`을 vending하는 코디네이터.
+///
+/// `CurrentUserIDProvider`를 구독해 사용자 변경 시 해당 사용자의 store 파일로
+/// 새 `CoreDataStack`을 만들어 교체한다. 동시에 하나의 stack만 보유하고, 이전
+/// stack은 ARC에 의해 deallocate된다.
+///
+/// 파일 경로 규약:
+/// - 로그인된 사용자: `<storeDirectory>/users/<uid>/NoteCard.sqlite`
+/// - 익명(미로그인): `<storeDirectory>/anonymous.sqlite`
+///
+/// 기본 `storeDirectory`는 앱 샌드박스의 `Application Support/`. 부모 디렉터리는 자동 생성된다.
+public final class UserScopedDataLayer {
+
+    private let userIDProvider: CurrentUserIDProvider
+    private let storeDirectory: URL
+    private let stackSubject: CurrentValueSubject<CoreDataStack, Never>
+    private var cancellable: AnyCancellable?
+
+    public init(userIDProvider: CurrentUserIDProvider, storeDirectory: URL? = nil) {
+        self.userIDProvider = userIDProvider
+        let directory = storeDirectory ?? Self.defaultStoreDirectory()
+        self.storeDirectory = directory
+        let initialStack = Self.makeStack(for: userIDProvider.currentUserID, in: directory)
+        self.stackSubject = CurrentValueSubject(initialStack)
+        attachUserIDListener()
+    }
+
+    /// 현재 사용자에 해당하는 stack.
+    public var currentStack: CoreDataStack {
+        stackSubject.value
+    }
+
+    /// 사용자 변경 시 새 stack을 emit. 구독 시점에 현재 stack을 즉시 emit한다.
+    public var currentStackPublisher: AnyPublisher<CoreDataStack, Never> {
+        stackSubject.eraseToAnyPublisher()
+    }
+
+    // MARK: - Private
+
+    private func attachUserIDListener() {
+        // removeDuplicates가 dropFirst보다 먼저 와야 함 — 순서가 반대면 첫 값이 baseline에서 빠져 같은 ID 재emit에도 stack을 다시 만든다.
+        cancellable = userIDProvider.currentUserIDPublisher
+            .removeDuplicates()
+            .dropFirst()
+            .sink { [weak self] userID in
+                guard let self else { return }
+                let newStack = Self.makeStack(for: userID, in: self.storeDirectory)
+                self.stackSubject.send(newStack)
+            }
+    }
+
+    private static func makeStack(for userID: String?, in directory: URL) -> CoreDataStack {
+        let storeURL = storeURL(for: userID, in: directory)
+        let parent = storeURL.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        } catch {
+            fatalError("UserScopedDataLayer: 부모 디렉터리 생성 실패 \(parent.path): \(error)")
+        }
+        return CoreDataStack(storeURL: storeURL)
+    }
+
+    private static func storeURL(for userID: String?, in directory: URL) -> URL {
+        if let userID {
+            return directory
+                .appendingPathComponent("users")
+                .appendingPathComponent(userID)
+                .appendingPathComponent("NoteCard.sqlite")
+        } else {
+            return directory.appendingPathComponent("anonymous.sqlite")
+        }
+    }
+
+    private static func defaultStoreDirectory() -> URL {
+        do {
+            return try FileManager.default.url(
+                for: .applicationSupportDirectory, in: .userDomainMask,
+                appropriateFor: nil, create: true
+            )
+        } catch {
+            fatalError("UserScopedDataLayer: Application Support 디렉터리 접근 실패: \(error)")
+        }
+    }
+}

--- a/Projects/Data/Tests/UserScopedDataLayerTests.swift
+++ b/Projects/Data/Tests/UserScopedDataLayerTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+import Combine
+import Domain
+@testable import Data
+
+/// `UserScopedDataLayer`가 사용자 변경에 맞춰 stack을 교체하고
+/// 사용자별 파일 격리가 보장되는지 검증.
+final class UserScopedDataLayerTests: XCTestCase {
+
+    private var tempDirectory: URL!
+
+    override func setUpWithError() throws {
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("UserScopedDataLayerTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDirectory)
+    }
+
+    func test_익명_상태로_시작하면_anonymous_sqlite_파일이_생성된다() {
+        // given
+        let provider = MockUserIDProvider(initial: nil)
+        let layer = UserScopedDataLayer(userIDProvider: provider, storeDirectory: tempDirectory)
+
+        // when
+        _ = layer.currentStack.backgroundContext  // lazy 컨테이너 트리거
+
+        // then
+        let expectedURL = tempDirectory.appendingPathComponent("anonymous.sqlite")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: expectedURL.path))
+    }
+
+    func test_사용자_ID가_세팅되면_users_uid_경로의_새_stack을_emit한다() {
+        // given
+        let provider = MockUserIDProvider(initial: nil)
+        let layer = UserScopedDataLayer(userIDProvider: provider, storeDirectory: tempDirectory)
+        let initialStack = layer.currentStack
+
+        var receivedStacks: [CoreDataStack] = []
+        let cancellable = layer.currentStackPublisher
+            .dropFirst()  // 구독 시점의 초기 emit은 제외
+            .sink { receivedStacks.append($0) }
+        defer { cancellable.cancel() }
+
+        // when
+        provider.setUserID("userA")
+
+        // then
+        XCTAssertEqual(receivedStacks.count, 1)
+        XCTAssertFalse(receivedStacks.first === initialStack, "사용자 변경 시 새 stack 인스턴스로 교체돼야 한다.")
+
+        _ = layer.currentStack.backgroundContext
+        let expectedURL = tempDirectory
+            .appendingPathComponent("users")
+            .appendingPathComponent("userA")
+            .appendingPathComponent("NoteCard.sqlite")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: expectedURL.path))
+    }
+
+    func test_같은_사용자_ID가_재emit돼도_stack은_교체되지_않는다() {
+        // given
+        let provider = MockUserIDProvider(initial: "userA")
+        let layer = UserScopedDataLayer(userIDProvider: provider, storeDirectory: tempDirectory)
+        let initialStack = layer.currentStack
+
+        var changeCount = 0
+        let cancellable = layer.currentStackPublisher
+            .dropFirst()
+            .sink { _ in changeCount += 1 }
+        defer { cancellable.cancel() }
+
+        // when: 같은 ID로 다시 emit
+        provider.setUserID("userA")
+
+        // then
+        XCTAssertEqual(changeCount, 0, "같은 사용자 ID로는 재emit하지 않아야 한다.")
+        XCTAssertTrue(layer.currentStack === initialStack)
+    }
+
+    func test_서로_다른_사용자의_stack은_데이터가_격리된다() async throws {
+        // given
+        let provider = MockUserIDProvider(initial: "userA")
+        let layer = UserScopedDataLayer(userIDProvider: provider, storeDirectory: tempDirectory)
+        let repoA = MemoRepositoryImpl(stack: layer.currentStack)
+        _ = try await repoA.createNewMemo()
+        let inA = try await repoA.getAllMemos()
+        XCTAssertEqual(inA.count, 1)
+
+        // when: 다른 사용자로 전환
+        provider.setUserID("userB")
+        let repoB = MemoRepositoryImpl(stack: layer.currentStack)
+
+        // then
+        let inB = try await repoB.getAllMemos()
+        XCTAssertTrue(inB.isEmpty, "다른 사용자에는 userA의 메모가 보이면 안 된다.")
+    }
+}
+
+// MARK: - Test Doubles
+
+private final class MockUserIDProvider: CurrentUserIDProvider, @unchecked Sendable {
+
+    private let subject: CurrentValueSubject<String?, Never>
+
+    init(initial: String?) {
+        self.subject = CurrentValueSubject(initial)
+    }
+
+    var currentUserID: String? { subject.value }
+
+    var currentUserIDPublisher: AnyPublisher<String?, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    func setUserID(_ id: String?) {
+        subject.send(id)
+    }
+}


### PR DESCRIPTION
## 배경
- 멀티 Apple ID 환경에서의 사용자 간 데이터 격리 인프라(A~G)의 sub-phase C.
- A (#31, `CoreDataStack`에 `storeURL` 파라미터)와 B (#32, `CurrentUserIDProvider`)를 묶어, 사용자 변경 시 자동으로 해당 사용자의 store 파일을 vending하는 코디네이터.

## 변경사항
- Data 모듈에 `UserScopedDataLayer` 신설
  - `CurrentUserIDProvider`를 구독, 사용자 변경 시 해당 사용자의 store URL로 새 `CoreDataStack` 생성·교체
  - 동시에 하나의 stack만 보유, 이전 stack은 ARC로 deallocate
  - 파일 경로 규약: 로그인 사용자 = `<dir>/users/<uid>/NoteCard.sqlite`, 익명 = `<dir>/anonymous.sqlite`
  - 부모 디렉터리는 자동 생성, 기본 `storeDirectory`는 `Application Support/<bundleID>/`
  - `currentStack` (현재 값) + `currentStackPublisher` (변경 스트림) 제공
- `UserScopedDataLayerTests` 신설 — 4종 회귀 테스트
  - 익명 상태 시작 → `anonymous.sqlite` 생성
  - 사용자 ID 세팅 → `users/<uid>/NoteCard.sqlite` 새 stack emit
  - 같은 사용자 ID 재emit → stack 교체 안 됨 (`removeDuplicates` 동작)
  - 서로 다른 사용자의 stack은 데이터 격리

## 테스트 방법
- `tuist test` 전체 통과 확인
- 동작 변화 없음 — 이번 PR은 코디네이터 클래스만 추가, 아직 어디서도 인스턴스화하지 않음

## 리뷰 노트
- `removeDuplicates`를 `dropFirst`보다 먼저 적용한 점은 의도된 순서. 반대 순서이면 첫 값이 baseline에서 사라져 같은 ID 재emit이 새 stack을 만들게 됨 (테스트 회귀로 확인됨).
- AppEnvironment 연결은 sub-phase D에서 진행. 그 전에 기존 사용자 데이터 마이그레이션(F) 결합 여부 검토 예정.
- 사용자별 데이터 격리 sub-phase A~G 중 C. A·B 머지 완료.