### PR TITLE
feat(login): 신규 사용자 진입용 LoginVC + SceneDelegate 분기

### DIFF
--- a/NoteCard/Global/Application/SceneDelegate.swift
+++ b/NoteCard/Global/Application/SceneDelegate.swift
@@ -9,6 +9,7 @@ import UIKit
 import Data
 import Domain
 import DesignSystem
+import LoginFeature
 import Shared
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -21,30 +22,76 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        
+
         self.window = UIWindow(windowScene: windowScene)
         self.window?.makeKeyAndVisible()
         self.window?.tintColor = UIColor.currentTheme
-        
+        self.window?.backgroundColor = .clear
+
+        // 다크모드 설정값 window에 반영하기.
+        applyDarkModeSetting()
+
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
             fatalError("AppDelegate를 찾을 수 없습니다.")
         }
-        let mainTabBarCon = MainTabBarController(environment: appDelegate.environment)
+
+        // 신규 사용자(익명 데이터 없음 + 아직 안내를 본 적 없음)에게만 로그인 화면을 띄움.
+        // 그 외(기존 사용자 / 이미 안내 본 사람)는 홈 화면으로 직행.
+        if shouldShowLoginScreen(environment: appDelegate.environment) {
+            self.window?.rootViewController = makeLoginViewController(environment: appDelegate.environment)
+        } else {
+            self.window?.rootViewController = makeMainTabBarController(environment: appDelegate.environment)
+        }
+    }
+
+    // MARK: - Root view construction
+
+    private func makeMainTabBarController(environment: AppEnvironment) -> MainTabBarController {
+        let mainTabBarCon = MainTabBarController(environment: environment)
         if #available(iOS 18.0, *) {
             mainTabBarCon.mode = .tabSidebar
         }
-        self.window?.rootViewController = mainTabBarCon
-        self.window?.backgroundColor = .clear
-        
-        // 다크모드 설정값 window에 반영하기.
-        
-        // 설정에서 다크모드 세팅 UserDefault 값에 해당하는 문자열
+        mainTabBarCon.selectedIndex = 0
+        return mainTabBarCon
+    }
+
+    private func makeLoginViewController(environment: AppEnvironment) -> LoginViewController {
+        LoginViewController(authService: environment.authService) { [weak self] outcome in
+            UserDefaults.standard.set(true, forKey: UserDefaultsKey.didShowSyncIntroduction.rawValue)
+            switch outcome {
+            case .signedIn, .skipped:
+                self?.transitionToMainTabBar(environment: environment)
+            }
+        }
+    }
+
+    private func transitionToMainTabBar(environment: AppEnvironment) {
+        guard let window = self.window else { return }
+        let target = makeMainTabBarController(environment: environment)
+        UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve) {
+            window.rootViewController = target
+        }
+    }
+
+    private func shouldShowLoginScreen(environment: AppEnvironment) -> Bool {
+        // 안내(로그인 화면 또는 What's new 모달)를 한 번 본 사람은 다시 띄우지 않음.
+        if UserDefaults.standard.bool(forKey: UserDefaultsKey.didShowSyncIntroduction.rawValue) {
+            return false
+        }
+        // 익명 store에 메모/카테고리 흔적이 있다 = 기존 사용자 = 홈으로 진입 후 What's new 모달 대상.
+        if AnonymousDataInspector.hasUserData(in: environment.coreDataStack) {
+            return false
+        }
+        return true
+    }
+
+    private func applyDarkModeSetting() {
         guard let darkModeSettingRawValue = UserDefaults.standard.string(
             forKey: UserDefaultsKeys.darkModeTheme.rawValue
         ) else {
             fatalError("다크모드 설정값이 초기화되지 않았습니다.")
         }
-        
+
         let darKModeValue = DarkModeTheme(rawValue: darkModeSettingRawValue)
         switch darKModeValue {
         case .light:
@@ -54,9 +101,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         default:
             window?.overrideUserInterfaceStyle = UIUserInterfaceStyle.unspecified
         }
-        
-        // 초기 화면은 홈 화면으로 설정.
-        mainTabBarCon.selectedIndex = 0
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Project.swift
+++ b/Project.swift
@@ -65,6 +65,7 @@ let appDependencies: [TargetDependency] = [
     .project(target: "SyncInterface", path: .relativeToRoot("Projects/Core/SyncInterface")),
     .project(target: "SyncImpl", path: .relativeToRoot("Projects/Core/SyncImpl")),
     .project(target: "SettingsFeature", path: .relativeToRoot("Projects/Feature/SettingsFeature")),
+    .project(target: "LoginFeature", path: .relativeToRoot("Projects/Feature/LoginFeature")),
 ]
 
 let project = Project(

--- a/Projects/Core/DesignSystem/Sources/Colors/UIColor+DesignSystem.swift
+++ b/Projects/Core/DesignSystem/Sources/Colors/UIColor+DesignSystem.swift
@@ -9,9 +9,15 @@ import UIKit
 import Shared
 
 public extension UIColor {
-    
+
     static let homeViewBackground = UIColor { traitCollection in
         return (traitCollection.userInterfaceStyle == .dark) ? .black : .systemGray6
     }
-    
+
+    /// 로그인 화면 배경. 다크모드에서 Apple 검정 버튼이 배경과 같은 색으로 묻히지 않도록
+    /// 시스템 검정이 아닌 살짝 밝은 회색을 사용.
+    static let loginBackground = UIColor { traitCollection in
+        return (traitCollection.userInterfaceStyle == .dark) ? .secondarySystemBackground : .white
+    }
+
 }

--- a/Projects/Core/Shared/Resources/Localizable.xcstrings
+++ b/Projects/Core/Shared/Resources/Localizable.xcstrings
@@ -2040,6 +2040,91 @@
           }
         }
       }
