### PR TITLE
fix(fastlane): upload-symbols 경로를 Tuist SPM 체크아웃 위치로 수정

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,15 +49,12 @@ def ensure_xcodeproj_generated
   sh("cd .. && tuist install && tuist generate --no-open")
 end
 
-# Locate the upload-symbols binary that SwiftPM checks out under DerivedData
-# when firebase-ios-sdk is resolved. build_app must have run first.
+# Locate the upload-symbols binary that Tuist resolves into Tuist/.build/checkouts
+# when firebase-ios-sdk is fetched. `tuist install` must have run first.
 def find_swiftpm_upload_symbols
-  glob = File.expand_path(
-    "~/Library/Developer/Xcode/DerivedData/**/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols"
-  )
-  binary = Dir.glob(glob).find { |p| File.executable?(p) }
-  UI.user_error!("upload-symbols not found under DerivedData. Run build_app first so SwiftPM resolves firebase-ios-sdk.") unless binary
-  binary
+  path = File.expand_path("../Tuist/.build/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols", __dir__)
+  UI.user_error!("upload-symbols not found at #{path}. Run `tuist install` first so Tuist resolves firebase-ios-sdk.") unless File.executable?(path)
+  path
 end
 
 platform :ios do


### PR DESCRIPTION
## 배경
- #37 머지 후 release CI에서 `upload-symbols not found under DerivedData` 에러로 실패.
- 원인: NoteCard는 Tuist 기반이라 SwiftPM 의존성이 `~/Library/Developer/Xcode/DerivedData/...`가 아니라 `<project>/Tuist/.build/checkouts/...`로 풀림.

## 변경사항
- `find_swiftpm_upload_symbols` 헬퍼의 탐색 경로를 `../Tuist/.build/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols`로 직접 지정.
- `__dir__` 앵커로 경로 해석 — Fastfile 내 `VERSION_XCCONFIG` 정의와 동일한 패턴.
- 글롭 탐색 제거 — 위치가 결정적이라 글롭 불필요.
- 에러 메시지의 안내 단계를 `build_app` → `tuist install`로 교체.

## 테스트 방법
- 로컬에서 `ls "$(pwd)/Tuist/.build/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols"` 실행해 파일 존재 확인.
- 머지 후 release CI 재실행하여 `upload_symbols_to_crashlytics` 단계 통과 확인.
- Firebase Console → Crashlytics → dSYMs 페이지에 새 dSYM 항목 등록 확인.

## 리뷰 노트
- `tuist install`은 기존 `ensure_xcodeproj_generated` lane에서 이미 호출됨 — 별도 단계 추가 불필요.
- Tuist가 의존성 해결 디렉토리 구조를 변경하면 경로 갱신 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)