### PR TITLE
feat(data): 사용자별 store 마이그레이션 + UserScopedDataLayer 연결 (F+D)

### DIFF
--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -23,8 +23,19 @@ struct AppEnvironment {
     let imageRepository: ImageRepository
     let analytics: Analytics
 
+    private let dataLayer: UserScopedDataLayer
+
     init() {
-        let coreDataStack = CoreDataStack()
+        // 인증 인프라는 별도 브랜치라 현재는 익명 사용자만 존재한다.
+        let userIDProvider = AnonymousUserIDProvider()
+
+        // 데이터 레이어가 익명 store를 열기 전에 레거시 데이터를 이전한다 (1회, 멱등).
+        LegacyStoreMigrator.migrateIfNeeded(anonymousStoreURL: UserScopedDataLayer.anonymousStoreURL())
+
+        let dataLayer = UserScopedDataLayer(userIDProvider: userIDProvider)
+        self.dataLayer = dataLayer
+
+        let coreDataStack = dataLayer.currentStack
         self.coreDataStack = coreDataStack
         let memoRepository = MemoRepositoryImpl(stack: coreDataStack)
         self.memoRepository = memoRepository

--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -30,7 +30,12 @@ struct AppEnvironment {
         let userIDProvider = AnonymousUserIDProvider()
 
         // 데이터 레이어가 익명 store를 열기 전에 레거시 데이터를 이전한다 (1회, 멱등).
-        LegacyStoreMigrator.migrateIfNeeded(anonymousStoreURL: UserScopedDataLayer.anonymousStoreURL())
+        // 실패 시 Debug 빌드에선 즉시 trap, Release 빌드에선 no-op이 되어 다음 실행에 재시도된다.
+        // TODO: Crashlytics non-fatal로 prod 가시성 확보 — onError 클로저는 그 의존성 주입을 위한 자리.
+        LegacyStoreMigrator.migrateIfNeeded(
+            anonymousStoreURL: UserScopedDataLayer.anonymousStoreURL(),
+            onError: { error in assertionFailure("LegacyStoreMigrator 실패: \(error)") }
+        )
 
         let dataLayer = UserScopedDataLayer(userIDProvider: userIDProvider)
         self.dataLayer = dataLayer

--- a/Projects/Data/Sources/CoreData/LegacyStoreMigrator.swift
+++ b/Projects/Data/Sources/CoreData/LegacyStoreMigrator.swift
@@ -39,7 +39,12 @@ public enum LegacyStoreMigrator {
                 type: .sqlite
             )
             userDefaults.set(true, forKey: migrationFlagKey)
+            // destroy로 store를 정상 해제한 뒤, 잔여 파일(.sqlite/-wal/-shm)을 명시적으로 삭제.
+            // destroyPersistentStore만으로는 파일이 남는 경우가 있어 직접 제거한다.
             try? coordinator.destroyPersistentStore(at: legacyURL, type: .sqlite, options: nil)
+            for suffix in ["", "-wal", "-shm"] {
+                try? FileManager.default.removeItem(atPath: legacyURL.path + suffix)
+            }
         } catch {
             // 실패 시 플래그를 세우지 않아 다음 실행에 재시도한다. 원본은 레거시 store에 그대로 남는다.
         }

--- a/Projects/Data/Sources/CoreData/LegacyStoreMigrator.swift
+++ b/Projects/Data/Sources/CoreData/LegacyStoreMigrator.swift
@@ -15,7 +15,8 @@ public enum LegacyStoreMigrator {
     public static func migrateIfNeeded(
         legacyStoreURL: URL? = nil,
         anonymousStoreURL: URL,
-        userDefaults: UserDefaults = .standard
+        userDefaults: UserDefaults = .standard,
+        onError: (Error) -> Void = { _ in }
     ) {
         guard !userDefaults.bool(forKey: migrationFlagKey) else { return }
 
@@ -46,7 +47,8 @@ public enum LegacyStoreMigrator {
                 try? FileManager.default.removeItem(atPath: legacyURL.path + suffix)
             }
         } catch {
-            // 실패 시 플래그를 세우지 않아 다음 실행에 재시도한다. 원본은 레거시 store에 그대로 남는다.
+            // 플래그 미설정 상태로 두어 다음 실행에 재시도. 원본은 레거시 store에 그대로 남는다.
+            onError(error)
         }
     }
 

--- a/Projects/Data/Sources/CoreData/LegacyStoreMigrator.swift
+++ b/Projects/Data/Sources/CoreData/LegacyStoreMigrator.swift
@@ -1,0 +1,62 @@
+//
+//  LegacyStoreMigrator.swift
+//  NoteCard
+//
+
+import CoreData
+import Foundation
+
+/// 레거시 기본 위치의 store를 익명 store(`anonymous.sqlite`)로 1회 멱등 이전한다.
+/// 데이터 레이어가 익명 store를 열기 전에 호출해야 한다.
+public enum LegacyStoreMigrator {
+
+    static let migrationFlagKey = "didMigrateLegacyStoreToAnonymous"
+
+    public static func migrateIfNeeded(
+        legacyStoreURL: URL? = nil,
+        anonymousStoreURL: URL,
+        userDefaults: UserDefaults = .standard
+    ) {
+        guard !userDefaults.bool(forKey: migrationFlagKey) else { return }
+
+        let legacyURL = legacyStoreURL ?? defaultLegacyStoreURL()
+        guard FileManager.default.fileExists(atPath: legacyURL.path) else {
+            userDefaults.set(true, forKey: migrationFlagKey)
+            return
+        }
+
+        do {
+            let coordinator = try makeCoordinator()
+            try FileManager.default.createDirectory(
+                at: anonymousStoreURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try coordinator.replacePersistentStore(
+                at: anonymousStoreURL,
+                destinationOptions: nil,
+                withPersistentStoreFrom: legacyURL,
+                sourceOptions: nil,
+                type: .sqlite
+            )
+            userDefaults.set(true, forKey: migrationFlagKey)
+            try? coordinator.destroyPersistentStore(at: legacyURL, type: .sqlite, options: nil)
+        } catch {
+            // 실패 시 플래그를 세우지 않아 다음 실행에 재시도한다. 원본은 레거시 store에 그대로 남는다.
+        }
+    }
+
+    private static func defaultLegacyStoreURL() -> URL {
+        NSPersistentContainer.defaultDirectoryURL()
+            .appendingPathComponent("NoteCardCoreData.sqlite")
+    }
+
+    private static func makeCoordinator() throws -> NSPersistentStoreCoordinator {
+        guard
+            let modelURL = DataResources.bundle.url(forResource: "NoteCardCoreData", withExtension: "momd"),
+            let model = NSManagedObjectModel(contentsOf: modelURL)
+        else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        return NSPersistentStoreCoordinator(managedObjectModel: model)
+    }
+}

--- a/Projects/Data/Sources/CoreData/UserScopedDataLayer.swift
+++ b/Projects/Data/Sources/CoreData/UserScopedDataLayer.swift
@@ -45,6 +45,11 @@ public final class UserScopedDataLayer {
         stackSubject.eraseToAnyPublisher()
     }
 
+    /// 익명(미로그인) 사용자의 store 위치. 레거시 마이그레이션 목적지 등 외부에서 경로가 필요할 때.
+    public static func anonymousStoreURL() -> URL {
+        storeURL(for: nil, in: defaultStoreDirectory())
+    }
+
     // MARK: - Private
 
     private func attachUserIDListener() {

--- a/Projects/Data/Tests/LegacyStoreMigratorTests.swift
+++ b/Projects/Data/Tests/LegacyStoreMigratorTests.swift
@@ -73,6 +73,45 @@ final class LegacyStoreMigratorTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: legacy2.path), "재실행이 무시되었으므로 legacy2는 destroy되지 않아야 한다.")
     }
 
+    func test_마이그레이션_성공시_레거시_store_파일들이_삭제된다() async throws {
+        let legacyURL = tempDir.appendingPathComponent("NoteCardCoreData.sqlite")
+        let anonymousURL = tempDir.appendingPathComponent("anonymous.sqlite")
+        try await createStore(memoCount: 1, at: legacyURL)
+
+        LegacyStoreMigrator.migrateIfNeeded(
+            legacyStoreURL: legacyURL,
+            anonymousStoreURL: anonymousURL,
+            userDefaults: defaults
+        )
+
+        // destroyPersistentStore가 .sqlite 및 사이드카(-wal, -shm)까지 정리해야 함
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path + "-wal"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path + "-shm"))
+        // 이전 결과는 익명 store에 남아있어야 함
+        XCTAssertTrue(FileManager.default.fileExists(atPath: anonymousURL.path))
+    }
+
+    func test_마이그레이션_실패시_익명_store는_안_만들어지고_레거시가_보존된다() async throws {
+        let legacyURL = tempDir.appendingPathComponent("NoteCardCoreData.sqlite")
+        try await createStore(memoCount: 1, at: legacyURL)
+
+        // 목적지 부모 경로 중간에 '파일'을 끼워 디렉터리 생성을 불가능하게 만들어 마이그레이션을 실패시킨다.
+        let fileBlocker = tempDir.appendingPathComponent("notadir")
+        try Data().write(to: fileBlocker)
+        let anonymousURL = fileBlocker.appendingPathComponent("sub").appendingPathComponent("anonymous.sqlite")
+
+        LegacyStoreMigrator.migrateIfNeeded(
+            legacyStoreURL: legacyURL,
+            anonymousStoreURL: anonymousURL,
+            userDefaults: defaults
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: anonymousURL.path), "실패 시 익명 store를 만들면 안 된다.")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: legacyURL.path), "실패 시 레거시 원본은 보존돼야 한다.")
+        XCTAssertFalse(defaults.bool(forKey: LegacyStoreMigrator.migrationFlagKey), "실패 시 플래그 미설정으로 다음 실행에 재시도 가능해야 한다.")
+    }
+
     // MARK: - Helpers
 
     private func createStore(memoCount: Int, at url: URL) async throws {
@@ -80,6 +119,11 @@ final class LegacyStoreMigratorTests: XCTestCase {
         let repo = MemoRepositoryImpl(stack: stack)
         for _ in 0..<memoCount {
             _ = try await repo.createNewMemo()
+        }
+        // 프로덕션에선 마이그레이션 시점에 레거시 store가 닫혀 있다. 테스트도 동일하게 닫아준다.
+        let coordinator = stack.persistentContainer.persistentStoreCoordinator
+        for store in coordinator.persistentStores {
+            try coordinator.remove(store)
         }
     }
 

--- a/Projects/Data/Tests/LegacyStoreMigratorTests.swift
+++ b/Projects/Data/Tests/LegacyStoreMigratorTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+import CoreData
+import Domain
+@testable import Data
+
+/// `LegacyStoreMigrator`가 레거시 store를 익명 store로 1회 멱등하게 이전하는지 검증.
+final class LegacyStoreMigratorTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LegacyStoreMigratorTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        suiteName = "LegacyStoreMigratorTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    func test_레거시가_있으면_익명_store로_이전되고_데이터가_보존된다() async throws {
+        let legacyURL = tempDir.appendingPathComponent("NoteCardCoreData.sqlite")
+        let anonymousURL = tempDir.appendingPathComponent("anonymous.sqlite")
+        try await createStore(memoCount: 1, at: legacyURL)
+
+        LegacyStoreMigrator.migrateIfNeeded(
+            legacyStoreURL: legacyURL,
+            anonymousStoreURL: anonymousURL,
+            userDefaults: defaults
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: anonymousURL.path))
+        let count = try await memoCount(at: anonymousURL)
+        XCTAssertEqual(count, 1)
+        XCTAssertTrue(defaults.bool(forKey: LegacyStoreMigrator.migrationFlagKey))
+    }
+
+    func test_레거시가_없으면_익명_store를_만들지_않고_플래그만_설정한다() {
+        let legacyURL = tempDir.appendingPathComponent("NoteCardCoreData.sqlite") // 존재하지 않음
+        let anonymousURL = tempDir.appendingPathComponent("anonymous.sqlite")
+
+        LegacyStoreMigrator.migrateIfNeeded(
+            legacyStoreURL: legacyURL,
+            anonymousStoreURL: anonymousURL,
+            userDefaults: defaults
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: anonymousURL.path))
+        XCTAssertTrue(defaults.bool(forKey: LegacyStoreMigrator.migrationFlagKey))
+    }
+
+    func test_이미_마이그레이션됐으면_재실행해도_익명_데이터를_덮어쓰지_않는다() async throws {
+        let anonymousURL = tempDir.appendingPathComponent("anonymous.sqlite")
+
+        // 1차: 메모 1개짜리 레거시 이전
+        let legacy1 = tempDir.appendingPathComponent("NoteCardCoreData.sqlite")
+        try await createStore(memoCount: 1, at: legacy1)
+        LegacyStoreMigrator.migrateIfNeeded(legacyStoreURL: legacy1, anonymousStoreURL: anonymousURL, userDefaults: defaults)
+
+        // 2차: 메모 2개짜리 새 레거시로 재실행 — 플래그가 set이라 무시돼야 함
+        let legacy2 = tempDir.appendingPathComponent("legacy2.sqlite")
+        try await createStore(memoCount: 2, at: legacy2)
+        LegacyStoreMigrator.migrateIfNeeded(legacyStoreURL: legacy2, anonymousStoreURL: anonymousURL, userDefaults: defaults)
+
+        // 익명에는 여전히 1개 (legacy2의 2개로 덮이지 않음)
+        let count = try await memoCount(at: anonymousURL)
+        XCTAssertEqual(count, 1)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: legacy2.path), "재실행이 무시되었으므로 legacy2는 destroy되지 않아야 한다.")
+    }
+
+    // MARK: - Helpers
+
+    private func createStore(memoCount: Int, at url: URL) async throws {
+        let stack = CoreDataStack(storeURL: url)
+        let repo = MemoRepositoryImpl(stack: stack)
+        for _ in 0..<memoCount {
+            _ = try await repo.createNewMemo()
+        }
+    }
+
+    private func memoCount(at url: URL) async throws -> Int {
+        let stack = CoreDataStack(storeURL: url)
+        let repo = MemoRepositoryImpl(stack: stack)
+        return try await repo.getAllMemos().count
+    }
+}


