### PR TITLE
feat(data): 익명 → 사용자 store 흡수 마이그레이션 추가

### DIFF
--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -49,7 +49,10 @@ struct AppEnvironment {
             onError: { error in assertionFailure("LegacyStoreMigrator 실패: \(error)") }
         )
 
-        let dataLayer = UserScopedDataLayer(userIDProvider: userIDProvider)
+        let dataLayer = UserScopedDataLayer(
+            userIDProvider: userIDProvider,
+            onMigrationError: { error in assertionFailure("AnonymousToUserMigrator 실패: \(error)") }
+        )
         self.dataLayer = dataLayer
 
         let memoRepository = MemoRepositoryImpl(dataLayer: dataLayer)

--- a/Projects/Data/Sources/CoreData/AnonymousToUserMigrator.swift
+++ b/Projects/Data/Sources/CoreData/AnonymousToUserMigrator.swift
@@ -1,0 +1,59 @@
+//
+//  AnonymousToUserMigrator.swift
+//  NoteCard
+//
+
+import CoreData
+import Foundation
+
+/// 사용자가 처음 로그인할 때 익명 store(`anonymous.sqlite`)의 내용을 사용자 store(`users/<uid>/NoteCard.sqlite`)로 1회 이전한다.
+/// `UserScopedDataLayer`가 stack을 교체하기 직전에 호출한다.
+///
+/// 정책:
+/// - 익명 store에 파일이 없으면 no-op.
+/// - 사용자 store가 *이미 존재*하면 no-op (sync 작업 단계에서 클라우드 데이터와 합쳐질 책임. 이번 단계 범위 밖).
+/// - target이 비어 있을 때만 `replacePersistentStore`로 단순 이전. 성공 시 익명 store는 비움.
+public enum AnonymousToUserMigrator {
+
+    public static func migrateIfNeeded(
+        anonymousStoreURL: URL,
+        userStoreURL: URL,
+        onError: (Error) -> Void = { _ in }
+    ) {
+        guard FileManager.default.fileExists(atPath: anonymousStoreURL.path) else { return }
+        guard !FileManager.default.fileExists(atPath: userStoreURL.path) else { return }
+
+        do {
+            let coordinator = try makeCoordinator()
+            try FileManager.default.createDirectory(
+                at: userStoreURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try coordinator.replacePersistentStore(
+                at: userStoreURL,
+                destinationOptions: nil,
+                withPersistentStoreFrom: anonymousStoreURL,
+                sourceOptions: nil,
+                type: .sqlite
+            )
+            // 익명 store는 비움 — 다음 익명 사용을 위해 깨끗한 상태로 둠.
+            // destroyPersistentStore만으로는 잔여 파일이 남는 경우가 있어 명시적으로 제거.
+            try? coordinator.destroyPersistentStore(at: anonymousStoreURL, type: .sqlite, options: nil)
+            for suffix in ["", "-wal", "-shm"] {
+                try? FileManager.default.removeItem(atPath: anonymousStoreURL.path + suffix)
+            }
+        } catch {
+            onError(error)
+        }
+    }
+
+    private static func makeCoordinator() throws -> NSPersistentStoreCoordinator {
+        guard
+            let modelURL = DataResources.bundle.url(forResource: "NoteCardCoreData", withExtension: "momd"),
+            let model = NSManagedObjectModel(contentsOf: modelURL)
+        else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        return NSPersistentStoreCoordinator(managedObjectModel: model)
+    }
+}

--- a/Projects/Data/Sources/CoreData/UserScopedDataLayer.swift
+++ b/Projects/Data/Sources/CoreData/UserScopedDataLayer.swift
@@ -23,13 +23,19 @@ public final class UserScopedDataLayer {
 
     private let userIDProvider: CurrentUserIDProvider
     private let storeDirectory: URL
+    private let onMigrationError: (Error) -> Void
     private let stackSubject: CurrentValueSubject<CoreDataStack, Never>
     private var cancellable: AnyCancellable?
 
-    public init(userIDProvider: CurrentUserIDProvider, storeDirectory: URL? = nil) {
+    public init(
+        userIDProvider: CurrentUserIDProvider,
+        storeDirectory: URL? = nil,
+        onMigrationError: @escaping (Error) -> Void = { _ in }
+    ) {
         self.userIDProvider = userIDProvider
         let directory = storeDirectory ?? Self.defaultStoreDirectory()
         self.storeDirectory = directory
+        self.onMigrationError = onMigrationError
         let initialStack = Self.makeStack(for: userIDProvider.currentUserID, in: directory)
         self.stackSubject = CurrentValueSubject(initialStack)
         attachUserIDListener()
@@ -59,6 +65,14 @@ public final class UserScopedDataLayer {
             .dropFirst()
             .sink { [weak self] userID in
                 guard let self else { return }
+                // 로그인 직후라면 익명 데이터를 사용자 store로 흡수 (target이 비어 있을 때만).
+                if let userID {
+                    AnonymousToUserMigrator.migrateIfNeeded(
+                        anonymousStoreURL: Self.storeURL(for: nil, in: self.storeDirectory),
+                        userStoreURL: Self.storeURL(for: userID, in: self.storeDirectory),
+                        onError: self.onMigrationError
+                    )
+                }
                 let newStack = Self.makeStack(for: userID, in: self.storeDirectory)
                 self.stackSubject.send(newStack)
             }

--- a/Projects/Data/Tests/AnonymousToUserMigratorTests.swift
+++ b/Projects/Data/Tests/AnonymousToUserMigratorTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+import CoreData
+import Domain
+@testable import Data
+
+/// `AnonymousToUserMigrator`가 익명 store를 사용자 store로 1회 이전하는지 검증.
+final class AnonymousToUserMigratorTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AnonymousToUserMigratorTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    func test_익명_store가_있고_사용자_store가_없으면_이전된다() async throws {
+        let anonURL = tempDir.appendingPathComponent("anonymous.sqlite")
+        let userURL = tempDir.appendingPathComponent("users/uid123/NoteCard.sqlite")
+        try await createStore(memoCount: 2, at: anonURL)
+
+        AnonymousToUserMigrator.migrateIfNeeded(
+            anonymousStoreURL: anonURL,
+            userStoreURL: userURL
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: userURL.path))
+        let count = try await memoCount(at: userURL)
+        XCTAssertEqual(count, 2)
+    }
+
+    func test_익명_store가_없으면_no_op() {
+        let anonURL = tempDir.appendingPathComponent("anonymous.sqlite") // 존재하지 않음
+        let userURL = tempDir.appendingPathComponent("users/uid123/NoteCard.sqlite")
+
+        AnonymousToUserMigrator.migrateIfNeeded(
+            anonymousStoreURL: anonURL,
+            userStoreURL: userURL
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: userURL.path))
+    }
+
+    func test_사용자_store가_이미_있으면_익명이_있어도_skip() async throws {
+        let anonURL = tempDir.appendingPathComponent("anonymous.sqlite")
+        let userURL = tempDir.appendingPathComponent("users/uid123/NoteCard.sqlite")
+        try await createStore(memoCount: 5, at: userURL)
+        try await createStore(memoCount: 2, at: anonURL)
+
+        AnonymousToUserMigrator.migrateIfNeeded(
+            anonymousStoreURL: anonURL,
+            userStoreURL: userURL
+        )
+
+        // 사용자 store는 원래 5개 그대로
+        let count = try await memoCount(at: userURL)
+        XCTAssertEqual(count, 5)
+        // 익명 store도 그대로 (skip이라 destroy 안 됨)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: anonURL.path))
+    }
+
+    func test_마이그레이션_성공시_익명_store_파일들이_삭제된다() async throws {
+        let anonURL = tempDir.appendingPathComponent("anonymous.sqlite")
+        let userURL = tempDir.appendingPathComponent("users/uid123/NoteCard.sqlite")
+        try await createStore(memoCount: 1, at: anonURL)
+
+        AnonymousToUserMigrator.migrateIfNeeded(
+            anonymousStoreURL: anonURL,
+            userStoreURL: userURL
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: anonURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: anonURL.path + "-wal"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: anonURL.path + "-shm"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: userURL.path))
+    }
+
+    func test_마이그레이션_실패시_익명이_보존되고_사용자_store는_안_만들어진다() async throws {
+        let anonURL = tempDir.appendingPathComponent("anonymous.sqlite")
+        try await createStore(memoCount: 1, at: anonURL)
+
+        // 목적지 부모 경로 중간에 파일을 끼워 디렉터리 생성을 불가능하게 만들어 실패시킨다.
+        let fileBlocker = tempDir.appendingPathComponent("notadir")
+        try Data().write(to: fileBlocker)
+        let userURL = fileBlocker.appendingPathComponent("sub").appendingPathComponent("NoteCard.sqlite")
+
+        var capturedError: Error?
+        AnonymousToUserMigrator.migrateIfNeeded(
+            anonymousStoreURL: anonURL,
+            userStoreURL: userURL,
+            onError: { capturedError = $0 }
+        )
+
+        XCTAssertNotNil(capturedError, "실패 시 onError로 에러가 전달되어야 한다.")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: userURL.path), "실패 시 사용자 store를 만들면 안 된다.")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: anonURL.path), "실패 시 익명 원본은 보존돼야 한다.")
+    }
+
+    // MARK: - Helpers
+
+    private func createStore(memoCount: Int, at url: URL) async throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let stack = CoreDataStack(storeURL: url)
+        let repo = MemoRepositoryImpl(stack: stack)
+        for _ in 0..<memoCount {
+            _ = try await repo.createNewMemo()
+        }
+        // 프로덕션에선 마이그레이션 시점에 익명 store가 닫혀 있다. 테스트도 동일하게 닫아준다.
+        let coordinator = stack.persistentContainer.persistentStoreCoordinator
+        for store in coordinator.persistentStores {
+            try coordinator.remove(store)
+        }
+    }
+
+    private func memoCount(at url: URL) async throws -> Int {
+        let stack = CoreDataStack(storeURL: url)
+        let repo = MemoRepositoryImpl(stack: stack)
+        return try await repo.getAllMemos().count
+    }
+}


