### PR TITLE
feat(sync): AuthService 인프라 + UserIDProvider 어댑터

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,15 @@ Core Data는 가장 위험한 영역이다. 다음을 어기면 사용자 데이
 ## Naming gotchas
 
 - ObjC runtime의 `Category` typedef와 충돌하므로 도메인 모델 `Category`는 호출부에서 **`Domain.Category`로 명시**한다. 새 코드에도 동일 규칙.
-- Localization 호출은 `"key".localized()` 형태. 기본 bundle이 `SharedResources.bundle`이므로 다른 모듈에 자체 xcstrings를 두면 `bundle:` 인자를 명시 전달.
+
+## Localization
+
+- **사용자에게 노출되는 모든 문구·문자열은 반드시 localization을 적용한다.** UI 라벨, 알럿/토스트, 에러 메시지(`LocalizedError.errorDescription` 포함), accessibility label, placeholder까지 모두 해당. 한국어/영어 하드코딩 금지.
+- 키는 `Projects/Core/Shared/Sources/Localization/L10n.swift`에 type-safe하게 등록하고, 번역은 `Projects/Core/Shared/Resources/Localizable.xcstrings`에 영어·한국어 둘 다 추가. 신규 키 추가 시 두 언어 모두 채울 것.
+- 호출은 `L10n.<group>.<name>` 형태 권장 (compile-time safe). 직접 `"key".localized()`도 가능하지만 신규 키는 L10n에 등록한다.
+- 기본 lookup bundle은 `SharedResources.bundle`. 다른 모듈에 자체 xcstrings를 두는 특수한 경우만 `bundle:` 인자 명시.
+- L10n을 사용하는 Domain·Core 모듈은 `.module(.shared)`를 dependencies에 추가 (예: `SyncInterface`).
+- 사용자 친화적 톤: 기술 용어(Firebase, OAuth, credential, UUID 등) 직접 노출 금지. "왜 안 되는지" 대신 "다음에 어떻게 할 수 있는지"를 안내하는 문장으로.
 
 ## Code conventions
 

--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -8,6 +8,8 @@ import Data
 import Domain
 import AnalyticsInterface
 import AnalyticsImpl
+import SyncInterface
+import SyncImpl
 
 /// 앱 전체에서 공유되는 의존성 묶음.
 ///
