### PR TITLE
chore(fastlane): beta lane에 Crashlytics dSYM 자동 업로드 추가

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,6 +49,17 @@ def ensure_xcodeproj_generated
   sh("cd .. && tuist install && tuist generate --no-open")
 end
 
+# Locate the upload-symbols binary that SwiftPM checks out under DerivedData
+# when firebase-ios-sdk is resolved. build_app must have run first.
+def find_swiftpm_upload_symbols
+  glob = File.expand_path(
+    "~/Library/Developer/Xcode/DerivedData/**/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols"
+  )
+  binary = Dir.glob(glob).find { |p| File.executable?(p) }
+  UI.user_error!("upload-symbols not found under DerivedData. Run build_app first so SwiftPM resolves firebase-ios-sdk.") unless binary
+  binary
+end
+
 platform :ios do
   before_all do
     # On CI, create a temporary keychain for code signing.
@@ -148,6 +159,12 @@ platform :ios do
           "com.minsung.NoteCard" => "match AppStore com.minsung.NoteCard"
         }
       }
+    )
+
+    upload_symbols_to_crashlytics(
+      binary_path: find_swiftpm_upload_symbols,
+      dsym_path: "./build/NoteCard.app.dSYM.zip",
+      gsp_path: "./NoteCard/GoogleService-Info.plist"
     )
 
     upload_to_testflight(


### PR DESCRIPTION
## 배경
- v2.3.0부터 Firebase Crashlytics 도입 상태이나 dSYM 자동 업로드 경로가 없어 크래시 로그 심볼리케이션 불가.
- Archive를 GitHub Actions에서 수행하므로 로컬에서 수동 추출/업로드 불가능 — CI 파이프라인 내에서 자동화 필요.

## 변경사항
- `find_swiftpm_upload_symbols` 헬퍼 추가 — DerivedData의 SwiftPM checkout에서 `firebase-ios-sdk/Crashlytics/upload-symbols` 바이너리를 글롭으로 탐색.
- `beta` lane의 `build_app` 직후, `upload_to_testflight` 전에 `upload_symbols_to_crashlytics` 단계 삽입.
- 별도 바이너리 커밋 없이 SwiftPM이 받은 파일을 그대로 사용 — Firebase SDK 버전 업데이트 시 자동 동기화.

## 테스트 방법
- 머지 후 다음 주간 release 워크플로 실행 시 fastlane 로그에서 `upload_symbols_to_crashlytics` 단계가 성공으로 종료되는지 확인.
- Firebase Console → Crashlytics → dSYMs 페이지에 새 dSYM 항목 등록 확인.

## 리뷰 노트
- 글롭 탐색은 `build_app` 이후에만 호출되므로 SwiftPM 해결이 끝난 상태가 전제 — 헬퍼 내부에서 미발견 시 명시적 에러 메시지로 실패하도록 처리.
- 이번 도입 이전에 배포된 빌드의 dSYM은 backfill하지 않음 — 필요 시 후속 PR에서 `download_dsyms` 기반 lane 추가 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)