### PR DESCRIPTION
## 배경
- 사용자별 store 분리 인프라의 마지막 데이터 흡수 단계. 익명으로 사용하던 사용자가 처음 로그인할 때 메모 손실 없이 계정으로 데이터가 옮겨지도록 보장.
- 사인인 UI 트랙(R1~R5)의 R1. 본 PR 단독으론 사용자 가시 변화 없음 — 사인인 진입점이 아직 없어 nil → userID 전환 이벤트가 발생하지 않음.

## 변경사항
- `AnonymousToUserMigrator` 신설 (Data 레이어)
  - `anonymous.sqlite` → `users/<uid>/NoteCard.sqlite` 1회 이전 (`replacePersistentStore`)
  - target user store가 이미 존재하면 skip — sync 단계에서 클라우드 데이터와의 병합 영역으로 위임
  - 성공 시 익명 store는 비움 (다음 익명 사용을 위해 깨끗한 상태). `destroyPersistentStore` + 잔여 파일(`-wal`/`-shm`) 명시적 제거
  - 실패 시 onError 클로저로 에러 전파, 익명 원본은 보존
- `UserScopedDataLayer.attachUserIDListener` 갱신
  - sink에서 nil → userID 전환 직전 마이그레이터 호출
  - init에 `onMigrationError` 클로저 추가 (default no-op). callsite가 dev/prod 가시성 결정
