### PR TITLE
refactor(data): Repository를 stack-aware lookup으로 전환

### DIFF
--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -19,7 +19,6 @@ import SyncImpl
 /// Combine publisher 이벤트도 화면 간에 끊김 없이 전달된다.
 struct AppEnvironment {
 
-    let coreDataStack: CoreDataStack
     let memoRepository: MemoRepository
     let categoryRepository: CategoryRepository
     let imageRepository: ImageRepository
@@ -27,6 +26,9 @@ struct AppEnvironment {
     let authService: AuthService
 
     private let dataLayer: UserScopedDataLayer
+
+    /// 현재 사용자에 해당하는 Core Data stack. 사용자 변경 시점에 dataLayer가 새 stack으로 교체한다.
+    var coreDataStack: CoreDataStack { dataLayer.currentStack }
 
     init() {
         // FirebaseApp.configure()는 setUpAnalytics 안에서 (plist가 있을 때만) 호출됨.
@@ -50,12 +52,10 @@ struct AppEnvironment {
         let dataLayer = UserScopedDataLayer(userIDProvider: userIDProvider)
         self.dataLayer = dataLayer
 
-        let coreDataStack = dataLayer.currentStack
-        self.coreDataStack = coreDataStack
-        let memoRepository = MemoRepositoryImpl(stack: coreDataStack)
+        let memoRepository = MemoRepositoryImpl(dataLayer: dataLayer)
         self.memoRepository = memoRepository
-        self.categoryRepository = CategoryRepositoryImpl(stack: coreDataStack)
-        self.imageRepository = ImageRepositoryImpl(stack: coreDataStack, memoRepository: memoRepository)
+        self.categoryRepository = CategoryRepositoryImpl(dataLayer: dataLayer)
+        self.imageRepository = ImageRepositoryImpl(dataLayer: dataLayer, memoRepository: memoRepository)
     }
 
     /// Crashlytics를 켜고(가능하면) Amplitude 기반 `Analytics`를 만든다.

--- a/Projects/Data/Sources/Repositories/CategoryRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/CategoryRepositoryImpl.swift
@@ -14,12 +14,21 @@ public protocol ComparableValue: Comparable {}
 extension String: ComparableValue {}
 extension Date: ComparableValue {}
 
-public actor CategoryRepositoryImpl: CategoryRepository {
-    
-    private let context: NSManagedObjectContext
+public final class CategoryRepositoryImpl: CategoryRepository, @unchecked Sendable {
 
-    public init(stack: CoreDataStack) {
-        self.context = stack.backgroundContext
+    private let stackResolver: () -> CoreDataStack
+
+    private var context: NSManagedObjectContext {
+        stackResolver().backgroundContext
+    }
+
+    public init(dataLayer: UserScopedDataLayer) {
+        self.stackResolver = { dataLayer.currentStack }
+    }
+
+    /// 단일 stack을 들고 사용자 변경에 반응하지 않는 테스트 편의 init.
+    internal init(stack: CoreDataStack) {
+        self.stackResolver = { stack }
     }
     
     private func categoryNameEqual(to name: String) -> NSPredicate {

--- a/Projects/Data/Sources/Repositories/ImageRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/ImageRepositoryImpl.swift
@@ -13,24 +13,36 @@ import PhotosUI
 import UIKit
 import UniformTypeIdentifiers
 
-public actor ImageRepositoryImpl: ImageRepository {
-    
-    private let context: NSManagedObjectContext
+public final class ImageRepositoryImpl: ImageRepository, @unchecked Sendable {
+
+    private let stackResolver: () -> CoreDataStack
     private let memoRepository: MemoRepositoryImpl
 
-    public init(stack: CoreDataStack, memoRepository: MemoRepositoryImpl) {
-        self.context = stack.backgroundContext
-        self.memoRepository = memoRepository
+    private var context: NSManagedObjectContext {
+        stackResolver().backgroundContext
     }
-    
+
     // MARK: - Subjects, Publisher
-    
-    nonisolated private let imageUpdatedSubject = PassthroughSubject<ImageUpdateType, Never>()
-    public nonisolated var imageUpdatedPublisher: AnyPublisher<ImageUpdateType, Never> {
+
+    private let imageUpdatedSubject = PassthroughSubject<ImageUpdateType, Never>()
+    public var imageUpdatedPublisher: AnyPublisher<ImageUpdateType, Never> {
         imageUpdatedSubject.eraseToAnyPublisher()
     }
-    private var cancellables = Set<AnyCancellable>()
-    
+
+    // MARK: - Init
+
+    public init(dataLayer: UserScopedDataLayer, memoRepository: MemoRepositoryImpl) {
+        self.stackResolver = { dataLayer.currentStack }
+        self.memoRepository = memoRepository
+    }
+
+    /// 단일 stack을 들고 사용자 변경에 반응하지 않는 테스트 편의 init.
+    internal init(stack: CoreDataStack, memoRepository: MemoRepositoryImpl) {
+        self.stackResolver = { stack }
+        self.memoRepository = memoRepository
+    }
+
+
     public func createImage(
         from pickerResult: PHPickerResult,
         for memo: Memo,
@@ -44,7 +56,7 @@ public actor ImageRepositoryImpl: ImageRepository {
         let thumbnailData = try ImageFileHandler.createThumbnailData(from: originalData)
         
         // MemoEntity 불러오기(후에 ImageEntity에서 생성자의 매개변수로 넣기 위함)
-        let memoEntity = try await memoRepository.fetchMemoEntity(id: memo.memoID)
+        let memoEntity = try memoRepository.fetchMemoEntity(id: memo.memoID)
         
         let createdMemoInfo =  try await context.perform { [unowned self] in
             // 코어데이터에 저장할 데이터

--- a/Projects/Data/Sources/Repositories/MemoRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/MemoRepositoryImpl.swift
@@ -27,26 +27,44 @@ public enum MemoEntityError: LocalizedError {
     
 }
 
-public actor MemoRepositoryImpl: MemoRepository {
-    
-    private let context: NSManagedObjectContext
+public final class MemoRepositoryImpl: MemoRepository, @unchecked Sendable {
 
-    public init(stack: CoreDataStack) {
-        self.context = stack.backgroundContext
+    private let stackResolver: () -> CoreDataStack
+
+    private var context: NSManagedObjectContext {
+        stackResolver().backgroundContext
     }
-    
+
+    // MARK: - Subjects, Publisher
+
+    private let memoUpdatedSubject = PassthroughSubject<MemoUpdateType, Never>()
+    public var memoUpdatedPublisher: AnyPublisher<MemoUpdateType, Never> {
+        memoUpdatedSubject.eraseToAnyPublisher()
+    }
+
+    // MARK: - Init
+
+    public init(dataLayer: UserScopedDataLayer) {
+        self.stackResolver = { dataLayer.currentStack }
+    }
+
+    /// 단일 stack을 들고 사용자 변경에 반응하지 않는 테스트 편의 init.
+    internal init(stack: CoreDataStack) {
+        self.stackResolver = { stack }
+    }
+
     @UserDefault<String>(key: .orderCriterion, defaultValue: OrderCriterion.modificationDate.rawValue)
     private var orderCriterion: String
-    
+
     @UserDefault<Bool>(key: .isOrderAscending, defaultValue: false)
     private var isOrderAscending: Bool
-    
+
     // MARK: - Predicates
-    
+
     private let isFavorite = NSPredicate(format: "isFavorite == true")
     private let notDeleted = NSPredicate(format: "isInTrash == false")
     private let deleted = NSPredicate(format: "isInTrash == true")
-    
+
     private func memoIDEquals(to id: UUID) -> NSPredicate {
         return NSPredicate(format: "memoID == %@", id as CVarArg)
     }
@@ -65,13 +83,6 @@ public actor MemoRepositoryImpl: MemoRepository {
         } else {
             return NSPredicate(format: "categories.@count == 0")
         }
-    }
-    
-    // MARK: - Subjects, Publisher
-    
-    nonisolated private let memoUpdatedSubject = PassthroughSubject<MemoUpdateType, Never>()
-    public nonisolated var memoUpdatedPublisher: AnyPublisher<MemoUpdateType, Never> {
-        memoUpdatedSubject.eraseToAnyPublisher()
     }
 }
 

--- a/Projects/Data/Tests/UserScopedDataLayerTests.swift
+++ b/Projects/Data/Tests/UserScopedDataLayerTests.swift
@@ -83,14 +83,14 @@ final class UserScopedDataLayerTests: XCTestCase {
         // given
         let provider = MockUserIDProvider(initial: "userA")
         let layer = UserScopedDataLayer(userIDProvider: provider, storeDirectory: tempDirectory)
-        let repoA = MemoRepositoryImpl(stack: layer.currentStack)
+        let repoA = MemoRepositoryImpl(dataLayer: layer)
         _ = try await repoA.createNewMemo()
         let inA = try await repoA.getAllMemos()
         XCTAssertEqual(inA.count, 1)
 
         // when: 다른 사용자로 전환
         provider.setUserID("userB")
-        let repoB = MemoRepositoryImpl(stack: layer.currentStack)
+        let repoB = MemoRepositoryImpl(dataLayer: layer)
 
         // then
         let inB = try await repoB.getAllMemos()

--- a/Projects/Domain/Sources/Models/Category.swift
+++ b/Projects/Domain/Sources/Models/Category.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Shared
 
-public struct Category: Hashable {
+public struct Category: Hashable, Sendable {
     public var name: String
     public let creationDate: Date
     public var modificationDate: Date

--- a/Projects/Domain/Sources/Models/Memo.swift
+++ b/Projects/Domain/Sources/Models/Memo.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Shared
 
-public struct Memo: Hashable {
+public struct Memo: Hashable, Sendable {
     public let memoID: UUID
     public let creationDate: Date
     public var modificationDate: Date

--- a/Projects/Domain/Sources/Models/MemoImageInfo.swift
+++ b/Projects/Domain/Sources/Models/MemoImageInfo.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Shared
 
-public struct MemoImageInfo: Hashable {
+public struct MemoImageInfo: Hashable, Sendable {
     public let id: UUID
     public let thumbnailID: UUID
     public var temporaryOrderIndex: Int


### PR DESCRIPTION
## 배경
- 사용자별 데이터 격리 인프라 후속 작업. 사용자 변경(로그인/로그아웃) 시 Repository가 새 store의 context를 자동으로 보도록 lookup 구조로 전환.
- AppEnvironment의 Repository는 init 시점에 stack을 한 번 capture했기 때문에, 사용자가 바뀌어도 옛 stack을 계속 봤음. 이 PR로 그 한계를 풂.

## 변경사항
- Repository 3종(`MemoRepositoryImpl` / `CategoryRepositoryImpl` / `ImageRepositoryImpl`)을 `actor`에서 `final class`로 전환
  - actor 격리가 보호할 mutable state가 사실상 없어 격리의 실효가 없는 상태였음. `NSManagedObjectContext.perform`이 이미 진짜 격리를 담당
- `stackResolver: () -> CoreDataStack` 클로저로 매 메서드 호출 시점에 현재 stack의 backgroundContext를 lookup
  - `public init(dataLayer:)` — `UserScopedDataLayer.currentStack`을 따라감
  - `internal init(stack:)` — 단일 stack을 고정해 사용자 변경에 반응하지 않음. 기존 테스트와의 호환용
- `AppEnvironment`
  - Repository 3종을 `dataLayer` init으로 생성하도록 전환
  - `coreDataStack`을 stored let 대신 `dataLayer.currentStack`을 lookup하는 computed property로 변경 (외부 사용처: `HomeViewController`, `SceneDelegate`)
- `Memo` / `Category` / `MemoImageInfo` struct에 `Sendable` 채택
  - actor 제거로 cross-isolation 매개변수 전달 경고가 노출됨. 모든 멤버가 stdlib Sendable이라 한 줄 채택으로 해소
- `ImageRepositoryImpl`의 `memoRepository.fetchMemoEntity` 호출에서 불필요해진 `await` 제거
- `UserScopedDataLayerTests`에서 Repository 생성 라벨을 `dataLayer:`로 갱신

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- `tuist test` 전체 통과 확인
- 수동: 앱 실행 → 기존 메모/카테고리/이미지가 정상 표시되는지 확인 (anonymous.sqlite 사용 흐름이 그대로여야 함)

## 리뷰 노트
- **사용자 동작 영향 0**: 현재 사인인 UI가 없어 stack 교체 이벤트가 발생하지 않음. 익명 단일 stack 흐름에서 기존 PR과 동작 동일.
- **`internal init(stack:)`의 의도**: actor 제거로 모든 테스트의 `MemoRepositoryImpl(stack:)` 호출이 깨지는 걸 피하기 위한 호환 init. 단일 stack을 고정해 사용자 변경에 반응하지 않음. prod 코드에서 호출하면 stack-aware 동작이 비활성되니 주의.
- **사용자 변경 시 화면 reload 트리거는 의도적으로 *제외***: stackResolver는 사용자 변경 시 다음 메서드 호출부터 새 store를 보지만, ViewController가 이미 들고 있는 데이터의 reload는 별도 신호가 있어야 함. 그 신호는 본격 sync 작업 시점에 `UserScopedDataLayer.currentStackPublisher`를 ViewController가 직접 구독하는 형태로 도입 예정 (메모 publisher에 사용자 변경 case를 섞으면 의미가 흐려져 일부러 분리).
- 남은 Sendable 경고 2종 (이번 PR 범위 밖): `Shared.CategoryProperties` enum 미채택, `ImageRepositoryImpl`의 `MemoEntity`(NSManagedObject) 클로저 캡처. 후자는 본질적 비-Sendable이라 별도 작업 필요.