### PR TITLE
feat(sync): SyncService 인터페이스 + SyncStatus/SyncError 추가

### DIFF
--- a/Projects/Core/Shared/Resources/Localizable.xcstrings
+++ b/Projects/Core/Shared/Resources/Localizable.xcstrings
@@ -1786,6 +1786,91 @@
         }
       }
     },
+    "sync.error.network": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You appear to be offline. Sync will resume when the network is back."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "네트워크에 연결되어 있지 않아요. 연결이 복구되면 동기화가 다시 진행돼요."
+          }
+        }
+      }
+    },
+    "sync.error.permissionDenied": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync was blocked. Please sign out and sign back in."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "동기화가 거부되었어요. 로그아웃 후 다시 로그인해 주세요."
+          }
+        }
+      }
+    },
+    "sync.error.quotaExceeded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The sync service is over capacity. Please try again later."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "동기화 사용량이 초과되었어요. 잠시 후 다시 시도해주세요."
+          }
+        }
+      }
+    },
+    "sync.error.unauthenticated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your session has expired. Please sign in again."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인 세션이 만료되었어요. 다시 로그인해 주세요."
+          }
+        }
+      }
+    },
+    "sync.error.unknown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync ran into a problem. Please try again later."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "동기화 중 문제가 발생했어요. 잠시 후 다시 시도해주세요."
+          }
+        }
+      }
+    },
     "tabBar.home": {
       "extractionState": "manual",
       "localizations": {

--- a/Projects/Core/Shared/Sources/Localization/L10n.swift
+++ b/Projects/Core/Shared/Sources/Localization/L10n.swift
@@ -134,6 +134,14 @@ public enum L10n {
             public static let unknown = "sync.auth.unknown".localized()
         }
 
+        public enum Error {
+            public static let network = "sync.error.network".localized()
+            public static let permissionDenied = "sync.error.permissionDenied".localized()
+            public static let quotaExceeded = "sync.error.quotaExceeded".localized()
+            public static let unauthenticated = "sync.error.unauthenticated".localized()
+            public static let unknown = "sync.error.unknown".localized()
+        }
+
         public enum Introduction {
             public static let title = "sync.introduction.title".localized()
             public static let body = "sync.introduction.body".localized()

--- a/Projects/Core/SyncInterface/Sources/SyncError.swift
+++ b/Projects/Core/SyncInterface/Sources/SyncError.swift
@@ -1,0 +1,33 @@
+//
+//  SyncError.swift
+//  NoteCard
+//
+
+import Foundation
+import Shared
+
+/// 동기화 작업 중 발생할 수 있는 에러.
+///
+/// `errorDescription`은 사용자에게 직접 보여줘도 무방한 친화적 문구(`L10n.Sync.Error.*`)를 반환.
+/// 내부 진단·로깅 용도는 case 자체나 연관된 `unknown(Error)`을 직접 참조.
+public enum SyncError: LocalizedError {
+    /// 오프라인 또는 네트워크 끊김.
+    case network
+    /// Firestore Security Rules에서 거부. 보통 토큰이 stale하거나 다른 사용자의 데이터에 접근한 경우.
+    case permissionDenied
+    /// Firebase 프로젝트의 quota 초과.
+    case quotaExceeded
+    /// 인증이 끊긴 상태에서 동기화가 호출됨. 로그아웃 직후 listener 정리 race 등.
+    case unauthenticated
+    case unknown(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .network:           return L10n.Sync.Error.network
+        case .permissionDenied:  return L10n.Sync.Error.permissionDenied
+        case .quotaExceeded:     return L10n.Sync.Error.quotaExceeded
+        case .unauthenticated:   return L10n.Sync.Error.unauthenticated
+        case .unknown:           return L10n.Sync.Error.unknown
+        }
+    }
+}

--- a/Projects/Core/SyncInterface/Sources/SyncService.swift
+++ b/Projects/Core/SyncInterface/Sources/SyncService.swift
@@ -1,0 +1,29 @@
+//
+//  SyncService.swift
+//  NoteCard
+//
+
+import Combine
+import Foundation
+
+/// Firestore 기반 동기화 서비스의 추상화.
+///
+/// 구현체는 별도 모듈(SyncImpl)에 두고 App composition root에서 인스턴스를 만들어 의존 주입한다.
+/// 본 인터페이스는 lifecycle 제어와 상태 노출만 노출하고, 실제 push/pull 책임은 구현체 내부의
+/// listener·writer가 가짐(외부에서 직접 호출하지 않음).
+public protocol SyncService: AnyObject, Sendable {
+
+    /// 현재 동기화 상태. UI 즉시 표시용 동기 접근자.
+    var currentStatus: SyncStatus { get }
+
+    /// 동기화 상태 스트림. 구독 시 현재 값을 즉시 1회 발행해야 함(구현체 책임).
+    var statusPublisher: AnyPublisher<SyncStatus, Never> { get }
+
+    /// 동기화 시작. 인증된 사용자가 없으면 `.disconnected` 유지.
+    /// 인증 상태 변경에 따라 자동으로 호출될 수도 있고, 명시적으로 호출해도 무관(idempotent).
+    func start() async
+
+    /// 동기화 중지. listener를 해제하고 `.disconnected` 상태로 전이.
+    /// 로컬 Core Data는 그대로 유지.
+    func stop() async
+}

--- a/Projects/Core/SyncInterface/Sources/SyncStatus.swift
+++ b/Projects/Core/SyncInterface/Sources/SyncStatus.swift
@@ -1,0 +1,32 @@
+//
+//  SyncStatus.swift
+//  NoteCard
+//
+
+import Foundation
+
+/// 동기화 상태. UI에 노출 가능한 4-케이스.
+///
+/// - `disconnected`: 로그아웃 상태이거나 사용자가 동기화를 끈 상태. 클라우드와의 어떤 연결도 없음.
+/// - `upToDate`: 마지막 sync가 성공적으로 끝나 로컬과 서버가 동일.
+/// - `syncing`: push/pull/listener 이벤트 처리가 진행 중.
+/// - `error`: 마지막 작업이 실패. 연관된 `SyncError`로 사용자 안내 가능.
+public enum SyncStatus: Equatable {
+    case disconnected
+    case upToDate
+    case syncing
+    case error(SyncError)
+
+    public static func == (lhs: SyncStatus, rhs: SyncStatus) -> Bool {
+        switch (lhs, rhs) {
+        case (.disconnected, .disconnected),
+             (.upToDate,     .upToDate),
+             (.syncing,      .syncing):
+            return true
+        case (.error(let l), .error(let r)):
+            return String(describing: l) == String(describing: r)
+        default:
+            return false
+        }
+    }
+}


### PR DESCRIPTION
## 배경
- 메모 동기화(Firestore) v1의 구현체(SyncImpl) 추가 전 단계로, App composition root와 UI가 의존할 추상 표면을 먼저 확정.
- 인증(\`AuthService\`)과 동일한 컨벤션 — Interface 모듈에는 프로토콜만, 실제 SDK 연동은 후속 SyncImpl PR에서.

## 변경사항
- \`SyncStatus\` enum (Equatable)
  - \`.disconnected\`: 로그아웃 또는 동기화 off 상태
  - \`.upToDate\`: 마지막 sync 성공, 로컬·서버 동일
  - \`.syncing\`: push/pull/listener 이벤트 처리 중
  - \`.error(SyncError)\`: 마지막 작업 실패
- \`SyncError\` enum (LocalizedError)
  - \`network\` / \`permissionDenied\` / \`quotaExceeded\` / \`unauthenticated\` / \`unknown(Error)\`
  - 사용자 노출 문구는 \`L10n.Sync.Error.*\` (한·영) 매핑
- \`SyncService\` 프로토콜
  - \`currentStatus: SyncStatus\` 동기 접근자
  - \`statusPublisher: AnyPublisher<SyncStatus, Never>\` 스트림 (구독 시 현재 값 1회 발행 책임은 구현체)
  - \`start()\` / \`stop()\` lifecycle (idempotent 가정)
- \`L10n.Sync.Error\` 네임스페이스 5개 키 추가 (xcstrings + L10n.swift)

## 테스트 방법
- \`tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'\` 통과 확인
- 인터페이스 정의만 추가되어 자동 테스트 대상 없음

## 리뷰 노트
- 현 PR 단독으로는 런타임 동작 변화 없음. SyncService 구현체·주입은 후속 PR.
- \`SyncStatus\`의 \`Equatable\` 비교는 \`.error\` 케이스에서 연관값(\`SyncError\`)의 \`String(describing:)\`을 비교. \`Error\`가 일반적으로 \`Equatable\` 보장이 없어 도입한 절충안 — \`unknown(Error)\`의 정확한 동등성 비교가 필요한 사용처가 생기면 별도 보강 예정.
- push/pull 책임은 외부 표면에 노출하지 않음 — 구현체 내부의 listener·writer가 가짐. 외부에서 \"강제 새로고침\" 등이 필요해지면 인터페이스에 \`refresh()\` 추가 검토.