### PR TITLE
feat(app): 기존 사용자에게 동기화 안내 sheet 모달 1회 표시

### DIFF
--- a/NoteCard/Presentation/HomeView/HomeViewController.swift
+++ b/NoteCard/Presentation/HomeView/HomeViewController.swift
@@ -77,6 +77,22 @@ class HomeViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         environment.analytics.log(.screenView(.home))
+        presentSyncIntroductionIfNeeded()
+    }
+
+    /// 동기화 안내를 한 번도 본 적 없는 사용자에게 sheet 모달로 1회 표시.
+    /// 키 set은 *표시 직전*에 수행해 viewDidAppear 재호출(모달 닫힘 직후) 시 무한루프 방지.
+    private func presentSyncIntroductionIfNeeded() {
+        let key = UserDefaultsKey.didShowSyncIntroduction.rawValue
+        guard !UserDefaults.standard.bool(forKey: key) else { return }
+        UserDefaults.standard.set(true, forKey: key)
+
+        let introVC = SyncIntroductionViewController()
+        if let sheet = introVC.sheetPresentationController {
+            sheet.detents = [.medium()]
+            sheet.prefersGrabberVisible = true
+        }
+        present(introVC, animated: true)
     }
 
     override func viewDidLoad() {

--- a/NoteCard/Presentation/SyncIntroduction/SyncIntroductionView.swift
+++ b/NoteCard/Presentation/SyncIntroduction/SyncIntroductionView.swift
@@ -1,0 +1,91 @@
+//
+//  SyncIntroductionView.swift
+//  NoteCard
+//
+
+import Shared
+import UIKit
+
+final class SyncIntroductionView: UIView {
+
+    let iconView: UIImageView = {
+        let configuration = UIImage.SymbolConfiguration(pointSize: 48, weight: .regular)
+        let image = UIImage(systemName: "arrow.triangle.2.circlepath.icloud", withConfiguration: configuration)
+        let view = UIImageView(image: image)
+        view.contentMode = .scaleAspectFit
+        return view
+    }()
+
+    let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = L10n.Sync.Introduction.title
+        label.font = .systemFont(ofSize: 22, weight: .bold)
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }()
+
+    let bodyLabel: UILabel = {
+        let label = UILabel()
+        label.text = L10n.Sync.Introduction.body
+        label.font = .systemFont(ofSize: 15)
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }()
+
+    let dismissButton: UIButton = {
+        var config = UIButton.Configuration.filled()
+        config.title = L10n.Sync.Introduction.dismiss
+        config.cornerStyle = .large
+        config.contentInsets = NSDirectionalEdgeInsets(top: 14, leading: 0, bottom: 14, trailing: 0)
+        let button = UIButton(configuration: config)
+        return button
+    }()
+
+    private lazy var textStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [titleLabel, bodyLabel])
+        stack.axis = .vertical
+        stack.spacing = 12
+        stack.alignment = .center
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        setupConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupUI() {
+        backgroundColor = .systemBackground
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        dismissButton.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(iconView)
+        addSubview(textStack)
+        addSubview(dismissButton)
+    }
+
+    private func setupConstraints() {
+        NSLayoutConstraint.activate([
+            iconView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            iconView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 32),
+            iconView.widthAnchor.constraint(equalToConstant: 60),
+            iconView.heightAnchor.constraint(equalToConstant: 60),
+
+            textStack.topAnchor.constraint(equalTo: iconView.bottomAnchor, constant: 20),
+            textStack.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            textStack.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -24),
+
+            dismissButton.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            dismissButton.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -24),
+            dismissButton.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -24),
+        ])
+    }
+}

--- a/NoteCard/Presentation/SyncIntroduction/SyncIntroductionViewController.swift
+++ b/NoteCard/Presentation/SyncIntroduction/SyncIntroductionViewController.swift
@@ -1,0 +1,28 @@
+//
+//  SyncIntroductionViewController.swift
+//  NoteCard
+//
+
+import UIKit
+
+/// 기존 사용자에게 동기화 기능이 추가됐음을 안내하는 sheet 모달.
+///
+/// 직접 로그인 버튼은 노출하지 않고 Settings 진입을 자연스럽게 유도하는 톤.
+/// 호출자가 `UISheetPresentationController.detents = [.medium()]`로 띄운다고 가정.
+final class SyncIntroductionViewController: UIViewController {
+
+    private lazy var rootView = self.view as! SyncIntroductionView
+
+    override func loadView() {
+        self.view = SyncIntroductionView()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        rootView.dismissButton.addTarget(self, action: #selector(dismissTapped), for: .touchUpInside)
+    }
+
+    @objc private func dismissTapped() {
+        dismiss(animated: true)
+    }
+}

--- a/Projects/Core/Shared/Resources/Localizable.xcstrings
+++ b/Projects/Core/Shared/Resources/Localizable.xcstrings
@@ -2125,6 +2125,57 @@
           }
         }
       }
