### PR TITLE
feat(sync): Memo Firestore DTO 추가

### DIFF
--- a/Projects/Core/SyncImpl/Project.swift
+++ b/Projects/Core/SyncImpl/Project.swift
@@ -10,5 +10,6 @@ let project = Project.module(
         .module(.syncInterface),
         .module(.domain),
         .external(name: "FirebaseAuth"),
-    ]
+    ],
+    hasTests: true
 )

--- a/Projects/Core/SyncImpl/Sources/FirestoreMemo.swift
+++ b/Projects/Core/SyncImpl/Sources/FirestoreMemo.swift
@@ -1,0 +1,43 @@
+//
+//  FirestoreMemo.swift
+//  NoteCard
+//
+
+import Domain
+import Foundation
+
+/// Firestore에 저장되는 메모 문서의 평면 스키마.
+///
+/// Document path: `users/{uid}/memos/{memoID}`.
+/// `serverUpdatedAt`은 Firestore에 쓸 때 `FieldValue.serverTimestamp()`로 채워지는 보조 timestamp로,
+/// 매퍼 책임 밖이라 이 DTO에는 포함하지 않는다. 카테고리 본문(이름·생성일 등)도 별도 컬렉션으로
+/// 분리되며, 메모 문서에는 관계 유지를 위한 `categoryIDs`만 보관한다. 이미지 메타·바이너리는
+/// 메모 sub-collection / Storage로 별도 관리되므로 본 DTO에는 포함하지 않는다.
+public struct FirestoreMemo: Codable, Equatable, Sendable {
+    public let memoID: String
+    public let memoTitle: String
+    public let memoText: String
+    public let isFavorite: Bool
+    public let isInTrash: Bool
+    public let creationDate: Date
+    public let modificationDate: Date
+    public let deletedDate: Date?
+    public let categoryIDs: [String]
+}
+
+public extension FirestoreMemo {
+
+    /// Domain `Memo`로부터 Firestore 페이로드를 만든다. `categoryIDs`는 안정적 비교/직렬화를 위해
+    /// uuidString 사전순으로 정렬해 저장한다.
+    init(_ memo: Memo) {
+        self.memoID = memo.memoID.uuidString
+        self.memoTitle = memo.memoTitle
+        self.memoText = memo.memoText
+        self.isFavorite = memo.isFavorite
+        self.isInTrash = memo.isInTrash
+        self.creationDate = memo.creationDate
+        self.modificationDate = memo.modificationDate
+        self.deletedDate = memo.deletedDate
+        self.categoryIDs = memo.categories.map(\.id.uuidString).sorted()
+    }
+}

