### PR TITLE
feat(domain): Category에 UUID 식별자 도입 (Firestore 동기화 선행)

### DIFF
--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -55,6 +55,13 @@ struct AppEnvironment {
         )
         self.dataLayer = dataLayer
 
+        // v3 모델로 마이그레이션된 store에서 categoryID가 nil인 row를 채움 (1회, 멱등).
+        // Core Data lightweight migration이 row별 다른 UUID를 부여 못 해 코드로 backfill.
+        CategoryUUIDBackfiller.backfill(
+            in: dataLayer.currentStack,
+            onError: { error in assertionFailure("CategoryUUIDBackfiller 실패: \(error)") }
+        )
+
         let memoRepository = MemoRepositoryImpl(dataLayer: dataLayer)
         self.memoRepository = memoRepository
         self.categoryRepository = CategoryRepositoryImpl(dataLayer: dataLayer)

--- a/Projects/Data/Sources/CoreData/CategoryUUIDBackfiller.swift
+++ b/Projects/Data/Sources/CoreData/CategoryUUIDBackfiller.swift
@@ -1,0 +1,33 @@
+//
+//  CategoryUUIDBackfiller.swift
+//  NoteCard
+//
+
+import CoreData
+import Foundation
+
+/// v2 → v3 마이그레이션 후 `CategoryEntity.categoryID`가 nil인 row를 찾아 새 UUID를 부여한다.
+///
+/// Core Data lightweight migration은 attribute 추가까지만 처리하고 row별 다른 값을 채우진 못해서
+/// (UUID Default Value는 단일 값만 가능) 코드 수준의 backfill이 필요. 앱 시작 시 1회 실행하면
+/// 이후엔 `categoryID`가 항상 non-nil 상태가 보장된다.
+public enum CategoryUUIDBackfiller {
+
+    public static func backfill(in stack: CoreDataStack, onError: (Error) -> Void = { _ in }) {
+        let context = stack.backgroundContext
+        context.performAndWait {
+            do {
+                let request = CategoryEntity.fetchRequest()
+                request.predicate = NSPredicate(format: "categoryID == nil")
+                let pending = try context.fetch(request)
+                guard !pending.isEmpty else { return }
+                for entity in pending {
+                    entity.categoryID = UUID()
+                }
+                try context.save()
+            } catch {
+                onError(error)
+            }
+        }
+    }
+}

--- a/Projects/Data/Sources/CoreData/Models/CategoryEntity+CoreDataProperties.swift
+++ b/Projects/Data/Sources/CoreData/Models/CategoryEntity+CoreDataProperties.swift
@@ -18,6 +18,8 @@ public extension CategoryEntity {
         return NSFetchRequest<CategoryEntity>(entityName: "CategoryEntity")
     }
 
+    /// v3에서 추가된 안정 식별자. v2 store에는 없으므로 optional로 유지하고 앱 시작 시 `CategoryUUIDBackfiller`로 채움.
+    @NSManaged var categoryID: UUID?
     @NSManaged var creationDate: Date
     @NSManaged var modificationDate: Date
     @NSManaged var name: String

