### PR TITLE
feat(sync): FirestoreMemoWriter — Memo upsert

### DIFF
--- a/Projects/Core/SyncImpl/Project.swift
+++ b/Projects/Core/SyncImpl/Project.swift
@@ -10,6 +10,7 @@ let project = Project.module(
         .module(.syncInterface),
         .module(.domain),
         .external(name: "FirebaseAuth"),
+        .external(name: "FirebaseFirestore"),
     ],
     hasTests: true
 )

--- a/Projects/Core/SyncImpl/Sources/FirestoreMemoWriter.swift
+++ b/Projects/Core/SyncImpl/Sources/FirestoreMemoWriter.swift
@@ -1,0 +1,46 @@
+//
+//  FirestoreMemoWriter.swift
+//  NoteCard
+//
+
+import Domain
+import FirebaseFirestore
+import Foundation
+
+/// Firestore에 메모 문서를 push하는 얇은 wrapper.
+///
+/// Document path: `users/{userID}/memos/{memoID}`. 페이로드는 `FirestoreMemo` Codable DTO를
+/// `Firestore.Encoder`로 인코딩한 dictionary에 server timestamp(`serverUpdatedAt`)를 더한다.
+/// `setData(merge: true)`라 서버에만 존재하는 필드(다른 기기가 추가한 미래 필드 등)는 보존된다.
+public final class FirestoreMemoWriter: @unchecked Sendable {
+
+    private let firestore: Firestore
+
+    public init(firestore: Firestore = .firestore()) {
+        self.firestore = firestore
+    }
+
+    /// 주어진 메모를 인증된 사용자의 store에 upsert한다.
+    public func upsert(_ memo: Memo, userID: String) async throws {
+        let payload = try Self.payload(for: memo)
+        let docRef = firestore
+            .collection("users").document(userID)
+            .collection("memos").document(memo.memoID.uuidString)
+        try await docRef.setData(payload, merge: true)
+    }
+
+    /// Firestore에 쓸 dictionary 페이로드를 만든다.
+    ///
+    /// 단위 테스트가 가능하도록 분리. 서버 timestamp는 SDK sentinel(`FieldValue.serverTimestamp()`)을
+    /// 그대로 넣고, 실제 시각은 Firestore가 commit 시점에 채운다. `deletedDate`가 nil일 때는
+    /// `setData(merge: true)`가 기존 필드를 보존하므로, 휴지통 복원 후에도 옛 값이 남지 않도록
+    /// 명시적 `FieldValue.delete()`를 push한다.
+    static func payload(for memo: Memo) throws -> [String: Any] {
+        var dict = try Firestore.Encoder().encode(FirestoreMemo(memo))
+        if memo.deletedDate == nil {
+            dict["deletedDate"] = FieldValue.delete()
+        }
+        dict["serverUpdatedAt"] = FieldValue.serverTimestamp()
+        return dict
+    }
+}

--- a/Projects/Core/SyncImpl/Tests/FirestoreMemoWriterTests.swift
+++ b/Projects/Core/SyncImpl/Tests/FirestoreMemoWriterTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+import Domain
+import FirebaseFirestore
+@testable import SyncImpl
+
+/// `FirestoreMemoWriter.payload(for:)`의 변환 결과를 검증한다.
+///
+/// 실제 네트워크 push(`upsert(_:userID:)`)는 Firestore 통합 환경이 필요해 단위 테스트로 다루지 않는다.
+final class FirestoreMemoWriterTests: XCTestCase {
+
+    func test_payload는_FirestoreMemo의_모든_필드를_포함한다() throws {
+        // given
+        let memoID = UUID()
+        let creation = Date(timeIntervalSince1970: 1_000_000)
+        let modification = Date(timeIntervalSince1970: 1_000_500)
+        let memo = makeMemo(
+            id: memoID,
+            title: "제목",
+            text: "본문",
+            isFavorite: true,
+            isInTrash: false,
+            creation: creation,
+            modification: modification
+        )
+
+        // when
+        let payload = try FirestoreMemoWriter.payload(for: memo)
+
+        // then
+        XCTAssertEqual(payload["memoID"] as? String, memoID.uuidString)
+        XCTAssertEqual(payload["memoTitle"] as? String, "제목")
+        XCTAssertEqual(payload["memoText"] as? String, "본문")
+        XCTAssertEqual(payload["isFavorite"] as? Bool, true)
+        XCTAssertEqual(payload["isInTrash"] as? Bool, false)
+        XCTAssertEqual(payload["categoryIDs"] as? [String], [])
+    }
+
+    func test_payload의_날짜는_Firestore_Timestamp로_인코딩된다() throws {
+        // given
+        let creation = Date(timeIntervalSince1970: 1_000_000)
+        let modification = Date(timeIntervalSince1970: 1_000_500)
+        let memo = makeMemo(creation: creation, modification: modification)
+
+        // when
+        let payload = try FirestoreMemoWriter.payload(for: memo)
+
+        // then: Firestore.Encoder는 Swift Date를 Firestore Timestamp로 변환한다
+        let creationTimestamp = try XCTUnwrap(payload["creationDate"] as? Timestamp)
+        let modificationTimestamp = try XCTUnwrap(payload["modificationDate"] as? Timestamp)
+        XCTAssertEqual(creationTimestamp.dateValue(), creation)
+        XCTAssertEqual(modificationTimestamp.dateValue(), modification)
+    }
+
+    func test_휴지통이_아닌_메모의_deletedDate는_FieldValue_delete로_push된다() throws {
+        // given: 휴지통 복원 등으로 deletedDate가 nil인 메모
+        let memo = makeMemo(isInTrash: false, deleted: nil)
+
+        // when
+        let payload = try FirestoreMemoWriter.payload(for: memo)
+
+        // then: setData(merge: true)가 기존 deletedDate를 보존하지 못하도록 명시적 delete sentinel을 보낸다
+        XCTAssertTrue(payload["deletedDate"] is FieldValue)
+    }
+
+    func test_휴지통_메모의_deletedDate는_Firestore_Timestamp로_인코딩된다() throws {
+        // given
+        let deleted = Date(timeIntervalSince1970: 1_000_900)
+        let memo = makeMemo(isInTrash: true, deleted: deleted)
+
+        // when
+        let payload = try FirestoreMemoWriter.payload(for: memo)
+
+        // then
+        let timestamp = try XCTUnwrap(payload["deletedDate"] as? Timestamp)
+        XCTAssertEqual(timestamp.dateValue(), deleted)
+    }
+
+    func test_payload는_server_timestamp_sentinel을_포함한다() throws {
+        // given
+        let memo = makeMemo()
+
+        // when
+        let payload = try FirestoreMemoWriter.payload(for: memo)
+
+        // then: 실제 시각은 Firestore가 commit 시점에 채우므로 여기서는 sentinel 객체임만 확인
+        let sentinel = try XCTUnwrap(payload["serverUpdatedAt"])
+        XCTAssertTrue(sentinel is FieldValue)
+    }
+
+    // MARK: - 헬퍼
+
+    private func makeMemo(
+        id: UUID = UUID(),
+        title: String = "",
+        text: String = "",
+        isFavorite: Bool = false,
+        isInTrash: Bool = false,
+        creation: Date = Date(timeIntervalSince1970: 0),
+        modification: Date = Date(timeIntervalSince1970: 0),
+        deleted: Date? = nil
+    ) -> Memo {
+        Memo(
+            memoID: id,
+            creationDate: creation,
+            modificationDate: modification,
+            deletedDate: deleted,
+            isFavorite: isFavorite,
+            isInTrash: isInTrash,
+            memoText: text,
+            memoTitle: title,
+            categories: [],
+            images: []
+        )
+    }
+}


