### PR TITLE
feat(settings): 계정 상세 페이지(AccountDetailVC) 추가

### DIFF
--- a/Projects/Core/Shared/Resources/Localizable.xcstrings
+++ b/Projects/Core/Shared/Resources/Localizable.xcstrings
@@ -2176,6 +2176,97 @@
           }
         }
       }
+    },
+    "account.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Account" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "계정" } }
+      }
+    },
+    "account.signInPrompt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Sign in with Apple to sync your memos across your devices." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "Apple로 로그인하면 메모를 다른 기기와 동기화할 수 있어요." } }
+      }
+    },
+    "account.syncStatusLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Sync status" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "동기화 상태" } }
+      }
+    },
+    "account.syncStatusComingSoon": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Coming soon" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "준비 중" } }
+      }
+    },
+    "account.lastSyncedLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Last synced" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "최근 동기화" } }
+      }
+    },
+    "account.lastSyncedNever": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "—" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "—" } }
+      }
+    },
+    "account.signOut": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Sign out" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "로그아웃" } }
+      }
+    },
+    "account.signOutConfirmTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Sign out?" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "로그아웃하시겠어요?" } }
+      }
+    },
+    "account.signOutConfirmMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "This device stops syncing. Your memos remain safe in your account." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이 기기에서 동기화가 멈춰요. 계정의 메모는 계속 안전하게 보관돼요." } }
+      }
+    },
+    "account.deleteAccount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Delete account" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "계정 삭제" } }
+      }
+    },
+    "account.deleteAccountConfirmTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Delete your account?" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "계정을 삭제하시겠어요?" } }
+      }
+    },
+    "account.deleteAccountConfirmMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "This cannot be undone. Your account and all synced data will be permanently deleted." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이 작업은 되돌릴 수 없어요. 계정과 모든 동기화 데이터가 영구 삭제돼요." } }
+      }
+    },
+    "account.deleteAccountProceed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Delete" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "삭제" } }
+      }
     }
   },
   "version": "1.0"

--- a/Projects/Core/Shared/Sources/Localization/L10n.swift
+++ b/Projects/Core/Shared/Sources/Localization/L10n.swift
@@ -149,6 +149,22 @@ public enum L10n {
         public static let skipConfirmationProceed = "login.skipConfirmationProceed".localized()
     }
 
