### PR TITLE
fix(sync): NSLock의 async-context 사용 경고 제거

### DIFF
--- a/Projects/Core/SyncImpl/Sources/FirestoreSyncService.swift
+++ b/Projects/Core/SyncImpl/Sources/FirestoreSyncService.swift
@@ -31,29 +31,41 @@ public final class FirestoreSyncService: SyncService, @unchecked Sendable {
 
     /// 인증 상태 구독을 시작한다. 이미 시작된 상태면 no-op (idempotent).
     public func start() async {
-        stateLock.lock()
-        guard _authCancellable == nil else {
-            stateLock.unlock()
-            return
-        }
-        let cancellable = authService.authStatePublisher
-            .sink { [weak self] user in
-                self?.handleAuthChange(user: user)
-            }
-        _authCancellable = cancellable
-        stateLock.unlock()
+        guard startSubscription() else { return }
         // No-op AuthService처럼 첫 값을 즉시 emit하지 않는 publisher 대비 — 현재 상태 한 번 명시 반영.
         handleAuthChange(user: authService.currentUser)
     }
 
     /// 인증 구독을 해제하고 `.disconnected`로 전이. listener를 정리하는 자리(후속 단계에서 확장).
     public func stop() async {
+        cancelSubscription()?.cancel()
+        statusSubject.send(.disconnected)
+    }
+
+    /// `stateLock` 구간을 동기 메서드로 격리한다.
+    ///
+    /// `NSLock.lock()`/`unlock()`은 async 컨텍스트에서 호출 시 suspension point를 가로질러
+    /// acquire/release 스레드가 달라질 수 있어 unavailable(Swift 6에선 error). lock 구간을
+    /// suspension이 없는 동기 메서드 안에 가두면 그 위험이 원천 차단된다.
+    /// - Returns: 이번 호출로 새로 구독을 시작했으면 `true`, 이미 시작돼 있었으면 `false`.
+    private func startSubscription() -> Bool {
         stateLock.lock()
+        defer { stateLock.unlock() }
+        guard _authCancellable == nil else { return false }
+        _authCancellable = authService.authStatePublisher
+            .sink { [weak self] user in
+                self?.handleAuthChange(user: user)
+            }
+        return true
+    }
+
+    /// 구독을 해제하고 직전 cancellable을 반환한다(`cancel()`은 lock 밖에서 호출하도록 위임).
+    private func cancelSubscription() -> AnyCancellable? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
         let previous = _authCancellable
         _authCancellable = nil
-        stateLock.unlock()
-        previous?.cancel()
-        statusSubject.send(.disconnected)
+        return previous
     }
 
     private func handleAuthChange(user: AuthUser?) {


### PR DESCRIPTION
## 배경
- \`FirestoreSyncService\`의 \`start()\`/\`stop()\`이 async 함수 안에서 \`NSLock.lock()\`/\`unlock()\`을 직접 호출 → \"unavailable from asynchronous contexts\" 경고 (Swift 6 모드에선 error).

## 변경사항
- lock 사용 구간을 동기 helper로 분리
  - \`startSubscription() -> Bool\`
  - \`cancelSubscription() -> AnyCancellable?\`
- async 함수는 helper만 호출 → lock을 직접 만지지 않음
- 동작 동일 — mutate 구간만 lock 보호, \`cancel()\`/\`statusSubject.send\`는 lock 밖에서 호출

## 테스트 방법
- 빌드 시 해당 경고 사라짐 확인
- \`tuist test\` 전체 통과 (FirestoreSyncServiceTests 8종 회귀 없음)