### PR TITLE
feat(di): SyncService 인스턴스 주입 + lifecycle 시작

### DIFF
--- a/NoteCard/Global/Application/AppDelegate.swift
+++ b/NoteCard/Global/Application/AppDelegate.swift
@@ -21,7 +21,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        
+
+        // 동기화 lifecycle 시작. 인증 상태 구독을 걸어두고, 사용자 변경 시 status가 자동 전이.
+        // 현재 start()는 빠르게 끝나므로 fire-and-forget으로 충분.
+        Task { [environment] in
+            await environment.syncService.start()
+        }
+
         // 앱 내의 설정값들 초기화 (다크모드 제외) -> 다크모드는 window 를 바꿔야 해서, window 설정하는 SceneDelegate에서...
         
         // 현재는 날짜 표시 형식을 직접 UserDefault에 저장하지 않고, locale을 기반으로 자동으로 변경되도록 설정.

--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -24,6 +24,7 @@ struct AppEnvironment {
     let imageRepository: ImageRepository
     let analytics: Analytics
     let authService: AuthService
+    let syncService: SyncService
 
     private let dataLayer: UserScopedDataLayer
 
@@ -66,6 +67,10 @@ struct AppEnvironment {
         self.memoRepository = memoRepository
         self.categoryRepository = CategoryRepositoryImpl(dataLayer: dataLayer)
         self.imageRepository = ImageRepositoryImpl(dataLayer: dataLayer, memoRepository: memoRepository)
+
+        // FirebaseApp 설정이 있으면 Firestore 기반 동기화, 아니면 No-op fallback.
+        // 인스턴스만 보관하고 실제 lifecycle 시작(start())은 AppDelegate에서 명시 호출.
+        self.syncService = SyncBootstrap.makeSyncService(authService: authService)
     }
 
     /// Crashlytics를 켜고(가능하면) Amplitude 기반 `Analytics`를 만든다.


### PR DESCRIPTION
## 배경
- 앞선 PR들에서 \`SyncService\` 인터페이스 / DTO / Writer / Service 셸은 모두 추가되었으나, 어디서도 인스턴스가 만들어지지 않아 실제로 동작하지 않던 상태.
- 본 PR이 composition root에 연결해 \`SyncService\`의 lifecycle을 처음으로 켠다. 단, 메모 push 결합·UI 표시는 후속 PR에서 따로.

## 변경사항
- \`AppEnvironment\`
  - \`let syncService: SyncService\` 프로퍼티 추가
  - init 마지막에 \`SyncBootstrap.makeSyncService(authService:)\` 호출 — FirebaseApp 설정 시 Firestore 구현, 미설정 시 No-op fallback이 자동 선택됨
- \`AppDelegate.didFinishLaunchingWithOptions\`
  - \`Task { [environment] in await environment.syncService.start() }\`로 lifecycle 시작
  - \`[environment]\` 캡처로 self 캡처 회피, Sendable 우려 정리

## 테스트 방법
- \`tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'\` 통과
- \`tuist test\` 전체 회귀 없음

## 리뷰 노트
- 사용자 가시 변화 없음 — \`statusPublisher\` 구독자가 아직 없음. AccountDetailView의 status 라벨 연결은 별 PR로.
- \`Task { ... }\`는 fire-and-forget. 현재 \`start()\`는 인증 구독을 거는 빠른 setup만이라 추적 불필요. 후속에 push 큐 등 비동기 작업이 추가되면 Task 관리 전략 재검토 예정.
- Firebase 미설정 환경(CI, GoogleService-Info.plist 없는 빌드)에선 \`NoOpSyncService\`가 들어가 동기화는 영구 \`.disconnected\`로 비활성됨 — 앱 동작에 영향 없음.