+    public enum Account {
+        public static let title = "account.title".localized()
+        public static let signInPrompt = "account.signInPrompt".localized()
+        public static let syncStatusLabel = "account.syncStatusLabel".localized()
+        public static let syncStatusComingSoon = "account.syncStatusComingSoon".localized()
+        public static let lastSyncedLabel = "account.lastSyncedLabel".localized()
+        public static let lastSyncedNever = "account.lastSyncedNever".localized()
+        public static let signOut = "account.signOut".localized()
+        public static let signOutConfirmTitle = "account.signOutConfirmTitle".localized()
+        public static let signOutConfirmMessage = "account.signOutConfirmMessage".localized()
+        public static let deleteAccount = "account.deleteAccount".localized()
+        public static let deleteAccountConfirmTitle = "account.deleteAccountConfirmTitle".localized()
+        public static let deleteAccountConfirmMessage = "account.deleteAccountConfirmMessage".localized()
+        public static let deleteAccountProceed = "account.deleteAccountProceed".localized()
+    }
+
     public enum ThemeColor {
         public static let blackWhite = "themeColor.blackWhite".localized()
         public static let brown = "themeColor.brown".localized()

--- a/Projects/Feature/SettingsFeature/Project.swift
+++ b/Projects/Feature/SettingsFeature/Project.swift
@@ -3,5 +3,8 @@ import ProjectDescriptionHelpers
 
 let project = Project.feature(
     .settingsFeature,
-    resources: ["Resources/**"]
+    resources: ["Resources/**"],
+    additionalDependencies: [
+        .module(.syncInterface),
+    ]
 )

--- a/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailView.swift
+++ b/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailView.swift
@@ -1,0 +1,199 @@
+//
+//  AccountDetailView.swift
+//  NoteCard
+//
+
+import AuthenticationServices
+import Shared
+import UIKit
+
+final class AccountDetailView: UIView {
+
+    // MARK: - Signed-out state
+
+    let signedOutContainer: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 20
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    let signInPromptLabel: UILabel = {
+        let label = UILabel()
+        label.text = L10n.Account.signInPrompt
+        label.font = .systemFont(ofSize: 15)
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }()
+
+    let signInButton: ASAuthorizationAppleIDButton = {
+        let button = ASAuthorizationAppleIDButton(authorizationButtonType: .signIn, authorizationButtonStyle: .black)
+        button.cornerRadius = 12
+        return button
+    }()
+
+    // MARK: - Signed-in state
+
+    let signedInContainer: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 16
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    let displayNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 22, weight: .bold)
+        label.textAlignment = .center
+        label.numberOfLines = 1
+        return label
+    }()
+
+    let emailLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 13)
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.numberOfLines = 1
+        return label
+    }()
+
+    let syncStatusRow = AccountDetailView.makeInfoRow(title: L10n.Account.syncStatusLabel, value: L10n.Account.syncStatusComingSoon)
+    let lastSyncedRow = AccountDetailView.makeInfoRow(title: L10n.Account.lastSyncedLabel, value: L10n.Account.lastSyncedNever)
+
+    let signOutButton: UIButton = {
+        var config = UIButton.Configuration.tinted()
+        config.title = L10n.Account.signOut
+        config.cornerStyle = .large
+        config.contentInsets = NSDirectionalEdgeInsets(top: 14, leading: 0, bottom: 14, trailing: 0)
+        let button = UIButton(configuration: config)
+        return button
+    }()
+
+    let deleteAccountButton: UIButton = {
+        var config = UIButton.Configuration.plain()
+        config.title = L10n.Account.deleteAccount
+        var attrs = AttributeContainer()
+        attrs.font = .systemFont(ofSize: 14)
+        attrs.foregroundColor = .systemRed
+        config.attributedTitle = AttributedString(L10n.Account.deleteAccount, attributes: attrs)
+        config.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0)
+        let button = UIButton(configuration: config)
+        return button
+    }()
+
+    let activityIndicator: UIActivityIndicatorView = {
+        let view = UIActivityIndicatorView(style: .medium)
+        view.hidesWhenStopped = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        setupConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupUI() {
+        backgroundColor = .systemGroupedBackground
+
+        let identityStack = UIStackView(arrangedSubviews: [displayNameLabel, emailLabel])
+        identityStack.axis = .vertical
+        identityStack.spacing = 4
+        identityStack.alignment = .center
+
+        let infoStack = UIStackView(arrangedSubviews: [syncStatusRow, lastSyncedRow])
+        infoStack.axis = .vertical
+        infoStack.spacing = 8
+        infoStack.alignment = .fill
+
+        signedInContainer.addArrangedSubview(identityStack)
+        signedInContainer.addArrangedSubview(infoStack)
+        signedInContainer.setCustomSpacing(28, after: identityStack)
+        signedInContainer.addArrangedSubview(signOutButton)
+        signedInContainer.setCustomSpacing(32, after: infoStack)
+        signedInContainer.addArrangedSubview(deleteAccountButton)
+
+        signedOutContainer.addArrangedSubview(signInPromptLabel)
+        signedOutContainer.addArrangedSubview(signInButton)
+
+        addSubview(signedOutContainer)
+        addSubview(signedInContainer)
+        addSubview(activityIndicator)
+    }
+
+    private func setupConstraints() {
+        NSLayoutConstraint.activate([
+            signedOutContainer.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            signedOutContainer.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -24),
+            signedOutContainer.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 40),
+
+            signInButton.heightAnchor.constraint(equalToConstant: 50),
+
+            signedInContainer.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            signedInContainer.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -24),
+            signedInContainer.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 40),
+
+            activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+    }
+
+    // MARK: - Helpers
+
+    /// 라벨-값 한 줄을 만드는 단순 행. systemGroupedBackground 위 흰 카드 느낌.
+    private static func makeInfoRow(title: String, value: String) -> UIView {
+        let container = UIView()
+        container.backgroundColor = .secondarySystemGroupedBackground
+        container.layer.cornerRadius = 10
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        let titleLabel = UILabel()
+        titleLabel.text = title
+        titleLabel.font = .systemFont(ofSize: 15)
+        titleLabel.textColor = .label
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let valueLabel = UILabel()
+        valueLabel.text = value
+        valueLabel.font = .systemFont(ofSize: 15)
+        valueLabel.textColor = .secondaryLabel
+        valueLabel.textAlignment = .right
+        valueLabel.translatesAutoresizingMaskIntoConstraints = false
+        valueLabel.tag = AccountDetailView.valueLabelTag
+
+        container.addSubview(titleLabel)
+        container.addSubview(valueLabel)
+        NSLayoutConstraint.activate([
+            container.heightAnchor.constraint(greaterThanOrEqualToConstant: 44),
+            titleLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            titleLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            valueLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+            valueLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            valueLabel.leadingAnchor.constraint(greaterThanOrEqualTo: titleLabel.trailingAnchor, constant: 12),
+        ])
+        return container
+    }
+
+    /// row 안의 valueLabel을 찾기 위한 식별 tag. row 갱신 헬퍼에서 사용.
+    fileprivate static let valueLabelTag = 5001
+}
+
+extension AccountDetailView {
+    /// 행 내부의 값 라벨 텍스트를 갱신.
+    func updateRow(_ row: UIView, value: String) {
+        guard let label = row.viewWithTag(Self.valueLabelTag) as? UILabel else { return }
+        label.text = value
+    }
+}