@@ -22,6 +24,7 @@ struct AppEnvironment {
     let categoryRepository: CategoryRepository
     let imageRepository: ImageRepository
     let analytics: Analytics
+    let authService: AuthService
 
     private let dataLayer: UserScopedDataLayer
 
@@ -47,6 +50,9 @@ struct AppEnvironment {
         self.categoryRepository = CategoryRepositoryImpl(stack: coreDataStack)
         self.imageRepository = ImageRepositoryImpl(stack: coreDataStack, memoRepository: memoRepository)
         self.analytics = Self.setUpAnalytics()
+        // FirebaseApp.configure()는 setUpAnalytics 안에서 (plist가 있을 때만) 호출됨.
+        // SyncBootstrap이 FirebaseApp.app() 존재 여부를 보고 Firebase/No-op 구현을 고른다.
+        self.authService = SyncBootstrap.makeAuthService()
     }
 
     /// Crashlytics를 켜고(가능하면) Amplitude 기반 `Analytics`를 만든다.

--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -29,8 +29,15 @@ struct AppEnvironment {
     private let dataLayer: UserScopedDataLayer
 
     init() {
-        // 인증 인프라는 별도 브랜치라 현재는 익명 사용자만 존재한다.
-        let userIDProvider = AnonymousUserIDProvider()
+        // FirebaseApp.configure()는 setUpAnalytics 안에서 (plist가 있을 때만) 호출됨.
+        // SyncBootstrap이 FirebaseApp.app() 존재 여부를 보고 Firebase/No-op 구현을 고른다.
+        self.analytics = Self.setUpAnalytics()
+        let authService = SyncBootstrap.makeAuthService()
+        self.authService = authService
+
+        // AuthService의 인증 상태를 CurrentUserIDProvider 형태로 어댑팅.
+        // 로그인/로그아웃에 따라 UserScopedDataLayer가 사용자별 stack으로 자동 교체한다.
+        let userIDProvider = AuthServiceUserIDProvider(authService: authService)
 
         // 데이터 레이어가 익명 store를 열기 전에 레거시 데이터를 이전한다 (1회, 멱등).
         // 실패 시 Debug 빌드에선 즉시 trap, Release 빌드에선 no-op이 되어 다음 실행에 재시도된다.
@@ -49,10 +56,6 @@ struct AppEnvironment {
         self.memoRepository = memoRepository
         self.categoryRepository = CategoryRepositoryImpl(stack: coreDataStack)
         self.imageRepository = ImageRepositoryImpl(stack: coreDataStack, memoRepository: memoRepository)
-        self.analytics = Self.setUpAnalytics()
-        // FirebaseApp.configure()는 setUpAnalytics 안에서 (plist가 있을 때만) 호출됨.
-        // SyncBootstrap이 FirebaseApp.app() 존재 여부를 보고 Firebase/No-op 구현을 고른다.
-        self.authService = SyncBootstrap.makeAuthService()
     }
 
     /// Crashlytics를 켜고(가능하면) Amplitude 기반 `Analytics`를 만든다.

--- a/Project.swift
+++ b/Project.swift
@@ -62,6 +62,8 @@ let appDependencies: [TargetDependency] = [
     .project(target: "Data", path: .relativeToRoot("Projects/Data")),
     .project(target: "AnalyticsInterface", path: .relativeToRoot("Projects/Core/AnalyticsInterface")),
     .project(target: "AnalyticsImpl", path: .relativeToRoot("Projects/Core/AnalyticsImpl")),
+    .project(target: "SyncInterface", path: .relativeToRoot("Projects/Core/SyncInterface")),
+    .project(target: "SyncImpl", path: .relativeToRoot("Projects/Core/SyncImpl")),
     .project(target: "SettingsFeature", path: .relativeToRoot("Projects/Feature/SettingsFeature")),
 ]
 

--- a/Projects/Core/Shared/Resources/Localizable.xcstrings
+++ b/Projects/Core/Shared/Resources/Localizable.xcstrings
@@ -1718,6 +1718,74 @@
         }
       }
     },