--- a/Projects/Data/Sources/CoreData/Models/CategoryEntity+Mapping.swift
+++ b/Projects/Data/Sources/CoreData/Models/CategoryEntity+Mapping.swift
@@ -10,30 +10,41 @@ import Domain
 import Shared
 
 public extension CategoryEntity {
-    
+
     func toDomain() -> Domain.Category {
-        Domain.Category(
+        let id: UUID
+        if let existing = self.categoryID {
+            id = existing
+        } else {
+            // backfill 누락 방어. assertionFailure로 dev 즉시 trap, release에선 self-heal로 새 UUID 부여.
+            assertionFailure("CategoryEntity.categoryID nil — CategoryUUIDBackfiller가 누락된 상태일 수 있음")
+            id = UUID()
+            self.categoryID = id
+        }
+        return Domain.Category(
+            id: id,
             name: self.name,
             creationDate: self.creationDate,
-            modificationDate: self.modificationDate,
+            modificationDate: self.modificationDate
         )
     }
-    
+
 }
 
 public extension Domain.Category {
-    
+
     func toEntity(in context: NSManagedObjectContext) -> CategoryEntity {
         let request = CategoryEntity.fetchRequest()
-        request.predicate = NSPredicate(format: "name == %@", name as CVarArg)
+        request.predicate = NSPredicate(format: "categoryID == %@", id as CVarArg)
 
         if let existingCategoryEntity = try? context.fetch(request).first {
             return existingCategoryEntity
         } else {
             let newEntity = CategoryEntity(context: context)
+            newEntity.categoryID = self.id
             newEntity.name = self.name
             return newEntity
         }
     }
-    
+
 }

--- a/Projects/Data/Sources/CoreData/NoteCardCoreData.xcdatamodeld/.xccurrentversion
+++ b/Projects/Data/Sources/CoreData/NoteCardCoreData.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>NoteCardCoreData 2.xcdatamodel</string>
+	<string>NoteCardCoreData 3.xcdatamodel</string>
 </dict>
 </plist>

--- a/Projects/Data/Sources/CoreData/NoteCardCoreData.xcdatamodeld/NoteCardCoreData 3.xcdatamodel/contents
+++ b/Projects/Data/Sources/CoreData/NoteCardCoreData.xcdatamodeld/NoteCardCoreData 3.xcdatamodel/contents
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24D70" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="CategoryEntity" representedClassName="CategoryEntity" syncable="YES">
+        <attribute name="categoryID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="creationDate" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="modificationDate" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="name" attributeType="String"/>
+        <relationship name="memoSet" toMany="YES" deletionRule="Nullify" destinationEntity="MemoEntity" inverseName="categories" inverseEntity="MemoEntity"/>
+    </entity>
+    <entity name="ImageEntity" representedClassName="ImageEntity" syncable="YES">
+        <attribute name="fileExtension" attributeType="String" defaultValueString="jpeg"/>
+        <attribute name="isTemporaryAppended" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isTemporaryDeleted" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="orderIndex" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="temporaryOrderIndex" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="thumbnailUUID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="uuid" attributeType="UUID" defaultValueString="00000000-0000-4000-A000-000000000000" usesScalarValueType="NO"/>
+        <relationship name="memo" maxCount="1" deletionRule="Nullify" destinationEntity="MemoEntity" inverseName="images" inverseEntity="MemoEntity"/>
+    </entity>
+    <entity name="MemoEntity" representedClassName="MemoEntity" syncable="YES">
+        <attribute name="creationDate" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="deletedDate" optional="YES" attributeType="Date" defaultDateTimeInterval="726847920" usesScalarValueType="NO"/>
+        <attribute name="isFavorite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isInTrash" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="memoID" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="memoText" attributeType="String"/>
+        <attribute name="memoTitle" attributeType="String"/>
+        <attribute name="modificationDate" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="categories" toMany="YES" deletionRule="Nullify" destinationEntity="CategoryEntity" inverseName="memoSet" inverseEntity="CategoryEntity"/>
+        <relationship name="images" toMany="YES" deletionRule="Nullify" destinationEntity="ImageEntity" inverseName="memo" inverseEntity="ImageEntity"/>
+    </entity>
+</model>

--- a/Projects/Data/Sources/Repositories/CategoryRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/CategoryRepositoryImpl.swift
@@ -64,20 +64,20 @@ public extension CategoryRepositoryImpl {
 
 public extension CategoryRepositoryImpl {
     
-    private func fetchCategoryEntity(name: String) throws -> CategoryEntity {
+    private func fetchCategoryEntity(id: UUID) throws -> CategoryEntity {
         let request = CategoryEntity.fetchRequest()
-        request.predicate = categoryNameEqual(to: name)
+        request.predicate = NSPredicate(format: "categoryID == %@", id as CVarArg)
         let foundCategory = try self.context.fetch(request)
         switch foundCategory.count {
         case 0:
-            throw CoreDataError.categoryNotFound(name: name)
+            throw CoreDataError.categoryNotFound(id: id)
         case 1:
             return foundCategory.first!
         default:
             throw CoreDataError.duplicateCategoryDetected
         }
     }
-    
+
     func create(name: String) async throws {
         let allCategoryNames = try await getAllCategories(inOrderOf: .modificationDate, isAscending: false).map(\.name)
         guard !allCategoryNames.contains(name) else {
@@ -85,6 +85,7 @@ public extension CategoryRepositoryImpl {
         }
         try await context.perform { [unowned self] in
             let newCategory = CategoryEntity(context: self.context)
+            newCategory.categoryID = UUID()
             newCategory.name = name
             try self.context.save()
         }
@@ -131,7 +132,7 @@ public extension CategoryRepositoryImpl {
             throw CoreDataError.duplicateCategoryDetected
         }
         try await context.perform { [unowned self] in
-            let categoryEntity = try fetchCategoryEntity(name: category.name)
+            let categoryEntity = try fetchCategoryEntity(id: category.id)
             categoryEntity.name = newName
             try context.save()
         }
@@ -139,7 +140,7 @@ public extension CategoryRepositoryImpl {
     
     func deleteCategory(_ category: Domain.Category) async throws {
         try await context.perform { [unowned self] in
-            let categoryEntity = try fetchCategoryEntity(name: category.name)
+            let categoryEntity = try fetchCategoryEntity(id: category.id)
             context.delete(categoryEntity)
             try context.save()
         }
@@ -147,14 +148,14 @@ public extension CategoryRepositoryImpl {
     
     func memoCount(of category: Domain.Category) async throws -> Int {
         try await context.perform { [unowned self] in
-            let categoryEntity = try fetchCategoryEntity(name: category.name)
+            let categoryEntity = try fetchCategoryEntity(id: category.id)
             return categoryEntity.memoSet.count
         }
     }
     
     func updateModificationDate(of category: Domain.Category) async throws {
         try await context.perform { [unowned self] in
-            let categoryEntity = try fetchCategoryEntity(name: category.name)
+            let categoryEntity = try fetchCategoryEntity(id: category.id)
             categoryEntity.modificationDate = .now
         }
     }

--- a/Projects/Data/Sources/Repositories/MemoRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/MemoRepositoryImpl.swift
@@ -79,7 +79,7 @@ public final class MemoRepositoryImpl: MemoRepository, @unchecked Sendable {
     /// `category` 인자가 `nil`인 경우, 카테고리가 없는 데이터를 가져옴.
     private func memoHasCategory(_ category: Domain.Category?) -> NSPredicate {
         if let category {
-            return NSPredicate(format: "ANY categories.name == %@", category.name as CVarArg)
+            return NSPredicate(format: "ANY categories.categoryID == %@", category.id as CVarArg)
         } else {
             return NSPredicate(format: "categories.@count == 0")
         }

--- a/Projects/Data/Tests/MappingTests.swift
+++ b/Projects/Data/Tests/MappingTests.swift
@@ -55,6 +55,7 @@ final class MappingTests: XCTestCase {
             // given
             let memoEntity = MemoEntity(context: context)
             let categoryEntity = CategoryEntity(context: context)
+            categoryEntity.categoryID = UUID()
             categoryEntity.name = "업무"
             memoEntity.addToCategories(categoryEntity)
 
@@ -111,6 +112,7 @@ final class MappingTests: XCTestCase {
         context.performAndWait {
             // given
             let entity = CategoryEntity(context: context)
+            entity.categoryID = UUID()
             entity.name = "개인"
 
             // when

--- a/Projects/Data/Tests/MappingTests.swift
+++ b/Projects/Data/Tests/MappingTests.swift
@@ -54,8 +54,9 @@ final class MappingTests: XCTestCase {
         context.performAndWait {
             // given
             let memoEntity = MemoEntity(context: context)
+            let categoryID = UUID()
             let categoryEntity = CategoryEntity(context: context)
-            categoryEntity.categoryID = UUID()
+            categoryEntity.categoryID = categoryID
             categoryEntity.name = "업무"
             memoEntity.addToCategories(categoryEntity)
 
@@ -63,6 +64,7 @@ final class MappingTests: XCTestCase {
             let memo = memoEntity.toDomain()
 
             // then
+            XCTAssertEqual(memo.categories.map(\.id), [categoryID])
             XCTAssertEqual(memo.categories.map(\.name), ["업무"])
         }
     }

--- a/Projects/Data/Tests/MappingTests.swift
+++ b/Projects/Data/Tests/MappingTests.swift
@@ -158,28 +158,31 @@ final class MappingTests: XCTestCase {
 
     // MARK: - Category → CategoryEntity
 
-    func test_같은_이름의_엔티티가_없으면_새_CategoryEntity를_만든다() {
+    func test_같은_id의_엔티티가_없으면_새_CategoryEntity를_만든다() {
         context.performAndWait {
-            // given: 컨텍스트에 같은 이름의 엔티티가 없음
-            let category = Domain.Category(name: "신규", creationDate: .now, modificationDate: .now)
+            // given: 컨텍스트에 같은 id의 엔티티가 없음
+            let category = Domain.Category(id: UUID(), name: "신규", creationDate: .now, modificationDate: .now)
 
             // when
             let entity = category.toEntity(in: context)
 
             // then
             XCTAssertEqual(entity.name, "신규")
+            XCTAssertEqual(entity.categoryID, category.id)
         }
     }
 
-    func test_같은_이름의_엔티티가_있으면_기존_것을_재사용한다() {
+    func test_같은_id의_엔티티가_있으면_기존_것을_재사용한다() {
         context.performAndWait {
-            // given: 이미 "업무" CategoryEntity가 컨텍스트에 존재
+            // given: 이미 같은 id의 CategoryEntity가 컨텍스트에 존재
+            let sharedID = UUID()
             let existing = CategoryEntity(context: context)
+            existing.categoryID = sharedID
             existing.name = "업무"
             try? context.save()
 
-            // when: 같은 이름의 Domain 모델을 엔티티로 변환하면
-            let category = Domain.Category(name: "업무", creationDate: .now, modificationDate: .now)
+            // when: 같은 id의 Domain 모델을 엔티티로 변환하면
+            let category = Domain.Category(id: sharedID, name: "업무", creationDate: .now, modificationDate: .now)
             let entity = category.toEntity(in: context)
 
             // then: 새로 만들지 않고 기존 엔티티를 그대로 돌려준다

--- a/Projects/Domain/Sources/Errors/CoreDataError.swift
+++ b/Projects/Domain/Sources/Errors/CoreDataError.swift
@@ -13,7 +13,7 @@ public enum CoreDataError: NoteCardError {
     case fetchFailed(Error?)
     case saveFailed(Error?)
     case objectNotFound
-    case categoryNotFound(name: String)
+    case categoryNotFound(id: UUID)
     case duplicateCategoryDetected
     case duplicateImageDetected
     
@@ -25,8 +25,8 @@ public enum CoreDataError: NoteCardError {
             return "변경사항을 저장하는 데 실패했습니다. 다시 시도해 주세요."
         case .objectNotFound:
             return "요청한 데이터를 찾을 수 없습니다."
-        case .categoryNotFound(let name):
-            return "카테고리를 찾을 수 없습니다. UUID: \(name)"
+        case .categoryNotFound(let id):
+            return "카테고리를 찾을 수 없습니다. UUID: \(id)"
         case .duplicateCategoryDetected:
             return "같은 이름의 카테고리가 2개 이상 발견되었습니다. 조치 필요."
         case .duplicateImageDetected:

--- a/Projects/Domain/Sources/Models/Category.swift
+++ b/Projects/Domain/Sources/Models/Category.swift
@@ -9,11 +9,13 @@ import Foundation
 import Shared
 
 public struct Category: Hashable, Sendable {
+    public let id: UUID
     public var name: String
     public let creationDate: Date
     public var modificationDate: Date
 
-    public init(name: String, creationDate: Date, modificationDate: Date) {
+    public init(id: UUID, name: String, creationDate: Date, modificationDate: Date) {
+        self.id = id
         self.name = name
         self.creationDate = creationDate
         self.modificationDate = modificationDate

--- a/Projects/Domain/Tests/DomainTests.swift
+++ b/Projects/Domain/Tests/DomainTests.swift
@@ -6,7 +6,9 @@ final class DomainModelInitTests: XCTestCase {
     func test_category_initializer_setsAllProperties() {
         let now = Date()
         let later = now.addingTimeInterval(60)
-        let c = Category(name: "Work", creationDate: now, modificationDate: later)
+        let id = UUID()
+        let c = Category(id: id, name: "Work", creationDate: now, modificationDate: later)
+        XCTAssertEqual(c.id, id)
         XCTAssertEqual(c.name, "Work")
         XCTAssertEqual(c.creationDate, now)
         XCTAssertEqual(c.modificationDate, later)
@@ -15,8 +17,8 @@ final class DomainModelInitTests: XCTestCase {
     func test_category_comparable_byModificationDateThenCreation() {
         let now = Date()
         let earlier = now.addingTimeInterval(-60)
-        let a = Category(name: "A", creationDate: earlier, modificationDate: now)
-        let b = Category(name: "B", creationDate: now, modificationDate: now.addingTimeInterval(10))
+        let a = Category(id: UUID(), name: "A", creationDate: earlier, modificationDate: now)
+        let b = Category(id: UUID(), name: "B", creationDate: now, modificationDate: now.addingTimeInterval(10))
         XCTAssertLessThan(a, b)
     }
 }


### PR DESCRIPTION
## 배경
- Firestore 동기화 본 작업 선행. Memo / MemoImageInfo는 이미 UUID 식별자를 갖지만 Category만 name이 식별 키였음
- 이름 변경 sync가 깨지는 문제(이름 바뀌면 클라우드 입장에선 새 카테고리로 인식)를 막기 위해 안정 식별자 도입
- Domain 모델 일관성 회복 — 다른 entity와 같은 패턴

## 변경사항
- **Core Data v3 모델 추가**
  - CategoryEntity에 optional UUID 속성 `categoryID` 추가. 다른 entity는 변경 없음
  - `.xccurrentversion` v3로 갱신. v2 → v3 lightweight migration이 자동 처리
  - optional 이유: lightweight migration의 Default Value가 단일 고정값만 가능 → row별 다른 UUID는 코드 backfill로 처리
- **Domain 모델**
  - `Category.id: UUID` 추가 (let 불변). init 시그니처 변경
  - `CoreDataError.categoryNotFound` 페이로드를 name(String) → id(UUID)로 변경
- **Data 레이어**
  - `CategoryEntity+CoreDataProperties`에 `@NSManaged var categoryID: UUID?` 추가
  - `CategoryEntity+Mapping`
    - toDomain: categoryID nil 시 self-heal로 새 UUID 부여(assertionFailure로 dev 즉시 trap, release 폴백)
    - toEntity: fetch predicate를 name → categoryID 기반으로 변경
  - `CategoryRepositoryImpl`
    - 내부 fetchCategoryEntity가 id 기반으로. 외부 API 시그니처는 그대로 (Category 객체 받음)
    - create(name:)에서 새 entity에 UUID 부여
  - `MemoRepositoryImpl.memoHasCategory` predicate를 `categories.name` → `categories.categoryID`로
  - **`CategoryUUIDBackfiller` 신설** — 앱 시작 시 nil categoryID row를 찾아 UUID 부여 + save. 1회 멱등
- **DI**
  - `AppEnvironment.init`에서 dataLayer 생성 직후 backfiller 호출
  - LegacyStoreMigrator / AnonymousToUserMigrator와 동일한 onError 주입 패턴
- 테스트 갱신 (DomainTests / MappingTests의 Category 생성 + 식별 기준)

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- 자동 테스트: Xcode에서 `NoteCard-Workspace` scheme + cmd+U (모든 test suite passed 확인)
- 수동 (가장 중요한 검증):
  - **v2 데이터가 있는 시뮬레이터**(직전 main 빌드 → 본 PR 빌드 업데이트) → 기존 카테고리 모두 정상 표시 + 카테고리에 연결된 메모도 정상 + 카테고리 이름 변경/삭제 정상
  - **새 시뮬레이터**(Erase All Content) → 신규 카테고리 생성 + 메모와 연결 + 재실행 시 그대로 유지
  - 카테고리 필터(홈 → 특정 카테고리) → 해당 카테고리 메모만 표시

## 리뷰 노트
- **categoryID가 optional인 이유**: lightweight migration 제약 + row별 다른 UUID 부여 필요성. 영구 optional은 *이상적이지 않음*. 미래 v4 모델로 promote 시 Custom Mapping Policy와 함께 non-optional 전환 가능 (별도 cycle)
- **외부 API 시그니처 변경 없음**: `CategoryRepository` 인터페이스의 메서드는 그대로. *내부 식별 메커니즘만 name → id*로 전환. 호출부(ViewController 등) 변경 0
- **사용자 동작 영향**: 마이그레이션 + backfill이 *조용히* 진행. 사용자가 보는 카테고리 동작은 완전 동일
- **방어선 이중**: backfill이 채움 + Mapping의 toDomain이 self-heal. 둘 중 어느 하나라도 실패해도 다음 한 단계가 받아줌
- **다음 작업**: Firestore 동기화 본 작업(Memo 양방향 sync 등)으로 진입