--- a/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
+++ b/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
@@ -1,0 +1,165 @@
+//
+//  AccountDetailViewController.swift
+//  NoteCard
+//
+
+import Combine
+import Shared
+import SyncInterface
+import UIKit
+
+/// Settings → 계정에서 진입하는 상세 페이지.
+/// 미로그인이면 Sign in with Apple 버튼, 로그인 상태면 사용자 정보 + 로그아웃/계정 삭제.
+public final class AccountDetailViewController: UIViewController {
+
+    private let authService: AuthService
+    private var cancellable: AnyCancellable?
+
+    private lazy var rootView = self.view as! AccountDetailView
+
+    public init(authService: AuthService) {
+        self.authService = authService
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) { fatalError("init(coder:) is unavailable") }
+
+    public override func loadView() {
+        self.view = AccountDetailView()
+    }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        title = L10n.Account.title
+        navigationItem.largeTitleDisplayMode = .never
+
+        rootView.signInButton.addTarget(self, action: #selector(signInTapped), for: .touchUpInside)
+        rootView.signOutButton.addTarget(self, action: #selector(signOutTapped), for: .touchUpInside)
+        rootView.deleteAccountButton.addTarget(self, action: #selector(deleteAccountTapped), for: .touchUpInside)
+
+        // 인증 상태 변경에 따라 화면 상태 토글.
+        cancellable = authService.authStatePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] user in
+                self?.render(user: user)
+            }
+    }
+
+    // MARK: - State render
+
+    private func render(user: AuthUser?) {
+        if let user {
+            rootView.signedOutContainer.isHidden = true
+            rootView.signedInContainer.isHidden = false
+            rootView.displayNameLabel.text = user.displayName ?? user.email ?? L10n.Account.title
+            rootView.emailLabel.text = user.email
+            rootView.emailLabel.isHidden = (user.email == nil)
+        } else {
+            rootView.signedOutContainer.isHidden = false
+            rootView.signedInContainer.isHidden = true
+        }
+    }
+
+    // MARK: - Actions
+
+    @objc private func signInTapped() {
+        setLoading(true)
+        Task { [weak self] in
+            guard let self else { return }
+            defer { Task { @MainActor in self.setLoading(false) } }
+            do {
+                _ = try await self.authService.signInWithApple()
+                // 성공 시 authStatePublisher가 새 user를 emit → render에서 자동 전환
+            } catch let error as AuthError {
+                await MainActor.run { self.presentInline(error: error) }
+            } catch {
+                await MainActor.run { self.showAlert(title: L10n.Sync.Auth.unknown) }
+            }
+        }
+    }
+
+    @objc private func signOutTapped() {
+        let alert = UIAlertController(
+            title: L10n.Account.signOutConfirmTitle,
+            message: L10n.Account.signOutConfirmMessage,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: L10n.Common.cancel, style: .cancel))
+        alert.addAction(UIAlertAction(title: L10n.Account.signOut, style: .destructive) { [weak self] _ in
+            self?.performSignOut()
+        })
+        present(alert, animated: true)
+    }
+
+    @objc private func deleteAccountTapped() {
+        let alert = UIAlertController(
+            title: L10n.Account.deleteAccountConfirmTitle,
+            message: L10n.Account.deleteAccountConfirmMessage,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: L10n.Common.cancel, style: .cancel))
+        alert.addAction(UIAlertAction(title: L10n.Account.deleteAccountProceed, style: .destructive) { [weak self] _ in
+            self?.performDeleteAccount()
+        })
+        present(alert, animated: true)
+    }
+
+    private func performSignOut() {
+        setLoading(true)
+        Task { [weak self] in
+            guard let self else { return }
+            defer { Task { @MainActor in self.setLoading(false) } }
+            do {
+                try await self.authService.signOut()
+                // authStatePublisher가 nil emit → 미로그인 상태로 자동 전환
+            } catch {
+                await MainActor.run { self.showAlert(title: L10n.Sync.Auth.unknown) }
+            }
+        }
+    }
+
+    private func performDeleteAccount() {
+        setLoading(true)
+        Task { [weak self] in
+            guard let self else { return }
+            defer { Task { @MainActor in self.setLoading(false) } }
+            do {
+                try await self.authService.deleteAccount()
+                // authStatePublisher가 nil emit → 미로그인 상태로 자동 전환
+            } catch let error as AuthError {
+                await MainActor.run { self.showAlert(title: error.errorDescription ?? L10n.Sync.Auth.unknown) }
+            } catch {
+                await MainActor.run { self.showAlert(title: L10n.Sync.Auth.unknown) }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func setLoading(_ loading: Bool) {
+        rootView.signInButton.isEnabled = !loading
+        rootView.signOutButton.isEnabled = !loading
+        rootView.deleteAccountButton.isEnabled = !loading
+        if loading { rootView.activityIndicator.startAnimating() } else { rootView.activityIndicator.stopAnimating() }
+    }
+
+    private func presentInline(error: AuthError) {
+        switch error {
+        case .cancelled:
+            return
+        case .missingFirebase:
+            showAlert(title: L10n.Sync.Auth.unavailable)
+        case .invalidCredential:
+            showAlert(title: L10n.Sync.Auth.invalidCredential)
+        case .unknown:
+            showAlert(title: L10n.Sync.Auth.unknown)
+        }
+    }
+
+    private func showAlert(title: String) {
+        let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: L10n.Common.ok, style: .default))
+        present(alert, animated: true)
+    }
+}