+    "sync.auth.cancelled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign-in cancelled."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인이 취소되었어요."
+          }
+        }
+      }
+    },
+    "sync.auth.invalidCredential": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't verify your Apple sign-in. Please try again in a moment."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple 로그인 정보를 확인할 수 없었어요. 잠시 후 다시 시도해주세요."
+          }
+        }
+      }
+    },
+    "sync.auth.unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync isn't available right now. Please try again later."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지금은 동기화 기능을 사용할 수 없어요. 잠시 후 다시 시도해주세요."
+          }
+        }
+      }
+    },
+    "sync.auth.unknown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Something went wrong while signing in. Please try again."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인 중 문제가 발생했어요. 잠시 후 다시 시도해주세요."
+          }
+        }
+      }
+    },
     "tabBar.home": {
       "extractionState": "manual",
       "localizations": {

--- a/Projects/Core/Shared/Sources/Localization/L10n.swift
+++ b/Projects/Core/Shared/Sources/Localization/L10n.swift
@@ -126,6 +126,15 @@ public enum L10n {
         public static let format12h = "settings.format12h".localized()
     }
 
+    public enum Sync {
+        public enum Auth {
+            public static let cancelled = "sync.auth.cancelled".localized()
+            public static let invalidCredential = "sync.auth.invalidCredential".localized()
+            public static let unavailable = "sync.auth.unavailable".localized()
+            public static let unknown = "sync.auth.unknown".localized()
+        }
+    }
+
     public enum ThemeColor {
         public static let blackWhite = "themeColor.blackWhite".localized()
         public static let brown = "themeColor.brown".localized()

--- a/Projects/Core/SyncImpl/Project.swift
+++ b/Projects/Core/SyncImpl/Project.swift
@@ -8,6 +8,7 @@ let project = Project.module(
     resources: nil,
     dependencies: [
         .module(.syncInterface),
+        .module(.domain),
         .external(name: "FirebaseAuth"),
     ]
 )

--- a/Projects/Core/SyncImpl/Project.swift
+++ b/Projects/Core/SyncImpl/Project.swift
@@ -1,0 +1,13 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.module(
+    .syncImpl,
+    product: .staticFramework,
+    sources: ["Sources/**"],
+    resources: nil,
+    dependencies: [
+        .module(.syncInterface),
+        .external(name: "FirebaseAuth"),
+    ]
+)

--- a/Projects/Core/SyncImpl/Sources/AuthServiceUserIDProvider.swift
+++ b/Projects/Core/SyncImpl/Sources/AuthServiceUserIDProvider.swift
@@ -1,0 +1,32 @@
+//
+//  AuthServiceUserIDProvider.swift
+//  NoteCard
+//
+
+import Combine
+import Domain
+import Foundation
+import SyncInterface
+
+/// `AuthService`의 인증 상태를 Data 레이어가 쓰는 `CurrentUserIDProvider` 형태로 노출하는 어댑터.
+/// Data ↔ Sync 간 직접 의존을 끊고 composition root에서만 연결한다.
+public final class AuthServiceUserIDProvider: CurrentUserIDProvider, @unchecked Sendable {
+
+    private let subject: CurrentValueSubject<String?, Never>
+    private var cancellable: AnyCancellable?
+
+    public init(authService: AuthService) {
+        self.subject = CurrentValueSubject(authService.currentUser?.id)
+        self.cancellable = authService.authStatePublisher
+            .map { $0?.id }
+            .sink { [weak self] userID in
+                self?.subject.send(userID)
+            }
+    }
+
+    public var currentUserID: String? { subject.value }
+
+    public var currentUserIDPublisher: AnyPublisher<String?, Never> {
+        subject.eraseToAnyPublisher()
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/FirebaseAuthService.swift
+++ b/Projects/Core/SyncImpl/Sources/FirebaseAuthService.swift
@@ -1,0 +1,213 @@
+//
+//  FirebaseAuthService.swift
+//  NoteCard
+//
+
+import AuthenticationServices
+import Combine
+import CryptoKit
+import FirebaseAuth
+import Foundation
+import SyncInterface
+import UIKit
+
+/// Firebase Auth 기반 `AuthService` 구현. Sign in with Apple을 단일 인증 수단으로 사용.
+///
+/// 동작 개요:
+/// - `Auth.auth().addStateDidChangeListener`로 인증 상태 변경을 구독해 `CurrentValueSubject`에 흘림.
+/// - Sign-in 흐름은 `ASAuthorizationController`의 delegate 패턴을 `CheckedContinuation`으로 async 래핑.
+/// - Apple `fullName`은 첫 sign-in에만 제공되므로 그때 Firebase `displayName`으로 영구 저장.
+public final class FirebaseAuthService: NSObject, AuthService, @unchecked Sendable {
+
+    private let authStateSubject = CurrentValueSubject<AuthUser?, Never>(nil)
+    private var stateHandle: AuthStateDidChangeListenerHandle?
+
+    // ASAuthorizationController delegate 콜백을 async로 잇기 위한 상태.
+    // 동시에 하나의 sign-in만 진행한다고 가정 (UI 흐름상 자연스러움).
+    private var currentNonce: String?
+    private var signInContinuation: CheckedContinuation<AuthUser, Error>?
+
+    public override init() {
+        super.init()
+        attachAuthStateListener()
+    }
+
+    deinit {
+        if let handle = stateHandle {
+            Auth.auth().removeStateDidChangeListener(handle)
+        }
+    }
+
+    public var currentUser: AuthUser? {
+        authStateSubject.value
+    }
+
+    public var authStatePublisher: AnyPublisher<AuthUser?, Never> {
+        authStateSubject.eraseToAnyPublisher()
+    }
+
+    public func signInWithApple() async throws -> AuthUser {
+        try await withCheckedThrowingContinuation { continuation in
+            self.signInContinuation = continuation
+
+            let nonce = Self.randomNonceString()
+            self.currentNonce = nonce
+
+            let provider = ASAuthorizationAppleIDProvider()
+            let request = provider.createRequest()
+            request.requestedScopes = [.fullName, .email]
+            request.nonce = Self.sha256(nonce)
+
+            let controller = ASAuthorizationController(authorizationRequests: [request])
+            controller.delegate = self
+            controller.presentationContextProvider = self
+            controller.performRequests()
+        }
+    }
+
+    public func signOut() async throws {
+        try Auth.auth().signOut()
+    }
+
+    public func deleteAccount() async throws {
+        guard let user = Auth.auth().currentUser else {
+            throw AuthError.invalidCredential
+        }
+        try await user.delete()
+    }
+
+    // MARK: - Private
+
+    private func attachAuthStateListener() {
+        stateHandle = Auth.auth().addStateDidChangeListener { [weak self] _, user in
+            guard let self else { return }
+            self.authStateSubject.send(user.map(Self.toAuthUser))
+        }
+    }
+
+    private static func toAuthUser(_ user: User) -> AuthUser {
+        AuthUser(id: user.uid, displayName: user.displayName, email: user.email)
+    }
+
+    /// Apple sign-in 보안용 random nonce 생성. (Apple 권장 패턴)
+    private static func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: [Character] = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remaining = length
+
+        while remaining > 0 {
+            let randoms: [UInt8] = (0..<16).map { _ in
+                var random: UInt8 = 0
+                let code = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if code != errSecSuccess { fatalError("SecRandomCopyBytes failed: \(code)") }
+                return random
+            }
+            for random in randoms where remaining > 0 {
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remaining -= 1
+                }
+            }
+        }
+        return result
+    }
+
+    private static func sha256(_ input: String) -> String {
+        SHA256.hash(data: Data(input.utf8))
+            .compactMap { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    private func resumeSignIn(returning user: AuthUser) {
+        signInContinuation?.resume(returning: user)
+        signInContinuation = nil
+        currentNonce = nil
+    }
+
+    private func resumeSignIn(throwing error: Error) {
+        signInContinuation?.resume(throwing: error)
+        signInContinuation = nil
+        currentNonce = nil
+    }
+}
+
+// MARK: - ASAuthorizationControllerDelegate
+
+extension FirebaseAuthService: ASAuthorizationControllerDelegate {
+
+    public func authorizationController(controller: ASAuthorizationController,
+                                        didCompleteWithAuthorization authorization: ASAuthorization) {
+        guard
+            let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
+            let nonce = currentNonce,
+            let tokenData = appleIDCredential.identityToken,
+            let idToken = String(data: tokenData, encoding: .utf8)
+        else {
+            resumeSignIn(throwing: AuthError.invalidCredential)
+            return
+        }
+
+        // fullName은 첫 sign-in에만 옴. 이후 sign-in에선 nil → Firebase displayName에 영구 저장.
+        let credential = OAuthProvider.appleCredential(
+            withIDToken: idToken,
+            rawNonce: nonce,
+            fullName: appleIDCredential.fullName
+        )
+
+        Auth.auth().signIn(with: credential) { [weak self] authResult, error in
+            guard let self else { return }
+            if let error {
+                self.resumeSignIn(throwing: error)
+                return
+            }
+            guard let user = authResult?.user else {
+                self.resumeSignIn(throwing: AuthError.invalidCredential)
+                return
+            }
+            self.persistDisplayNameIfNeeded(appleCredential: appleIDCredential, user: user) {
+                self.resumeSignIn(returning: Self.toAuthUser(Auth.auth().currentUser ?? user))
+            }
+        }
+    }
+
+    public func authorizationController(controller: ASAuthorizationController,
+                                        didCompleteWithError error: Error) {
+        if let asError = error as? ASAuthorizationError, asError.code == .canceled {
+            resumeSignIn(throwing: AuthError.cancelled)
+        } else {
+            resumeSignIn(throwing: AuthError.unknown(error))
+        }
+    }
+
+    private func persistDisplayNameIfNeeded(appleCredential: ASAuthorizationAppleIDCredential,
+                                            user: User,
+                                            completion: @escaping () -> Void) {
+        guard
+            user.displayName == nil,
+            let nameComponents = appleCredential.fullName
+        else {
+            completion()
+            return
+        }
+        let fullName = PersonNameComponentsFormatter().string(from: nameComponents)
+        guard !fullName.isEmpty else {
+            completion()
+            return
+        }
+        let change = user.createProfileChangeRequest()
+        change.displayName = fullName
+        change.commitChanges { _ in completion() }
+    }
+}
+
+// MARK: - ASAuthorizationControllerPresentationContextProviding
+
+extension FirebaseAuthService: ASAuthorizationControllerPresentationContextProviding {
+
+    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        UIApplication.shared.connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.windows.first(where: { $0.isKeyWindow }) }
+            .first ?? ASPresentationAnchor()
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/NoOpAuthService.swift
+++ b/Projects/Core/SyncImpl/Sources/NoOpAuthService.swift
@@ -1,0 +1,34 @@
+//
+//  NoOpAuthService.swift
+//  NoteCard
+//
+
+import Combine
+import Foundation
+import SyncInterface
+
+/// 동기화를 비활성화하는 no-op 구현.
+///
+/// Firebase 설정(`GoogleService-Info.plist`)이 없는 환경(CI 빌드, 미설정 등)에서
+/// `SyncBootstrap`이 fallback으로 사용한다. 모든 인증 요청은 `missingFirebase` 에러로 거부.
+public final class NoOpAuthService: AuthService, @unchecked Sendable {
+    public init() {}
+
+    public var currentUser: AuthUser? { nil }
+
+    public var authStatePublisher: AnyPublisher<AuthUser?, Never> {
+        Empty(completeImmediately: false).eraseToAnyPublisher()
+    }
+
+    public func signInWithApple() async throws -> AuthUser {
+        throw AuthError.missingFirebase
+    }
+
+    public func signOut() async throws {
+        // no-op
+    }
+
+    public func deleteAccount() async throws {
+        throw AuthError.missingFirebase
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
+++ b/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
@@ -1,0 +1,29 @@
+//
+//  SyncBootstrap.swift
+//  NoteCard
+//
+
+import Foundation
+import FirebaseCore
+import SyncInterface
+
+/// 동기화 SDK 조립 지점. App composition root에서 호출한다.
+///
+/// `FirebaseApp.configure()`는 분석 부트스트랩(`AnalyticsBootstrap.startCrashReporting`)에서
+/// 먼저 수행되어 있어야 한다. 설정이 없으면 No-op 구현이 반환되어 앱은 정상 동작하되
+/// 동기화만 비활성된다.
+public enum SyncBootstrap {
+
+    /// FirebaseApp 설정이 완료돼 있으면 Firebase 기반 `AuthService`를, 아니면 No-op 구현을 반환.
+    public static func makeAuthService() -> AuthService {
+        guard FirebaseApp.app() != nil else {
+            return NoOpAuthService()
+        }
+        return FirebaseAuthService()
+    }
+
+    /// 명시적으로 No-op 구현을 만들고 싶을 때 (테스트·프리뷰 등).
+    public static func makeNoOpAuthService() -> AuthService {
+        NoOpAuthService()
+    }
+}

--- a/Projects/Core/SyncInterface/Project.swift
+++ b/Projects/Core/SyncInterface/Project.swift
@@ -6,5 +6,7 @@ let project = Project.module(
     product: .staticFramework,
     sources: ["Sources/**"],
     resources: nil,
-    dependencies: []
+    dependencies: [
+        .module(.shared),
+    ]
 )

--- a/Projects/Core/SyncInterface/Project.swift
+++ b/Projects/Core/SyncInterface/Project.swift
@@ -1,0 +1,10 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.module(
+    .syncInterface,
+    product: .staticFramework,
+    sources: ["Sources/**"],
+    resources: nil,
+    dependencies: []
+)

--- a/Projects/Core/SyncInterface/Sources/AuthService.swift
+++ b/Projects/Core/SyncInterface/Sources/AuthService.swift
@@ -5,6 +5,7 @@
 
 import Combine
 import Foundation
+import Shared
 
 /// 외부 인증 SDK(Firebase Auth) 통합 지점 추상화.
 /// 구현체는 별도 모듈(SyncImpl)에 두고, App composition root에서만 인스턴스를 만들어 의존 주입한다.
@@ -40,6 +41,9 @@ public struct AuthUser: Sendable, Equatable {
 }
 
 /// 인증 관련 에러.
+///
+/// `errorDescription`은 사용자에게 직접 보여줘도 무방한 친화적 문구(`L10n.Sync.Auth.*`)를 반환.
+/// 내부 진단·로깅 용도는 case 자체(예: `.missingFirebase`)나 연관된 `unknown(Error)`을 직접 참조.
 public enum AuthError: LocalizedError {
     case cancelled
     case invalidCredential
@@ -48,10 +52,10 @@ public enum AuthError: LocalizedError {
 
     public var errorDescription: String? {
         switch self {
-        case .cancelled:         return "사용자가 로그인을 취소했습니다."
-        case .invalidCredential: return "Apple 자격 증명이 유효하지 않습니다."
-        case .missingFirebase:   return "Firebase 설정이 없어 동기화 기능을 사용할 수 없습니다."
-        case .unknown(let err):  return err.localizedDescription
+        case .cancelled:         return L10n.Sync.Auth.cancelled
+        case .invalidCredential: return L10n.Sync.Auth.invalidCredential
+        case .missingFirebase:   return L10n.Sync.Auth.unavailable
+        case .unknown:           return L10n.Sync.Auth.unknown
         }
     }
 }

--- a/Projects/Core/SyncInterface/Sources/AuthService.swift
+++ b/Projects/Core/SyncInterface/Sources/AuthService.swift
@@ -1,0 +1,57 @@
+//
+//  AuthService.swift
+//  NoteCard
+//
+
+import Combine
+import Foundation
+
+/// 외부 인증 SDK(Firebase Auth) 통합 지점 추상화.
+/// 구현체는 별도 모듈(SyncImpl)에 두고, App composition root에서만 인스턴스를 만들어 의존 주입한다.
+public protocol AuthService: AnyObject, Sendable {
+
+    /// 현재 로그인된 사용자. nil이면 로그아웃 상태.
+    var currentUser: AuthUser? { get }
+
+    /// 인증 상태 변경 스트림. 로그인·로그아웃 모두 반영.
+    var authStatePublisher: AnyPublisher<AuthUser?, Never> { get }
+
+    /// Sign in with Apple로 로그인. 시스템 시트를 띄우고 완료 시 AuthUser를 반환.
+    func signInWithApple() async throws -> AuthUser
+
+    /// 로그아웃. 클라우드 데이터는 유지되고 이 기기의 동기화만 멈춤.
+    func signOut() async throws
+
+    /// 계정 및 모든 클라우드 데이터를 삭제 (PIPA 권리 행사).
+    func deleteAccount() async throws
+}
+
+/// 인증된 사용자 정보. 동기화 사용자 식별에 사용.
+public struct AuthUser: Sendable, Equatable {
+    public let id: String        // Firebase UID
+    public let displayName: String?
+    public let email: String?
+
+    public init(id: String, displayName: String?, email: String?) {
+        self.id = id
+        self.displayName = displayName
+        self.email = email
+    }
+}
+
+/// 인증 관련 에러.
+public enum AuthError: LocalizedError {
+    case cancelled
+    case invalidCredential
+    case missingFirebase
+    case unknown(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .cancelled:         return "사용자가 로그인을 취소했습니다."
+        case .invalidCredential: return "Apple 자격 증명이 유효하지 않습니다."
+        case .missingFirebase:   return "Firebase 설정이 없어 동기화 기능을 사용할 수 없습니다."
+        case .unknown(let err):  return err.localizedDescription
+        }
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/ModulePaths.swift
+++ b/Tuist/ProjectDescriptionHelpers/ModulePaths.swift
@@ -21,6 +21,8 @@ public enum Module: String {
     case shared             = "Shared"
     case analyticsInterface = "AnalyticsInterface"
     case analyticsImpl      = "AnalyticsImpl"
+    case syncInterface      = "SyncInterface"
+    case syncImpl           = "SyncImpl"
     case homeFeature        = "HomeFeature"
     case memoFeature        = "MemoFeature"
     case settingsFeature    = "SettingsFeature"
@@ -29,7 +31,7 @@ public enum Module: String {
         switch self {
         case .domain: return .domain
         case .data:   return .data
-        case .designSystem, .shared, .analyticsInterface, .analyticsImpl:
+        case .designSystem, .shared, .analyticsInterface, .analyticsImpl, .syncInterface, .syncImpl:
             return .core
         case .homeFeature, .memoFeature, .settingsFeature:
             return .feature


### PR DESCRIPTION
## 배경
- 메모 동기화 v1을 위한 인증 인프라 도입. Sign in with Apple + Firebase Auth.
- 본 PR 단독으론 사용자 가시 변화 없음 — 진입 UI(사인인 버튼 등)는 후속.
- 다음 단계(Repository 재구성 + 사인인 UI)가 같은 `AppEnvironment.swift`를 또 건드릴 예정이라, 충돌 누적 방지 차원에서 현재까지 작업을 먼저 머지.

## 변경사항
- SyncInterface 모듈 신설 (Core 레이어)
  - `AuthService` 프로토콜, `AuthUser` 값 타입, `AuthError`
- SyncImpl 모듈 신설 (Core 레이어, FirebaseAuth 의존)
  - `FirebaseAuthService` — Sign in with Apple + Firebase Auth 통합
    - `ASAuthorizationController` delegate를 `CheckedContinuation`으로 async 래핑
    - random nonce + SHA256 (Apple 권장 보안 패턴)
    - 첫 sign-in의 fullName을 Firebase displayName으로 영구 저장
  - `NoOpAuthService` — Firebase 미설정 환경 fallback
  - `SyncBootstrap` — `FirebaseApp.app()` 존재 여부로 구현체 선택
- `AuthServiceUserIDProvider` 어댑터
  - `AuthService.authStatePublisher` → `CurrentUserIDProvider` 형태로 노출
  - Auth ↔ Data 직접 의존 차단 (composition root에서만 연결)
- AppEnvironment 연결
  - `authService: AuthService` 속성 추가
  - `AnonymousUserIDProvider` → `AuthServiceUserIDProvider`로 교체
  - init 순서 재정렬 (analytics → authService → userIDProvider → dataLayer)
- AuthError 사용자 노출 문구 localization
  - `L10n.Sync.Auth.*` 키 + Localizable.xcstrings 한국어/영어 등록
  - 기술 용어(Firebase, credential 등) 직접 노출 제거
- AGENTS.md
  - Localization 섹션 신설 — 사용자 노출 문구 하드코딩 금지 규칙

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- `tuist test` 전체 통과 확인
- 수동: 앱 실행 → 기존 메모/카테고리/이미지가 정상 표시되는지 확인 (`anonymous.sqlite` 사용 흐름이 그대로여야 함)

## 리뷰 노트
- **사용자 동작 영향 0**: 사인인 UI가 없어 `authService.currentUser`는 항상 `nil` → `AuthServiceUserIDProvider`도 `nil` emit → `UserScopedDataLayer`는 `anonymous.sqlite` 고수.
- **후속 작업 예정**:
  - Repository 재구성: 현재 `AppEnvironment`가 init 시점 stack을 capture하므로, 로그인/로그아웃 시 stack 교체가 화면에 반영되지 않음. 사인인 UI 작업과 묶어서 해결 예정.
  - 익명 → 로그인 첫 전환 시 데이터 정책 결정 필요 (anonymous 데이터 이전 vs 격리).
  - 사인인 UI / 온보딩 변화 / 계정 센터는 별도 트랙으로 디자인 후 진행.
- Firebase Auth init 자체는 PR #30에서 이미 main에 진입한 상태 — 본 PR이 SDK를 새로 깨우지 않음.