### PR TITLE
feat(data): CategoryRepository 변경 이벤트 publisher 추가

### DIFF
--- a/Projects/Data/Sources/Repositories/CategoryRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/CategoryRepositoryImpl.swift
@@ -170,6 +170,7 @@ public extension CategoryRepositoryImpl {
         try await context.perform { [unowned self] in
             let categoryEntity = try fetchCategoryEntity(id: category.id)
             categoryEntity.modificationDate = .now
+            try context.save()
         }
         categoryUpdatedSubject.send(.update(content: .modificationDate(categoryIDs: [category.id])))
     }

--- a/Projects/Data/Sources/Repositories/CategoryRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/CategoryRepositoryImpl.swift
@@ -5,6 +5,7 @@
 //  Created by 김민성 on 8/28/25.
 //
 
+import Combine
 import Foundation
 import CoreData
 import Domain
@@ -21,6 +22,15 @@ public final class CategoryRepositoryImpl: CategoryRepository, @unchecked Sendab
     private var context: NSManagedObjectContext {
         stackResolver().backgroundContext
     }
+
+    // MARK: - Subjects, Publisher
+
+    private let categoryUpdatedSubject = PassthroughSubject<CategoryUpdateType, Never>()
+    public var categoryUpdatedPublisher: AnyPublisher<CategoryUpdateType, Never> {
+        categoryUpdatedSubject.eraseToAnyPublisher()
+    }
+
+    // MARK: - Init
 
     public init(dataLayer: UserScopedDataLayer) {
         self.stackResolver = { dataLayer.currentStack }
@@ -89,6 +99,7 @@ public extension CategoryRepositoryImpl {
             newCategory.name = name
             try self.context.save()
         }
+        categoryUpdatedSubject.send(.create)
     }
     
     func getAllCategories(inOrderOf orderCriterion: CategoryProperties, isAscending: Bool) async throws -> [Domain.Category] {
@@ -136,14 +147,16 @@ public extension CategoryRepositoryImpl {
             categoryEntity.name = newName
             try context.save()
         }
+        categoryUpdatedSubject.send(.update(content: .name(categoryIDs: [category.id])))
     }
-    
+
     func deleteCategory(_ category: Domain.Category) async throws {
         try await context.perform { [unowned self] in
             let categoryEntity = try fetchCategoryEntity(id: category.id)
             context.delete(categoryEntity)
             try context.save()
         }
+        categoryUpdatedSubject.send(.delete)
     }
     
     func memoCount(of category: Domain.Category) async throws -> Int {
@@ -158,6 +171,7 @@ public extension CategoryRepositoryImpl {
             let categoryEntity = try fetchCategoryEntity(id: category.id)
             categoryEntity.modificationDate = .now
         }
+        categoryUpdatedSubject.send(.update(content: .modificationDate(categoryIDs: [category.id])))
     }
     
 }

--- a/Projects/Data/Tests/CategoryRepositoryTests.swift
+++ b/Projects/Data/Tests/CategoryRepositoryTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import XCTest
 import Domain
 @testable import Data
@@ -194,6 +195,66 @@ final class CategoryRepositoryTests: XCTestCase {
 
         // then
         XCTAssertEqual(count, 0)
+    }
+
+    // MARK: - 이벤트 퍼블리셔
+
+    func test_카테고리를_생성하면_퍼블리셔로_생성_이벤트가_방출된다() async throws {
+        // given
+        var received: [CategoryUpdateType] = []
+        let cancellable = sut.categoryUpdatedPublisher.sink { received.append($0) }
+        defer { cancellable.cancel() }
+
+        // when
+        try await sut.create(name: "업무")
+
+        // then
+        XCTAssertEqual(received, [.create])
+    }
+
+    func test_카테고리_이름을_변경하면_퍼블리셔로_업데이트_이벤트가_방출된다() async throws {
+        // given
+        try await sut.create(name: "업무")
+        let work = try await category(named: "업무")
+        var received: [CategoryUpdateType] = []
+        let cancellable = sut.categoryUpdatedPublisher.sink { received.append($0) }
+        defer { cancellable.cancel() }
+
+        // when
+        try await sut.changeCategoryName(work, newName: "회사")
+
+        // then
+        XCTAssertEqual(received, [.update(content: .name(categoryIDs: [work.id]))])
+    }
+
+    func test_카테고리를_삭제하면_퍼블리셔로_삭제_이벤트가_방출된다() async throws {
+        // given
+        try await sut.create(name: "업무")
+        let work = try await category(named: "업무")
+        var received: [CategoryUpdateType] = []
+        let cancellable = sut.categoryUpdatedPublisher.sink { received.append($0) }
+        defer { cancellable.cancel() }
+
+        // when
+        try await sut.deleteCategory(work)
+
+        // then
+        XCTAssertEqual(received, [.delete])
+    }
+
+    func test_수정일_갱신시_퍼블리셔로_업데이트_이벤트가_방출된다() async throws {
+        // given
+        try await sut.create(name: "업무")
+        let work = try await category(named: "업무")
+        var received: [CategoryUpdateType] = []
+        let cancellable = sut.categoryUpdatedPublisher.sink { received.append($0) }
+        defer { cancellable.cancel() }
+
+        // when
+        try await sut.updateModificationDate(of: work)
+
+        // then
+        XCTAssertEqual(received, [.update(content: .modificationDate(categoryIDs: [work.id]))])
     }
 
     // MARK: - 헬퍼