+    },
+    "login.promptDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign in with Apple to sync your memos across your devices."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple로 로그인하면 메모를 다른 기기와 동기화할 수 있어요."
+          }
+        }
+      }
+    },
+    "login.skipButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue without signing in"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인 없이 사용"
+          }
+        }
+      }
+    },
+    "login.skipConfirmationTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue without signing in?"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인 없이 사용"
+          }
+        }
+      }
+    },
+    "login.skipConfirmationMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Without signing in, your memos won't sync with other devices. Continue?"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인하지 않으면 다른 기기와 동기화할 수 없어요. 계속하시겠어요?"
+          }
+        }
+      }
+    },
+    "login.skipConfirmationProceed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "계속하기"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Projects/Core/Shared/Sources/Localization/L10n.swift
+++ b/Projects/Core/Shared/Sources/Localization/L10n.swift
@@ -135,6 +135,14 @@ public enum L10n {
         }
     }
 
+    public enum Login {
+        public static let promptDescription = "login.promptDescription".localized()
+        public static let skipButton = "login.skipButton".localized()
+        public static let skipConfirmationTitle = "login.skipConfirmationTitle".localized()
+        public static let skipConfirmationMessage = "login.skipConfirmationMessage".localized()
+        public static let skipConfirmationProceed = "login.skipConfirmationProceed".localized()
+    }
+
     public enum ThemeColor {
         public static let blackWhite = "themeColor.blackWhite".localized()
         public static let brown = "themeColor.brown".localized()

--- a/Projects/Core/Shared/Sources/PropertyWrapper/UserDefaults.swift
+++ b/Projects/Core/Shared/Sources/PropertyWrapper/UserDefaults.swift
@@ -15,6 +15,9 @@ public enum UserDefaultsKey: String {
     case orderCriterion
     case isOrderAscending
     case darkModeTheme
+    /// 동기화 안내(신규자 로그인 화면 or 기존자 What's new 모달)를 1회 표시한 뒤 set.
+    /// set 이후엔 어느 안내도 다시 띄우지 않음.
+    case didShowSyncIntroduction
 }
 
 

--- a/Projects/Data/Sources/CoreData/AnonymousDataInspector.swift
+++ b/Projects/Data/Sources/CoreData/AnonymousDataInspector.swift
@@ -1,0 +1,35 @@
+//
+//  AnonymousDataInspector.swift
+//  NoteCard
+//
+
+import CoreData
+import Foundation
+
+/// 현재 stack(주로 익명 stack)에 사용자 데이터가 존재하는지 동기로 확인하는 진단 helper.
+///
+/// SceneDelegate가 신규/기존 사용자를 분기할 때 사용. async API 없이 즉시 결과가 필요한
+/// composition-root 시점의 한정된 용도. 일반 데이터 조회는 `MemoRepository`를 거친다.
+public enum AnonymousDataInspector {
+
+    /// stack에 메모 또는 카테고리가 1개 이상 존재하는지 반환. 에러 발생 시 안전하게 `false`.
+    ///
+    /// 신규 설치자는 둘 다 0개로 시작하므로, 어느 한쪽이라도 존재 = 사용자가 앱을 써본 적 있음.
+    /// 메모를 모두 지우고 카테고리만 남긴 사용자도 기존 사용자로 분류된다.
+    public static func hasUserData(in stack: CoreDataStack) -> Bool {
+        let context = stack.backgroundContext
+        var has = false
+        context.performAndWait {
+            let memoRequest = MemoEntity.fetchRequest()
+            memoRequest.fetchLimit = 1
+            if ((try? context.count(for: memoRequest)) ?? 0) > 0 {
+                has = true
+                return
+            }
+            let categoryRequest = CategoryEntity.fetchRequest()
+            categoryRequest.fetchLimit = 1
+            has = ((try? context.count(for: categoryRequest)) ?? 0) > 0
+        }
+        return has
+    }
+}

--- a/Projects/Feature/LoginFeature/Project.swift
+++ b/Projects/Feature/LoginFeature/Project.swift
@@ -1,0 +1,9 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.feature(
+    .loginFeature,
+    additionalDependencies: [
+        .module(.syncInterface),
+    ]
+)

--- a/Projects/Feature/LoginFeature/Sources/LoginView.swift
+++ b/Projects/Feature/LoginFeature/Sources/LoginView.swift
@@ -1,0 +1,113 @@
+//
+//  LoginView.swift
+//  NoteCard
+//
+
+import AuthenticationServices
+import Shared
+import UIKit
+
+final class LoginView: UIView {
+
+    let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "NoteCard"
+        label.font = .systemFont(ofSize: 36, weight: .bold)
+        label.textAlignment = .center
+        return label
+    }()
+
+    let promptLabel: UILabel = {
+        let label = UILabel()
+        label.text = L10n.Login.promptDescription
+        label.font = .systemFont(ofSize: 15)
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }()
+
+    lazy var signInButton: ASAuthorizationAppleIDButton = {
+        let style: ASAuthorizationAppleIDButton.Style = traitCollection.userInterfaceStyle == .dark ? .white : .black
+        let button = ASAuthorizationAppleIDButton(authorizationButtonType: .signIn, authorizationButtonStyle: style)
+        button.cornerRadius = 12
+        return button
+    }()
+
+    let skipButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle(L10n.Login.skipButton, for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 15)
+        return button
+    }()
+
+    let errorLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 13)
+        label.textColor = .systemRed
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }()
+
+    let activityIndicator: UIActivityIndicatorView = {
+        let view = UIActivityIndicatorView(style: .medium)
+        view.hidesWhenStopped = true
+        return view
+    }()
+
+    private lazy var topStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [titleLabel, promptLabel])
+        stack.axis = .vertical
+        stack.spacing = 16
+        stack.alignment = .center
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    private lazy var buttonStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [signInButton, errorLabel, skipButton])
+        stack.axis = .vertical
+        stack.spacing = 12
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        setupConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupUI() {
+        backgroundColor = .systemBackground
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(topStack)
+        addSubview(buttonStack)
+        addSubview(activityIndicator)
+    }
+
+    private func setupConstraints() {
+        NSLayoutConstraint.activate([
+            topStack.centerXAnchor.constraint(equalTo: centerXAnchor),
+            topStack.centerYAnchor.constraint(equalTo: centerYAnchor, constant: -100),
+            topStack.leadingAnchor.constraint(greaterThanOrEqualTo: safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            topStack.trailingAnchor.constraint(lessThanOrEqualTo: safeAreaLayoutGuide.trailingAnchor, constant: -24),
+
+            buttonStack.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            buttonStack.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -24),
+            buttonStack.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -40),
+
+            signInButton.heightAnchor.constraint(equalToConstant: 50),
+
+            activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+            activityIndicator.topAnchor.constraint(equalTo: signInButton.bottomAnchor, constant: 12),
+        ])
+    }
+}