### PR DESCRIPTION
## 배경
- Firestore 기반 메모 동기화 v1에서 실제 클라우드에 메모를 push하는 가장 얇은 wrapper.
- 메모 push가 가능한 표면이 생긴 첫 PR. 이 위에 SyncService(다음 PR)가 올라가며 \`MemoRepository\` publisher와 결합.

## 변경사항
- \`SyncImpl\`에 \`FirebaseFirestore\` 외부 의존성 추가
- \`FirestoreMemoWriter\` 클래스
  - \`upsert(_ memo: Memo, userID: String) async throws\` — \`users/{uid}/memos/{memoID}\` 경로에 \`setData(merge: true)\`
  - \`payload(for:)\` static helper로 dictionary 구성 로직 분리(테스트 대상)
- payload 구성 규칙
  - \`Firestore.Encoder\`로 \`FirestoreMemo\` Codable 인코딩 → Swift Date가 Firestore Timestamp로 자동 변환
  - \`serverUpdatedAt\`: \`FieldValue.serverTimestamp()\` sentinel — 서버가 commit 시점에 실제 시각으로 채움
  - \`deletedDate == nil\`: \`FieldValue.delete()\` sentinel — \`setData(merge:)\` 의미론 보완(아래 리뷰 노트)
- 단위 테스트 5종 — 필드 매핑 / Timestamp 변환 / 두 sentinel / 휴지통 \&amp; 휴지통 복원 경로

## 테스트 방법
- \`tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'\`
- \`tuist test\` 전체 통과 — \`SyncImplTests\` 9개(기존 DTO 4 + 신규 Writer 5) 포함
- 실제 Firestore 네트워크 push는 다음 PR(서비스/구독 결합)에서 통합 동작과 함께 검증 예정

## 리뷰 노트
- **\`deletedDate == nil\` 명시적 delete sentinel 처리 — 작성 중 catch된 의미 버그**
  - \`Firestore.Encoder\`는 nil Optional 필드를 dictionary에서 생략
  - \`setData(merge: true)\`는 dictionary에 없는 필드를 \"변경 없음\"으로 해석해 서버의 기존 값을 보존
  - 그대로 두면 휴지통 복원(deletedDate → nil) 후에도 서버에 옛 \`deletedDate\`가 남아, 다른 기기가 stale 상태로 pull받는 문제
  - 해결: nil일 때 \`FieldValue.delete()\` sentinel을 명시적으로 푸시 → 서버에서도 필드 제거
- 실 네트워크 push 자체는 단위 테스트하지 않음 — Firestore SDK 호출 한 줄 wrapping이라 비용 대비 효용이 낮고, payload 구성을 분리해 의미 있는 부분만 검증
- \`FirestoreMemoWriter\`는 \`@unchecked Sendable\` — \`Firestore\` 인스턴스는 SDK가 동시 호출에 안전하다고 문서화하고 있으며 다른 Repository 패턴과도 일관
- 본 PR 단독으로는 런타임 동작 변화 없음 — \`Writer\`를 호출하는 주체가 아직 없음. 후속 \`FirestoreSyncService\`에서 연결