### PR DESCRIPTION
## 배경
- 사인인 UI 트랙(R1~R5)의 R4. Settings → 계정에서 진입할 상세 페이지를 SettingsFeature 모듈에 추가
- 미로그인 상태에서는 Sign in with Apple 진입점, 로그인 상태에서는 사용자 정보·로그아웃·계정 삭제를 한 페이지에서 처리
- 본 PR 단독으론 *진입점 없음*. Settings 첫 섹션에 "계정" 셀 추가는 R5에서. R5 머지 시점에 사용자에게 노출됨

## 변경사항
- L10n.Account 네임스페이스 신설 (13개 키, 한국어·영어)
  - 동기화 가치 안내 + 되돌릴 수 없음 경고 톤
  - 동기화 상태/시각 값은 sync 본 작업 전이라 placeholder("준비 중", "—")
- SettingsFeature가 SyncInterface(AuthService)에 의존하도록 Project.swift 갱신
- AccountDetailView + AccountDetailViewController 신설 (SettingsFeature 기존 sub-feature 패턴 따름)
  - 두 가지 상태를 stackView 컨테이너 isHidden 토글로 표시
    - 미로그인: 안내 텍스트 + ASAuthorizationAppleIDButton(.black 고정)
    - 로그인: 이름/이메일 + 동기화 상태 row + 최근 동기화 row + 로그아웃 + 계정 삭제
  - 상태 전환은 authStatePublisher 구독으로 자동 반영. 액션 직후 수동 reload 불요
  - 로그아웃·계정 삭제 모두 confirmation alert 1단계 (텍스트 입력 없이 destructive 버튼만 — 일전 결정 정책)
  - 활동 인디케이터 + 버튼 비활성으로 비동기 호출 중 중복 입력 차단

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- `tuist test` 전체 통과 확인
- 수동 검증은 *진입점 없음*으로 어려움. 개발자가 임시로 SceneDelegate 또는 다른 곳에서 `AccountDetailViewController(authService:)`를 push해서 화면 단독 검증 권장. 정식 검증은 R5 머지 후

## 리뷰 노트
- **본 PR 단독 사용자 영향 0**: 진입점이 R5에서 추가될 예정이라 현재 코드는 호출되지 않음
- **이름/이메일 표시**: `AuthUser.displayName` / `.email`을 그대로 표시. 첫 로그인 시 Apple로부터 받은 정보가 Firebase Auth user profile에 영구 저장되므로 다른 기기에서도 동일하게 노출
- **로그아웃 시 동기화 상태 안내**: confirmation 본문에 "이 기기에서 동기화가 멈춤" + "계정의 메모는 계속 안전" 명시. 사용자가 데이터 손실 우려 없이 의도 확인 가능
- **계정 삭제 톤**: "되돌릴 수 없어요. 계정과 모든 동기화 데이터가 영구 삭제돼요". App Store 정책상 *앱 내 계정 삭제 경로* 필수 요건도 본 PR로 갖춰짐
- **동기화 상태·시각 placeholder**: 두 row가 항상 "준비 중" / "—"로 표시됨. sync 본 작업에서 실제 값으로 교체될 영역
- **다음 작업 R5**: Settings 첫 섹션에 "계정" 셀 추가 + AccountDetailVC로 push. 노출 시점. 일전 결정한 "다음 release까지 무조건 완성, 못 완성하면 임시 flag 게이트" 정책의 *완성 시점*