--- a/Projects/Feature/LoginFeature/Sources/LoginView.swift
+++ b/Projects/Feature/LoginFeature/Sources/LoginView.swift
@@ -4,6 +4,7 @@
 //
 
 import AuthenticationServices
+import DesignSystem
 import Shared
 import UIKit
 
@@ -27,9 +28,8 @@ final class LoginView: UIView {
         return label
     }()
 
-    lazy var signInButton: ASAuthorizationAppleIDButton = {
-        let style: ASAuthorizationAppleIDButton.Style = traitCollection.userInterfaceStyle == .dark ? .white : .black
-        let button = ASAuthorizationAppleIDButton(authorizationButtonType: .signIn, authorizationButtonStyle: style)
+    let signInButton: ASAuthorizationAppleIDButton = {
+        let button = ASAuthorizationAppleIDButton(authorizationButtonType: .signIn, authorizationButtonStyle: .black)
         button.cornerRadius = 12
         return button
     }()
@@ -85,7 +85,7 @@ final class LoginView: UIView {
     }
 
     private func setupUI() {
-        backgroundColor = .systemBackground
+        backgroundColor = .loginBackground
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false
 
         addSubview(topStack)

--- a/Projects/Feature/LoginFeature/Sources/LoginViewController.swift
+++ b/Projects/Feature/LoginFeature/Sources/LoginViewController.swift
@@ -1,0 +1,117 @@
+//
+//  LoginViewController.swift
+//  NoteCard
+//
+
+import Shared
+import SyncInterface
+import UIKit
+
+/// 신규 사용자가 앱을 처음 켰을 때 표시되는 fullScreen 진입 화면.
+///
+/// 두 가지 결과를 `onCompletion`으로 알린다:
+/// - `.signedIn`: Apple Sign in 성공 → 호출자가 rootVC를 메인 화면으로 교체
+/// - `.skipped`: 사용자가 "로그인 없이 사용"을 확정 → 호출자가 rootVC 교체 + 다음 실행 시 재표시 금지 플래그 set
+public final class LoginViewController: UIViewController {
+
+    public enum Outcome {
+        case signedIn
+        case skipped
+    }
+
+    private let authService: AuthService
+    private let onCompletion: (Outcome) -> Void
+
+    private lazy var rootView = self.view as! LoginView
+
+    // MARK: - Init
+
+    public init(authService: AuthService, onCompletion: @escaping (Outcome) -> Void) {
+        self.authService = authService
+        self.onCompletion = onCompletion
+        super.init(nibName: nil, bundle: nil)
+        // 첫 진입은 swipe-down으로 닫을 수 없게. skip 버튼이 명시적 대안.
+        isModalInPresentation = true
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) is unavailable") }
+
+    // MARK: - Lifecycle
+
+    public override func loadView() {
+        self.view = LoginView()
+    }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        rootView.signInButton.addTarget(self, action: #selector(signInTapped), for: .touchUpInside)
+        rootView.skipButton.addTarget(self, action: #selector(skipTapped), for: .touchUpInside)
+    }
+
+    // MARK: - Actions
+
+    @objc private func signInTapped() {
+        rootView.errorLabel.text = nil
+        setLoading(true)
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                _ = try await self.authService.signInWithApple()
+                await MainActor.run {
+                    self.setLoading(false)
+                    self.onCompletion(.signedIn)
+                }
+            } catch let error as AuthError {
+                await MainActor.run {
+                    self.setLoading(false)
+                    self.present(error: error)
+                }
+            } catch {
+                await MainActor.run {
+                    self.setLoading(false)
+                    self.rootView.errorLabel.text = L10n.Sync.Auth.unknown
+                }
+            }
+        }
+    }
+
+    @objc private func skipTapped() {
+        let alert = UIAlertController(
+            title: L10n.Login.skipConfirmationTitle,
+            message: L10n.Login.skipConfirmationMessage,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: L10n.Common.cancel, style: .cancel))
+        alert.addAction(UIAlertAction(title: L10n.Login.skipConfirmationProceed, style: .default) { [weak self] _ in
+            self?.onCompletion(.skipped)
+        })
+        present(alert, animated: true)
+    }
+
+    // MARK: - Private
+
+    private func present(error: AuthError) {
+        switch error {
+        case .cancelled:
+            // 사용자가 직접 닫은 액션. 추가 알림 없이 화면에 머무름.
+            rootView.errorLabel.text = nil
+        case .missingFirebase:
+            rootView.errorLabel.text = L10n.Sync.Auth.unavailable
+        case .invalidCredential:
+            rootView.errorLabel.text = L10n.Sync.Auth.invalidCredential
+        case .unknown:
+            rootView.errorLabel.text = L10n.Sync.Auth.unknown
+        }
+    }
+
+    private func setLoading(_ loading: Bool) {
+        rootView.signInButton.isEnabled = !loading
+        rootView.skipButton.isEnabled = !loading
+        if loading {
+            rootView.activityIndicator.startAnimating()
+        } else {
+            rootView.activityIndicator.stopAnimating()
+        }
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/ModulePaths.swift
+++ b/Tuist/ProjectDescriptionHelpers/ModulePaths.swift
@@ -26,6 +26,7 @@ public enum Module: String {
     case homeFeature        = "HomeFeature"
     case memoFeature        = "MemoFeature"
     case settingsFeature    = "SettingsFeature"
+    case loginFeature       = "LoginFeature"
 
     public var layer: Layer {
         switch self {
@@ -33,7 +34,7 @@ public enum Module: String {
         case .data:   return .data
         case .designSystem, .shared, .analyticsInterface, .analyticsImpl, .syncInterface, .syncImpl:
             return .core
-        case .homeFeature, .memoFeature, .settingsFeature:
+        case .homeFeature, .memoFeature, .settingsFeature, .loginFeature:
             return .feature
         }
     }


### PR DESCRIPTION
## 배경
- 사인인 UI 트랙(R1~R5)의 R2. 한 번도 앱을 켠 적 없는 사용자가 fullScreen 로그인 화면을 먼저 만나도록 진입 흐름 분기 도입
- 본 PR 단독 머지 시점에 사용자 가시 변화 있음: 신규 설치자에게 로그인 화면이 노출됨. 단 후속 R3/R4/R5가 따라와야 *전체 사용자 흐름*이 매끄러움. 일전 결정대로 다음 release까지 R5까지 무조건 완성 예정이며, 못 완성하면 임시 게이트 도입

## 변경사항
- LoginFeature 모듈 신설 (Feature 레이어)
  - `Project.feature` 팩토리로 등록. SyncInterface(AuthService) 추가 의존
  - `ModulePaths.Module`에 `loginFeature` case 추가
- `LoginView` (UIView 서브클래스) + `LoginViewController` 분리 구현
  - View: 컴포넌트 + 레이아웃 보유. NoteCard 기존 View/VC 패턴(`loadView` + `rootView` 캐스팅) 따름
  - VC: 이벤트 처리 + AuthService 호출 + lifecycle. `Outcome` 콜백(.signedIn / .skipped)으로 결과를 호출자에 알림
  - UI: 로고(NoteCard 텍스트) / 안내 텍스트 / `ASAuthorizationAppleIDButton` / 로그인 없이 사용 버튼 / inline error label / activity indicator
  - Apple Sign in 흐름: `.cancelled`는 무처리(사용자 의도적 액션), 그 외 에러는 case별 친화적 문구 inline 표시
  - "로그인 없이 사용" 흐름: 경고 모달 → 확인 시 .skipped 콜백
  - `isModalInPresentation = true`로 swipe-down 차단 (skip 버튼이 명시적 대안)
- `AnonymousDataInspector` 진단 helper 추가 (Data 레이어)
  - 현재 stack에 메모 또는 카테고리가 1개 이상 존재하는지 동기로 확인
  - 신규 설치자는 둘 다 0개로 시작하므로 어느 한쪽이라도 존재 = 기존 사용자
  - `performAndWait` + count fetchRequest. 에러 시 false 폴백
- `UserDefaultsKey.didShowSyncIntroduction` 키 추가 (Shared 레이어)
  - 신규자 로그인 화면 1회 표시 / 기존자 What's new 모달(R3) 1회 표시 영속화 통합 키
- `L10n.Login` 네임스페이스 + Localizable.xcstrings 한국어·영어 등록
  - 안내 톤은 동기화 가치 중심. 기술 용어 직접 노출 없음
- `SceneDelegate.scene(_:willConnectTo:options:)` 분기 로직 추가
  - 신규자(익명 데이터 없음 + 키 미설정) → `LoginViewController` rootVC
  - 그 외 → `MainTabBarController` rootVC (기존 흐름)
  - LoginVC 결과 콜백에서 키 set + cross-dissolve로 rootVC 교체
  - 다크모드 적용 / rootVC 생성을 별도 helper로 추출
- 앱 root `Project.swift`에 LoginFeature 의존 추가

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- `tuist test` 전체 통과 확인 (92개)
- 수동 (시뮬레이터, Erase All Content로 처음 상태에서 시작):
  - 첫 실행 → LoginVC 표시 확인 (로고 / 안내 / 두 버튼)
  - "로그인 없이 사용" → 경고 모달 → 확인 → MainTabBar로 cross-dissolve 전환
  - 앱 재실행 → MainTabBar 직진 (`didShowSyncIntroduction` 영속화 검증)
  - 시뮬레이터에 Apple Account 미로그인 상태에서 Sign in 시도 → `.cancelled` → 화면 머무름 (에러 라벨 비어 있음)
  - `GoogleService-Info.plist` 미포함 빌드 → Sign in 시도 시 inline error "서비스를 일시적으로 사용할 수 없어요" 표시

## 리뷰 노트
- **신규 설치자 강제 노출**: 본 PR 머지 후 빌드되는 첫 실행에서 LoginVC가 강제 노출됨. 기존 사용자에겐 변화 없음(`anonymous.sqlite`에 데이터 있으니 분기에서 제외)
- **Apple Sign in 성공 시나리오 검증의 어려움**: 성공 흐름은 R4(앱 내 계정 삭제) 완성 후 반복 검증이 매끄러움. 지금 단독으로 검증하려면 시뮬레이터 Erase + Firebase Console에서 user 삭제 + iOS 설정에서 "Apple로 로그인" 권한 삭제 — 매번 거치기엔 무거움. 본 PR 단독 검증은 *시트 진입까지* 권장
- **R3(What's new 모달) 없음**: 기존 사용자에겐 현재 *아무 안내가 없음*. R3에서 같은 키(`didShowSyncIntroduction`)로 1회 모달을 띄울 예정. 키 의미가 *신규자 LoginVC 1회 + 기존자 What's new 1회 통합*임을 인지해주세요
- **stack 교체 race**: 로그인 성공 직후 Firebase Auth state 변경 → `AuthServiceUserIDProvider` emit → `UserScopedDataLayer`가 stack 교체. 이 과정 중 SceneDelegate의 rootVC transition이 *완료 전에* 시작될 수 있음. 데이터 reload는 새 화면 fetch로 자연스럽게 처리되지만, 본격 차단 UI가 필요해지면 후속 작업
- **SceneDelegate 리팩터 일부**: 기존 인라인 코드 일부를 메서드로 추출(`makeMainTabBarController`, `applyDarkModeSetting`). 로직 변경 없음
- **다음 작업 R3**: What's new 모달 (기존 사용자 대상). 같은 PR에 한 번 더 SceneDelegate를 건드릴 가능성 있으므로 본 PR 머지 후 진행 권장

## 스크린샷
<img width="250" alt="simulator_screenshot_25AAB10D-FB58-4F6A-80F2-AA8FE08664F6" src="https://github.com/user-attachments/assets/f4543452-0074-4762-b287-bb296f5e82f3" />