- `AppEnvironment`에서 `onMigrationError`로 `assertionFailure` 주입
  - Debug 빌드 즉시 trap, Release 빌드 no-op이 되어 다음 로그인 시 재시도
  - LegacyStoreMigrator의 onError 주입 패턴과 동일
- 테스트 5종 (`AnonymousToUserMigratorTests`)
  - 정상 이전 / 익명 부재 시 no-op / target 존재 시 skip / 성공 시 파일 삭제 / 실패 시 보존

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- `tuist test` 전체 통과 확인 — AnonymousToUserMigratorTests 5종 포함 92개
- 수동: 익명 store에 메모가 있는 상태에서 (사인인 UI는 아직 없으므로) 동작 검증은 어려움. 테스트 커버리지로 대체

## 리뷰 노트
- **사용자 동작 영향 0**: 사인인 UI가 없어 `AuthService.currentUser`가 항상 nil → nil → userID 전환 이벤트 발생 안 함. 마이그레이터는 호출되지 않는 상태로 main에 들어감
- **LegacyStoreMigrator와의 코드 중복**: `replacePersistentStore` + 파일 정리 패턴이 거의 동일. 의도적으로 분리 유지 — 호출 시점(앱 시작 vs 사용자 변경)과 정책(legacy 단방향 vs anonymous는 비움)이 달라 공통 helper 추출의 효용 적음. 후속에서 거슬리면 추출 가능
- **target user store 이미 존재 케이스는 skip**: sync 본 작업에서 클라우드 데이터와의 conflict resolution과 함께 다룸. 일전 결정 ("복잡한 dedupe는 영영 안 풀어도 됨")과 일치
- **다음 작업 R2**: LoginVC + SceneDelegate rootVC 분기. 같은 영역(AppEnvironment)을 또 건드릴 예정이라 본 PR 머지 후 진행