### PR DESCRIPTION
## 배경
- 사용자별 데이터 격리 인프라(A~G)의 sub-phase **F+D**. 둘은 원자적으로 묶여 같은 릴리스에 함께 나가야 함 (한쪽만 출시 시 기존 사용자 데이터 손실).
- D: Repository가 `UserScopedDataLayer.currentStack`을 쓰도록 전환 → 익명 사용자 데이터가 `anonymous.sqlite`로 이동.
- F: 그 전환으로 기존 사용자가 데이터를 잃지 않도록, 레거시 `NoteCardCoreData.sqlite`를 `anonymous.sqlite`로 마이그레이션.

## 변경사항
- **F — LegacyStoreMigrator (신설)**
  - 레거시 기본 위치 `Application Support/NoteCardCoreData.sqlite` → `anonymous.sqlite`로 1회 이전
  - `UserDefaults` 플래그로 멱등 보장 (정확히 한 번 실행). 실패 시 플래그 미설정 → 다음 실행 재시도 (데이터는 레거시에 안전)
  - `replacePersistentStore(type: .sqlite)`로 WAL/SHM 사이드카까지 안전 이전, `destroyPersistentStore`로 옛 파일 정리
  - `UserScopedDataLayer.anonymousStoreURL()` 노출 — 목적지 경로 single source
