### PR TITLE
feat(settings): Settings 첫 섹션에 계정 진입점 추가

### DIFF
--- a/NoteCard/Presentation/TabBar/MainTabBarController.swift
+++ b/NoteCard/Presentation/TabBar/MainTabBarController.swift
@@ -101,6 +101,7 @@ class MainTabBarController: UITabBarController {
             memoRepository: environment.memoRepository,
             categoryRepository: environment.categoryRepository,
             analytics: environment.analytics,
+            authService: environment.authService,
             makeTrashViewController: { [environment] in
                 MemoViewController(memoVCType: .trash, environment: environment)
             }

--- a/Projects/Feature/SettingsFeature/Sources/SettingsViewController.swift
+++ b/Projects/Feature/SettingsFeature/Sources/SettingsViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import Domain
 import DesignSystem
 import Shared
+import SyncInterface
 import Combine
 
 public final class SettingsViewController: UITableViewController {
@@ -17,17 +18,20 @@ public final class SettingsViewController: UITableViewController {
     private let memoRepository: MemoRepository
     private let categoryRepository: CategoryRepository
     private let analytics: Analytics
+    private let authService: AuthService
     private let makeTrashViewController: () -> UIViewController
 
     public init(
         memoRepository: MemoRepository,
         categoryRepository: CategoryRepository,
         analytics: Analytics,
+        authService: AuthService,
         makeTrashViewController: @escaping () -> UIViewController
     ) {
         self.memoRepository = memoRepository
         self.categoryRepository = categoryRepository
         self.analytics = analytics
+        self.authService = authService
         self.makeTrashViewController = makeTrashViewController
         super.init(nibName: nil, bundle: nil)
     }
@@ -37,7 +41,10 @@ public final class SettingsViewController: UITableViewController {
     }
 
     var settingTitles: [[String]] = [
-        
+
+        //account
+        [L10n.Account.title],
+
         //design
         //표시 순서는 각 컬렉션뷰에서 선택
         [L10n.Settings.themeColor,
@@ -47,14 +54,14 @@ public final class SettingsViewController: UITableViewController {
         ],
         //표시 순서 대신, 표시 안의 하위 항목으로 앱 잠금 시 표시 방법? 이런 걸 써도 좋을 듯. (앱 잠금 시 제목만 보일 건지, 아니면 수정 날짜만 보일 건지...등)
         //그리고 표시 안의 하위 항목으로 다른 것들 도 표시할 수 있으니...
-        
+
         //data
         //"메모 검색" 기능은 추후 아예 탭으로 빼 버릴 수도 있음.
         [L10n.Settings.totalMemos, L10n.Settings.totalCategories, L10n.MemoView.trash, L10n.Settings.emptyTrash],
-        
+
         //contact
         [L10n.Settings.version]
-        
+
     ]
     
     let settingsTableView: UITableView = {
@@ -98,7 +105,7 @@ public final class SettingsViewController: UITableViewController {
     }
     
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        self.tableView.reloadRows(at: [IndexPath(row: 3, section: 0)], with: UITableView.RowAnimation.none)
+        self.tableView.reloadRows(at: [IndexPath(row: 3, section: 2)], with: UITableView.RowAnimation.none)
     }
     
     private func setupUI() {
@@ -182,6 +189,14 @@ extension SettingsViewController {
         
         switch indexPath {
         case IndexPath(row: 0, section: 0):
+            cell.configureCell(
+                image: UIImage(systemName: "person.crop.circle"),
+                text: self.settingTitles[indexPath.section][indexPath.row],
+                secondaryText: "",
+                accesoryType: UITableViewCell.AccessoryType.disclosureIndicator
+            )
+
+        case IndexPath(row: 0, section: 1):
             guard let currentTheme = UserDefaults.standard.string(forKey: UserDefaultsKeys.themeColor.rawValue) else { fatalError() }
             var secondaryText: String = ""
             
@@ -216,7 +231,7 @@ extension SettingsViewController {
                                accesoryType: UITableViewCell.AccessoryType.disclosureIndicator
             )
             
-        case IndexPath(row: 1, section: 0):
+        case IndexPath(row: 1, section: 1):
             let isTimeFormat24 = UserDefaults.standard.bool(forKey: UserDefaultsKeys.isTimeFormat24.rawValue)
             cell.configureCell(image: UIImage(systemName: "clock"), 
                                text: self.settingTitles[indexPath.section][indexPath.row],
@@ -224,7 +239,7 @@ extension SettingsViewController {
                                accesoryType: UITableViewCell.AccessoryType.disclosureIndicator
             )
             
-        case IndexPath(row: 2, section: 0):
+        case IndexPath(row: 2, section: 1):
             guard let userDefaultCriterion = UserDefaults.standard.string(forKey: UserDefaultsKeys.orderCriterion.rawValue) else { fatalError() }
             let userDefautlAscendingValue = UserDefaults.standard.bool(forKey: UserDefaultsKeys.isOrderAscending.rawValue)
             let currentState1: String
@@ -252,7 +267,7 @@ extension SettingsViewController {
                                accesoryType: UITableViewCell.AccessoryType.disclosureIndicator
             )
             
-        case IndexPath(row: 3, section: 0):
+        case IndexPath(row: 3, section: 1):
             guard let darkModeTheme =
                     UserDefaults.standard.string(forKey: UserDefaultsKeys.darkModeTheme.rawValue) else { fatalError()}
             switch darkModeTheme {
@@ -284,7 +299,7 @@ extension SettingsViewController {
             }
             
             
-        case IndexPath(row: 0, section: 1):
+        case IndexPath(row: 0, section: 2):
             let totalNumberOfMemo = self.totalMemoCount
             
             cell.configureCell(image: UIImage(systemName: "rectangle.portrait.on.rectangle.portrait"),
@@ -294,7 +309,7 @@ extension SettingsViewController {
             )
             cell.selectionStyle = .none
             
-        case IndexPath(row: 1, section: 1):
+        case IndexPath(row: 1, section: 2):
             let totalNumberOfCategory = self.totalCategoryCount
             cell.configureCell(image: UIImage(systemName: "circlebadge.2"),
                                text: self.settingTitles[indexPath.section][indexPath.row],
@@ -303,7 +318,7 @@ extension SettingsViewController {
             )
             cell.selectionStyle = .none
             
-        case IndexPath(row: 2, section: 1):
+        case IndexPath(row: 2, section: 2):
             let numberOfMemoesInTrash = self.trashMemoCount
             cell.configureCell(image: UIImage(systemName: "trash")?.withTintColor(.systemGray).withRenderingMode(UIImage.RenderingMode.alwaysOriginal),
                                text: self.settingTitles[indexPath.section][indexPath.row],
@@ -311,7 +326,7 @@ extension SettingsViewController {
                                accesoryType: UITableViewCell.AccessoryType.disclosureIndicator
             )
             
-        case IndexPath(row: 3, section: 1):
+        case IndexPath(row: 3, section: 2):
             let numberOfMemoesInTrash = self.trashMemoCount
             
             cell.configureCell(text: self.settingTitles[indexPath.section][indexPath.row],
@@ -319,7 +334,7 @@ extension SettingsViewController {
                                accesoryType: UITableViewCell.AccessoryType.none
             )
             
-        case IndexPath(row: 0, section: 2):
+        case IndexPath(row: 0, section: 3):
             
             guard let currentAppName = Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String else { fatalError() }
             guard let currentAppVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { fatalError() }
@@ -345,7 +360,7 @@ extension SettingsViewController {
     }
     
     public override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        if section == 1 {
+        if section == 2 {
             return L10n.Settings.trashRetentionMessage
         } else {
             return nil
@@ -358,7 +373,7 @@ extension SettingsViewController {
 extension SettingsViewController {
     
     public override func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-        guard indexPath.section == 1, indexPath.row == 3 else { return indexPath }
+        guard indexPath.section == 2, indexPath.row == 3 else { return indexPath }
         guard let cell = self.settingsTableView.cellForRow(at: indexPath) as? SettingsTableViewCell else { fatalError() }
         let numberOfMemoesInTrash = self.trashMemoCount
         if numberOfMemoesInTrash == 0 {
@@ -374,17 +389,19 @@ extension SettingsViewController {
         
         switch indexPath {
         case IndexPath(row: 0, section: 0):
+            targetVC = AccountDetailViewController(authService: authService)
+        case IndexPath(row: 0, section: 1):
             targetVC = ThemeColorPickingViewController()
-        case IndexPath(row: 1, section: 0):
+        case IndexPath(row: 1, section: 1):
             targetVC = TimeFormatSettingViewController()
-        case IndexPath(row: 2, section: 0):
+        case IndexPath(row: 2, section: 1):
             targetVC = OrderSettingViewController()
-        case IndexPath(row: 3, section: 0):
+        case IndexPath(row: 3, section: 1):
             targetVC = DarkModeSettingViewController()
             
-        case IndexPath(row: 2, section: 1):
+        case IndexPath(row: 2, section: 2):
             targetVC = makeTrashViewController()
-        case IndexPath(row: 3, section: 1):
+        case IndexPath(row: 3, section: 2):
             showDeleteAllAlert(indexPath: indexPath)
             
         default:


### PR DESCRIPTION
## 배경
- 사인인 UI 트랙(R1~R5)의 마지막 R5. 사용자에게 동기화 진입 경로를 정식 노출
- 본 PR 머지 후 사용자가 Settings → 계정에서 Apple Sign in / 로그아웃 / 계정 삭제 가능. *Firestore 동기화는 별개* (sync 본 작업 대기)

## 변경사항
- SettingsViewController의 `settingTitles` 첫 섹션으로 `[L10n.Account.title]`만 담은 새 섹션 추가
  - 기존 design / data / contact 섹션이 한 단계씩 뒤로 밀림
  - 모든 IndexPath 분기와 `section == N` 체크를 그에 맞춰 +1 갱신
    - `cellForRowAt` / `didSelectRowAt` switch
    - `willSelectRowAt` (휴지통 비활성 조건)
    - `titleForFooterInSection` (휴지통 보관 안내 위치)
    - `traitCollectionDidChange` (다크모드 row reload)
- `cellForRowAt`에 새 row 0 section 0 = account 셀(`person.crop.circle` 아이콘 + 텍스트 + disclosure indicator) 추가
- `didSelectRowAt`에 새 row 0 section 0 → `AccountDetailViewController` push 핸들러 추가
- `SettingsViewController.init`에 `authService` 매개변수 추가. SyncInterface import 추가
- `MainTabBarController`에서 SettingsVC 생성 시 `environment.authService` 전달

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- `tuist test` 전체 통과 확인
- 수동:
  - Settings 탭 진입 → 첫 섹션에 "계정" 셀 + person.crop.circle 아이콘 표시 확인
  - 셀 누름 → AccountDetailVC navigation push
    - 미로그인 상태: Sign in with Apple 버튼 + 안내 텍스트
    - 로그인 상태: 사용자 이름/이메일 + 동기화 상태 placeholder + 로그아웃 + 계정 삭제
  - 기존 design / data / contact 섹션의 모든 항목이 정상 동작 (테마 / 시간 형식 / 정렬 / 다크모드 / 휴지통 / 빈 휴지통 확인 / 버전 표시)
  - 휴지통 메모 0개일 때 "휴지통 비우기" 셀 비활성 (willSelectRowAt 조건 갱신 검증)

## 리뷰 노트
- **사용자 노출 시작 시점**: 본 PR 머지 시점부터 사용자가 Settings에서 동기화 진입 가능. 일전 결정 "다음 release까지 무조건 완성" 정책의 *완성 시점*. sync 본 작업이 R5 머지 후 별도 트랙으로 진행됨
- **IndexPath 일괄 +1**: 분기 다수에서 hardcoded section 번호를 +1로 옮김. 변경량 자체는 크지만 *기계적 이동*. 잘못 옮긴 분기가 없는지 수동 검증으로 보강 권장
  - 다크모드 row reload 위치, 휴지통 footer 위치, 휴지통 비우기 비활성 조건 셋
- **아이콘 색상**: `SettingsTableViewCell.configureCell`이 자동으로 `tintColor`를 `currentTheme.withAlphaComponent(0.8)`로 적용. 다른 셀과 일관

## 사인인 UI 트랙 완료
- R1 ✅ AnonymousToUserMigrator (#39)
- R2 ✅ LoginVC + SceneDelegate 분기 (#40)
- R3 ✅ What's new 모달 (#41)
- R4 ✅ 계정 상세 페이지 (#42)
- R5 (본 PR) Settings 진입점
- 다음 트랙: Firestore 동기화 본 작업