--- a/Projects/Domain/Sources/Repositories/CategoryRepository.swift
+++ b/Projects/Domain/Sources/Repositories/CategoryRepository.swift
@@ -5,11 +5,14 @@
 //  Created by 김민성 on 8/28/25.
 //
 
+import Combine
 import Foundation
 import Shared
 
 public protocol CategoryRepository: Sendable {
-    
+
+    var categoryUpdatedPublisher: AnyPublisher<CategoryUpdateType, Never> { get }
+
     func create(name: String) async throws
     
     func getAllCategories(

--- a/Projects/Domain/Sources/Repositories/CategoryUpdateType.swift
+++ b/Projects/Domain/Sources/Repositories/CategoryUpdateType.swift
@@ -1,0 +1,25 @@
+//
+//  CategoryUpdateType.swift
+//  NoteCard
+//
+
+import Foundation
+
+/// `CategoryRepository`가 발행하는 카테고리 변경 이벤트의 종류.
+public enum CategoryUpdateType: Equatable {
+    public enum UpdateAttribute: Equatable {
+        case name(categoryIDs: [UUID])
+        case modificationDate(categoryIDs: [UUID])
+
+        public var categoryIDs: [UUID] {
+            switch self {
+            case .name(let categoryIDs): return categoryIDs
+            case .modificationDate(let categoryIDs): return categoryIDs
+            }
+        }
+    }
+
+    case create
+    case delete
+    case update(content: UpdateAttribute)
+}


### PR DESCRIPTION
## 배경
- 메모 동기화(Firestore) v1의 선행 작업. 외부 기기에서 카테고리가 추가/이름변경/삭제되어 로컬 Core Data가 갱신될 때, UI(특히 홈 화면 카테고리 셀)가 반응할 수 있도록 변경 이벤트 publisher 도입.
- `MemoRepository.memoUpdatedPublisher`와 동일 패턴으로 통일.

## 변경사항
- `CategoryUpdateType` enum 신설 (`Domain` 레이어)
  - `.create` / `.delete` / `.update(content:)`
  - `UpdateAttribute`: `.name(categoryIDs:)`, `.modificationDate(categoryIDs:)`
- `CategoryRepository` 프로토콜에 `categoryUpdatedPublisher: AnyPublisher<CategoryUpdateType, Never>` 요구 추가
- `CategoryRepositoryImpl`
  - `PassthroughSubject<CategoryUpdateType, Never>` 추가
  - 4개 mutation에서 이벤트 발행
    - `create(name:)` → `.create`
    - `changeCategoryName(_:newName:)` → `.update(content: .name(...))`
    - `deleteCategory(_:)` → `.delete`
    - `updateModificationDate(of:)` → `.update(content: .modificationDate(...))`
- known issue fix: `updateModificationDate(of:)`가 `context.save()`를 호출하지 않아 다음 앱 실행 시 카테고리 수정일이 유실되던 문제 함께 해결 (별도 commit)
- `CategoryRepositoryTests`에 publisher 발행 검증 4종 추가

## 테스트 방법
- \`tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'\`
- \`tuist test\` 전체 96개 통과 — \`CategoryRepositoryTests\` 16개(기존 12 + 신규 4) 포함

## 리뷰 노트
- 현 PR 단독으로는 UI 동작에 변화 없음. publisher 구독자는 후속 sync 본 작업 및 홈 화면 카테고리 셀 반영 작업에서 추가될 예정.
- 발행 시점은 \`context.save()\` 이후, async 컨텍스트 빠져나온 메인 흐름에서 \`subject.send\`. \`MemoRepository\`와 동일 시점·동일 스레딩 가정.
- \`updateModificationDate\` save 누락 fix는 별도 commit으로 분리. 의미 단위(publisher 도입 / bug fix / 테스트) 3-commit 구성.