- **D — AppEnvironment 전환**
  - `CoreDataStack()` 직접 생성 → `UserScopedDataLayer.currentStack` 사용
  - 데이터 레이어 초기화 *전에* 마이그레이션 실행 (Repository 접근 시점엔 이전 완료 보장)
  - 현재는 익명 사용자만(인증 인프라는 별도 브랜치) → `AnonymousUserIDProvider`
  - `coreDataStack` 속성은 현재 stack을 그대로 노출해 기존 호출부(HomeVC context 관찰, SceneDelegate saveContext) 호환 유지

## 테스트 방법
- `tuist test` 전체 통과 (LegacyStoreMigratorTests 3종 포함 — 이전·보존 / 레거시 없음 / 멱등 재실행)
- **⚠️ 수동 업그레이드 테스트 권장 (기존 사용자 데이터 영향)**:
  1. 이전 버전(main 직전) 설치 → 메모·이미지 여러 개 생성
  2. 이 브랜치 빌드로 덮어 설치 (시뮬레이터에서 같은 bundle id로)
  3. 첫 실행 후 메모·이미지가 그대로 보이는지 확인
  4. Xcode "Download Container"로 `anonymous.sqlite` 존재 + 레거시 파일 정리 확인

## 리뷰 노트
- 이미지 파일(`Documents/<memoUUID>/`)은 건드리지 않음 — memo UUID로 연결돼 store 위치와 무관하게 따라옴 (의도된 동작).
- 이 PR이 다음 주 릴리스에 나가는 마이그레이션. 인증 인프라는 별도 브랜치에서 그 다음 사이클에 적용 예정.
- 사용자 변경 시 stack 교체(동적 전환)는 미포함 — 인증·로그인 UI가 들어오는 후속 단계(E)에서 처리. 현재는 익명 단일 사용자라 stack이 바뀔 일이 없음.