--- a/Projects/Core/SyncImpl/Tests/FirestoreMemoTests.swift
+++ b/Projects/Core/SyncImpl/Tests/FirestoreMemoTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+import Domain
+@testable import SyncImpl
+
+/// Domain `Memo` → `FirestoreMemo` 변환과 Codable 라운드트립을 검증한다.
+final class FirestoreMemoTests: XCTestCase {
+
+    // MARK: - Domain → DTO
+
+    func test_도메인_메모의_모든_필드가_DTO에_복사된다() {
+        // given
+        let memoID = UUID()
+        let creation = Date(timeIntervalSince1970: 1_000_000)
+        let modification = Date(timeIntervalSince1970: 1_000_500)
+        let deleted = Date(timeIntervalSince1970: 1_000_900)
+        let memo = makeMemo(
+            id: memoID,
+            title: "제목",
+            text: "본문",
+            isFavorite: true,
+            isInTrash: true,
+            creation: creation,
+            modification: modification,
+            deleted: deleted,
+            categories: []
+        )
+
+        // when
+        let dto = FirestoreMemo(memo)
+
+        // then
+        XCTAssertEqual(dto.memoID, memoID.uuidString)
+        XCTAssertEqual(dto.memoTitle, "제목")
+        XCTAssertEqual(dto.memoText, "본문")
+        XCTAssertTrue(dto.isFavorite)
+        XCTAssertTrue(dto.isInTrash)
+        XCTAssertEqual(dto.creationDate, creation)
+        XCTAssertEqual(dto.modificationDate, modification)
+        XCTAssertEqual(dto.deletedDate, deleted)
+        XCTAssertEqual(dto.categoryIDs, [])
+    }
+
+    func test_삭제되지_않은_메모의_deletedDate는_nil로_매핑된다() {
+        // given
+        let memo = makeMemo(isInTrash: false, deleted: nil)
+
+        // when
+        let dto = FirestoreMemo(memo)
+
+        // then
+        XCTAssertNil(dto.deletedDate)
+    }
+
+    func test_categoryIDs는_uuidString_사전순으로_정렬된다() {
+        // given: 의도적으로 사전순 역순으로 배치된 카테고리들
+        let earlyID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        let midID   = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+        let lateID  = UUID(uuidString: "00000000-0000-0000-0000-000000000003")!
+        let categories: Set<Domain.Category> = [
+            Domain.Category(id: lateID,  name: "C", creationDate: .now, modificationDate: .now),
+            Domain.Category(id: earlyID, name: "A", creationDate: .now, modificationDate: .now),
+            Domain.Category(id: midID,   name: "B", creationDate: .now, modificationDate: .now),
+        ]
+        let memo = makeMemo(categories: categories)
+
+        // when
+        let dto = FirestoreMemo(memo)
+
+        // then
+        XCTAssertEqual(dto.categoryIDs, [earlyID.uuidString, midID.uuidString, lateID.uuidString])
+    }
+
+    // MARK: - Codable 라운드트립
+
+    func test_JSON_라운드트립_후에도_모든_필드가_동일하다() throws {
+        // given
+        let memo = makeMemo(
+            title: "round",
+            text: "trip",
+            isFavorite: true,
+            isInTrash: false,
+            categories: [
+                Domain.Category(id: UUID(), name: "A", creationDate: .now, modificationDate: .now),
+                Domain.Category(id: UUID(), name: "B", creationDate: .now, modificationDate: .now),
+            ]
+        )
+        let original = FirestoreMemo(memo)
+
+        // when
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(FirestoreMemo.self, from: encoded)
+
+        // then
+        XCTAssertEqual(decoded, original)
+    }
+
+    // MARK: - 헬퍼
+
+    private func makeMemo(
+        id: UUID = UUID(),
+        title: String = "",
+        text: String = "",
+        isFavorite: Bool = false,
+        isInTrash: Bool = false,
+        creation: Date = Date(timeIntervalSince1970: 0),
+        modification: Date = Date(timeIntervalSince1970: 0),
+        deleted: Date? = nil,
+        categories: Set<Domain.Category> = []
+    ) -> Memo {
+        Memo(
+            memoID: id,
+            creationDate: creation,
+            modificationDate: modification,
+            deletedDate: deleted,
+            isFavorite: isFavorite,
+            isInTrash: isInTrash,
+            memoText: text,
+            memoTitle: title,
+            categories: categories,
+            images: []
+        )
+    }
+}


### PR DESCRIPTION
## 배경
- Firestore 기반 메모 동기화 v1의 첫 본격 단계. 실제 push/pull 로직 진입 전에 Firestore에 저장될 메모 문서의 스키마를 코드로 고정.
- 후속 PR에서 \`FirestoreSyncService\` 가 이 DTO를 사용해 Memo를 push.

## 변경사항
- \`FirestoreMemo\` Codable struct (SyncImpl)
  - Document path 가정: \`users/{uid}/memos/{memoID}\`
  - 평면 스키마, camelCase 필드
  - 메모 본문 / 즐겨찾기 / 휴지통 / 생성·수정·삭제일 / 카테고리 관계만 포함
  - 카테고리 관계는 \`categoryIDs: [String]\` (사전순 정렬)
- \`init(_ memo: Memo)\` — Domain → DTO 변환
- \`SyncImpl\` 모듈 테스트 타겟 활성화 (\`hasTests: true\`)
- 단위 테스트 4종
  - 모든 필드 복사
  - 휴지통이 아닌 메모의 \`deletedDate\` nil
  - \`categoryIDs\` 사전순 정렬
  - JSON 라운드트립 동등성

## 테스트 방법
- \`tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'\`
- \`tuist test\` 전체 100개 통과 — \`SyncImplTests\` 4개 포함

## 리뷰 노트
- 의도적으로 제외한 것들 (후속 PR에서)
  - \`FirestoreMemo → Memo\` 역변환 — \`categoryIDs\`만으로는 \`Category\` 본문 resolve 불가. service 레이어 책임.
  - Category 본문 collection, 이미지 sub-collection / Storage 스키마
  - \`serverUpdatedAt\` 보조 timestamp — push 시 \`FieldValue.serverTimestamp()\`로 채울 예정이므로 매퍼 책임 밖
- 매퍼는 Firestore SDK 무의존 — Date만 다룸. SDK가 Swift Date ↔ Firestore Timestamp 자동 변환을 처리하므로 충분.
- 본 PR 단독으로는 런타임 동작 변화 없음 — DTO·테스트만 추가. \`FirebaseFirestore\` 의존성 추가도 push 메서드 작성 시 함께.