+    },
+    "sync.introduction.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync is now available"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "동기화 기능이 추가됐어요"
+          }
+        }
+      }
+    },
+    "sync.introduction.body": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign in with Apple to sync your memos across your devices. You can start from Settings → Account."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple로 로그인하면 메모를 다른 기기와 동기화할 수 있어요. 설정 → 계정에서 시작하세요."
+          }
+        }
+      }
+    },
+    "sync.introduction.dismiss": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Got it"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Projects/Core/Shared/Sources/Localization/L10n.swift
+++ b/Projects/Core/Shared/Sources/Localization/L10n.swift
@@ -133,6 +133,12 @@ public enum L10n {
             public static let unavailable = "sync.auth.unavailable".localized()
             public static let unknown = "sync.auth.unknown".localized()
         }
+
+        public enum Introduction {
+            public static let title = "sync.introduction.title".localized()
+            public static let body = "sync.introduction.body".localized()
+            public static let dismiss = "sync.introduction.dismiss".localized()
+        }
     }
 
     public enum Login {


### PR DESCRIPTION
## 배경
- 사인인 UI 트랙(R1~R5)의 R3. 업데이트 후 첫 실행하는 기존 사용자에게 "이제 동기화 기능을 사용할 수 있어요" 안내
- 직접 로그인 버튼은 노출하지 않고 Settings → 계정 진입을 자연스럽게 유도 — 사용자 결정 정책
- 본 PR 단독으론 *기존 사용자에게만* 가시 변화. 신규자는 LoginVC 콜백에서 이미 동일 키가 set이라 영향 없음

## 변경사항
- L10n.Sync.Introduction 네임스페이스 신설 (title / body / dismiss)
- Localizable.xcstrings에 한국어·영어 등록. 본문은 "설정 → 계정에서 시작" 톤
- SyncIntroductionView + SyncIntroductionViewController 신설 (App 레이어, View/VC 분리)
  - 아이콘(SF Symbols `arrow.triangle.2.circlepath.icloud`) + 제목 + 본문 + 닫기 버튼
  - 아이콘/닫기 버튼은 tintColor를 명시하지 않아 SceneDelegate의 `window.tintColor`(사용자 테마 색)를 view 계층으로 상속. NoteCard 표준 패턴
- HomeViewController.viewDidAppear에 1회 표시 트리거 추가
  - `UserDefaultsKey.didShowSyncIntroduction` 미설정 시 `UISheetPresentationController`로 `.medium` detent + 그래버 표시 후 present
  - **키 set은 present 직전에 수행** — viewDidAppear가 모달 닫힘 직후 재호출돼도 다시 띄우지 않도록 보장

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- `tuist test` 전체 통과 확인
- 수동 (시뮬레이터, 기존 사용자 흐름):
  - 익명 store에 메모/카테고리 1개 이상 있는 상태(직전 main 버전을 켜고 사용하다가 본 PR 빌드로 업데이트한 시나리오 또는 시뮬레이터에서 메모 1개 생성 후 앱 재실행)
  - 앱 시작 → MainTabBar 직진 → HomeVC viewDidAppear → **sheet 모달 표시**
  - 닫기 버튼 또는 swipe-down으로 dismiss → viewDidAppear 재호출되어도 모달 다시 안 뜸
  - 앱 재실행 → 모달 표시 안 됨
- 수동 (신규자 흐름, 모달이 *안 떠야* 정상):
  - 시뮬레이터 Erase → 앱 실행 → LoginVC → "로그인 없이 사용" 또는 사인인 → HomeVC 진입 → 모달 표시되지 않음을 확인 (이미 LoginVC 콜백에서 키 set)

## 리뷰 노트
- **`didShowSyncIntroduction` 키의 의미 통합**: R2에서 추가된 키를 본 PR에서 재활용. *신규자 LoginVC 1회 + 기존자 What's new 모달 1회 통합*이라는 의도가 이번 PR로 완성됨
- **viewDidAppear 무한 루프 방지**: 키 set을 present 직전에 수행. 모달 닫힘 → viewDidAppear 재호출 → 키 set이라 조기 return → 재진입 없음
- **아이콘/디자인은 placeholder 수준**: SF Symbols 임시 선택. 본격 디자인 조정은 후속(R5 또는 별도 디자인 트랙)
- **다음 작업 R4**: Settings 계정 상세 페이지 (Sign in 버튼 / 로그아웃 / 계정 삭제 / 동기화 상태). R5에서 Settings 첫 섹션에 진입 셀 추가 + 게이트 활성화