### PR TITLE
feat(sync): FirestoreSyncService 셸 + 인증 상태 자동 전이

### DIFF
--- a/Projects/Core/SyncImpl/Sources/FirestoreSyncService.swift
+++ b/Projects/Core/SyncImpl/Sources/FirestoreSyncService.swift
@@ -1,0 +1,62 @@
+//
+//  FirestoreSyncService.swift
+//  NoteCard
+//
+
+import Combine
+import Foundation
+import SyncInterface
+
+/// Firestore 기반 `SyncService` 구현.
+///
+/// 본 단계의 책임은 status 노출과 인증 상태 동기화 lifecycle만이며, 실제 push/pull 로직(메모·카테고리·이미지)은
+/// 후속에서 결합된다. 인증된 사용자가 있으면 `.upToDate`, 없으면 `.disconnected`로 status를 자동 전이.
+public final class FirestoreSyncService: SyncService, @unchecked Sendable {
+
+    private let authService: AuthService
+    private let statusSubject = CurrentValueSubject<SyncStatus, Never>(.disconnected)
+    private let stateLock = NSLock()
+    /// `stateLock`으로 보호되는 mutable state. 직접 접근 금지.
+    private var _authCancellable: AnyCancellable?
+
+    public init(authService: AuthService) {
+        self.authService = authService
+    }
+
+    public var currentStatus: SyncStatus { statusSubject.value }
+
+    public var statusPublisher: AnyPublisher<SyncStatus, Never> {
+        statusSubject.eraseToAnyPublisher()
+    }
+
+    /// 인증 상태 구독을 시작한다. 이미 시작된 상태면 no-op (idempotent).
+    public func start() async {
+        stateLock.lock()
+        guard _authCancellable == nil else {
+            stateLock.unlock()
+            return
+        }
+        let cancellable = authService.authStatePublisher
+            .sink { [weak self] user in
+                self?.handleAuthChange(user: user)
+            }
+        _authCancellable = cancellable
+        stateLock.unlock()
+        // No-op AuthService처럼 첫 값을 즉시 emit하지 않는 publisher 대비 — 현재 상태 한 번 명시 반영.
+        handleAuthChange(user: authService.currentUser)
+    }
+
+    /// 인증 구독을 해제하고 `.disconnected`로 전이. listener를 정리하는 자리(후속 단계에서 확장).
+    public func stop() async {
+        stateLock.lock()
+        let previous = _authCancellable
+        _authCancellable = nil
+        stateLock.unlock()
+        previous?.cancel()
+        statusSubject.send(.disconnected)
+    }
+
+    private func handleAuthChange(user: AuthUser?) {
+        statusSubject.send(user == nil ? .disconnected : .upToDate)
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/NoOpSyncService.swift
+++ b/Projects/Core/SyncImpl/Sources/NoOpSyncService.swift
@@ -1,0 +1,25 @@
+//
+//  NoOpSyncService.swift
+//  NoteCard
+//
+
+import Combine
+import Foundation
+import SyncInterface
+
+/// 동기화를 비활성화하는 no-op 구현.
+///
+/// Firebase 설정(`GoogleService-Info.plist`)이 없는 환경(CI 빌드, 미설정 등)에서
+/// `SyncBootstrap`이 fallback으로 사용한다. status는 영구히 `.disconnected`.
+public final class NoOpSyncService: SyncService, @unchecked Sendable {
+    public init() {}
+
+    public var currentStatus: SyncStatus { .disconnected }
+
+    public var statusPublisher: AnyPublisher<SyncStatus, Never> {
+        Just(.disconnected).eraseToAnyPublisher()
+    }
+
+    public func start() async {}
+    public func stop() async {}
+}

--- a/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
+++ b/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
@@ -26,4 +26,17 @@ public enum SyncBootstrap {
     public static func makeNoOpAuthService() -> AuthService {
         NoOpAuthService()
     }
+
+    /// FirebaseApp 설정이 완료돼 있으면 Firestore 기반 `SyncService`를, 아니면 No-op 구현을 반환.
+    public static func makeSyncService(authService: AuthService) -> SyncService {
+        guard FirebaseApp.app() != nil else {
+            return NoOpSyncService()
+        }
+        return FirestoreSyncService(authService: authService)
+    }
+
+    /// 명시적으로 No-op 구현을 만들고 싶을 때 (테스트·프리뷰 등).
+    public static func makeNoOpSyncService() -> SyncService {
+        NoOpSyncService()
+    }
 }

--- a/Projects/Core/SyncImpl/Tests/FirestoreSyncServiceTests.swift
+++ b/Projects/Core/SyncImpl/Tests/FirestoreSyncServiceTests.swift
@@ -1,0 +1,150 @@
+import Combine
+import XCTest
+import SyncInterface
+@testable import SyncImpl
+
+/// `FirestoreSyncService`의 status 전이를 검증한다. Firestore 네트워크에는 접근하지 않으며
+/// `AuthService` 인증 상태 변경에 따른 lifecycle만 다룬다.
+final class FirestoreSyncServiceTests: XCTestCase {
+
+    private var auth: MockAuthService!
+    private var sut: FirestoreSyncService!
+
+    override func setUp() {
+        super.setUp()
+        auth = MockAuthService()
+        sut = FirestoreSyncService(authService: auth)
+    }
+
+    override func tearDown() {
+        sut = nil
+        auth = nil
+        super.tearDown()
+    }
+
+    func test_초기_status는_disconnected이다() {
+        XCTAssertEqual(sut.currentStatus, .disconnected)
+    }
+
+    func test_인증된_사용자가_있는_상태에서_start하면_upToDate가_된다() async {
+        // given
+        auth.emit(.sample)
+
+        // when
+        await sut.start()
+
+        // then
+        XCTAssertEqual(sut.currentStatus, .upToDate)
+    }
+
+    func test_인증되지_않은_상태에서_start하면_disconnected_유지() async {
+        // given: auth는 초기값 nil
+
+        // when
+        await sut.start()
+
+        // then
+        XCTAssertEqual(sut.currentStatus, .disconnected)
+    }
+
+    func test_start_후_로그인하면_upToDate로_전이된다() async {
+        // given
+        await sut.start()
+        XCTAssertEqual(sut.currentStatus, .disconnected)
+
+        // when
+        auth.emit(.sample)
+
+        // then
+        XCTAssertEqual(sut.currentStatus, .upToDate)
+    }
+
+    func test_start_후_로그아웃하면_disconnected로_전이된다() async {
+        // given
+        auth.emit(.sample)
+        await sut.start()
+        XCTAssertEqual(sut.currentStatus, .upToDate)
+
+        // when
+        auth.emit(nil)
+
+        // then
+        XCTAssertEqual(sut.currentStatus, .disconnected)
+    }
+
+    func test_stop은_disconnected로_전이하고_이후_인증_변경에_반응하지_않는다() async {
+        // given
+        auth.emit(.sample)
+        await sut.start()
+        XCTAssertEqual(sut.currentStatus, .upToDate)
+
+        // when
+        await sut.stop()
+
+        // then
+        XCTAssertEqual(sut.currentStatus, .disconnected)
+
+        // and: stop 이후 인증 이벤트는 무시된다
+        auth.emit(.sample)
+        XCTAssertEqual(sut.currentStatus, .disconnected)
+    }
+
+    func test_start는_idempotent하다() async {
+        // given
+        auth.emit(.sample)
+        await sut.start()
+
+        // when: 한 번 더 호출해도 추가 구독이 생기지 않는다 — emit 시 한 번만 전이
+        await sut.start()
+
+        // then
+        XCTAssertEqual(sut.currentStatus, .upToDate)
+    }
+
+    func test_statusPublisher는_변경마다_값을_방출한다() async {
+        // given
+        var received: [SyncStatus] = []
+        let cancellable = sut.statusPublisher.sink { received.append($0) }
+        defer { cancellable.cancel() }
+
+        // when
+        await sut.start()        // .disconnected (초기 emit)
+        auth.emit(.sample)       // .upToDate
+        auth.emit(nil)           // .disconnected
+        await sut.stop()         // .disconnected (중복)
+
+        // then
+        XCTAssertEqual(received.first, .disconnected)
+        XCTAssertTrue(received.contains(.upToDate))
+        XCTAssertEqual(received.last, .disconnected)
+    }
+}
+
+// MARK: - Mock
+
+private final class MockAuthService: AuthService, @unchecked Sendable {
+
+    private let subject = CurrentValueSubject<AuthUser?, Never>(nil)
+
+    var currentUser: AuthUser? { subject.value }
+
+    var authStatePublisher: AnyPublisher<AuthUser?, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    func signInWithApple() async throws -> AuthUser {
+        fatalError("not used in tests")
+    }
+
+    func signOut() async throws {}
+
+    func deleteAccount() async throws {}
+
+    func emit(_ user: AuthUser?) {
+        subject.send(user)
+    }
+}
+
+private extension AuthUser {
+    static let sample = AuthUser(id: "test-uid", displayName: "Tester", email: "test@example.com")
+}


### PR DESCRIPTION
## 배경
- Firestore 기반 메모 동기화 v1에서 사용자에게 노출될 동기화 상태(\`SyncStatus\`)를 운영하는 첫 컨테이너.
- 본 PR 단계의 책임은 status 노출 + 인증 상태 lifecycle만이며, 실제 push/pull(메모 Repository 구독, Writer 호출, Firestore listener)은 후속 PR에서 결합.

## 변경사항
- \`FirestoreSyncService\` — \`SyncService\` 프로토콜 구현 (SyncImpl)
  - \`AuthService\` 주입, \`authStatePublisher\` 구독으로 status 자동 전이
    - 사용자 있음 → \`.upToDate\`
    - 사용자 없음 → \`.disconnected\`
  - \`start()\` idempotent (이미 구독 중이면 no-op), \`stop()\` 이후 인증 이벤트 무시
  - \`NSLock\`으로 mutable cancellable 필드 보호 — \`@unchecked Sendable\`이 실제로도 race-free
- \`NoOpSyncService\` — Firebase 미설정 환경 fallback (status 영구 \`.disconnected\`)
- \`SyncBootstrap.makeSyncService(authService:)\` factory
  - FirebaseApp 설정 시 \`FirestoreSyncService\`, 아니면 \`NoOpSyncService\` 반환
  - 명시 No-op 헬퍼(\`makeNoOpSyncService\`) 함께 노출 — 테스트·프리뷰용
- \`FirestoreSyncServiceTests\` 8종 — \`MockAuthService\`로 인증 상태 변경 시나리오 검증
  - 초기 status
  - start 후 인증 유무에 따른 status
  - 로그인 / 로그아웃 전이
  - stop 후 인증 이벤트 무시
  - start idempotency
  - statusPublisher 시퀀스

## 테스트 방법
- \`tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'\`
- \`tuist test\` 전체 통과 — \`SyncImplTests\` 17개 포함

## 리뷰 노트
- **mutable 상태 보호 — \`NSLock\` 도입 의도**
  - \`var _authCancellable: AnyCancellable?\`은 진짜 mutable stored property라, lock 없이 동시 호출되면 data race
  - 현실 호출 패턴은 단일 호출자(composition root)지만, \`Sendable\` 계약을 형식만이 아니라 실제로도 지키도록 lock으로 보호
  - 다른 Repository(\`MemoRepositoryImpl\` 등)는 mutable stored property가 사실상 없어 같은 패턴이 필요 없는 상태 — 본 클래스는 별개 상황
- mutate가 일어나는 짧은 구간만 lock 안에 두고, 외부로 흘러나가는 동작(\`cancellable.cancel()\`, \`statusSubject.send\`, \`handleAuthChange\`)은 lock 밖에서 호출 — 재진입·deadlock 방지
- 본 PR 단독으로는 런타임 동작 변화 없음 — 호출하는 주체(\`AppEnvironment\` 결합)가 아직 없음. 후속에서 composition root에 주입