### PR TITLE
feat(domain): MemoUpdateType이 모든 이벤트에 대상 memoID 포함

### DIFF
--- a/Projects/Data/Sources/Repositories/MemoRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/MemoRepositoryImpl.swift
@@ -96,7 +96,7 @@ public extension MemoRepositoryImpl {
             try self.context.save()
             return newMemoEntity.toDomain()
         }
-        memoUpdatedSubject.send(.create)
+        memoUpdatedSubject.send(.create(memoIDs: [createdMemo.memoID]))
         return createdMemo
     }
     
@@ -240,7 +240,7 @@ public extension MemoRepositoryImpl {
             memoEntityToTrash.removeFromCategories(memoEntityToTrash.categories)
             try self.context.save()
         }
-        memoUpdatedSubject.send((.trash))
+        memoUpdatedSubject.send(.trash(memoIDs: [memo.memoID]))
     }
     
     func moveToTrash(_ memos: [Memo]) async throws {
@@ -254,7 +254,7 @@ public extension MemoRepositoryImpl {
             }
             try self.context.save()
         }
-        memoUpdatedSubject.send(.trash)
+        memoUpdatedSubject.send(.trash(memoIDs: memos.map(\.memoID)))
     }
     
 }
@@ -277,7 +277,7 @@ public extension MemoRepositoryImpl {
             self.context.delete(memoEntityToDelete)
             try self.context.save()
         }
-        memoUpdatedSubject.send(.delete)
+        memoUpdatedSubject.send(.delete(memoIDs: [memo.memoID]))
     }
     
     func deleteMemos(_ memos: [Memo]) async throws {
@@ -296,7 +296,7 @@ public extension MemoRepositoryImpl {
             }
             try self.context.save()
         }
-        memoUpdatedSubject.send(.delete)
+        memoUpdatedSubject.send(.delete(memoIDs: memos.map(\.memoID)))
     }
     
 }
@@ -312,7 +312,7 @@ public extension MemoRepositoryImpl {
             memoEntityToRestore.deletedDate = nil
             try self.context.save()
         }
-        memoUpdatedSubject.send(.restore)
+        memoUpdatedSubject.send(.restore(memoIDs: [memo.memoID]))
     }
     
     func restore(_ memos: [Memo]) async throws {
@@ -324,7 +324,7 @@ public extension MemoRepositoryImpl {
             }
             try self.context.save()
         }
-        memoUpdatedSubject.send(.restore)
+        memoUpdatedSubject.send(.restore(memoIDs: memos.map(\.memoID)))
     }
     
 }

--- a/Projects/Data/Tests/MemoRepositoryTests.swift
+++ b/Projects/Data/Tests/MemoRepositoryTests.swift
@@ -395,10 +395,10 @@ final class MemoRepositoryTests: XCTestCase {
         defer { cancellable.cancel() }
 
         // when
-        _ = try await sut.createNewMemo()
+        let created = try await sut.createNewMemo()
 
-        // then
-        XCTAssertEqual(received, [.create])
+        // then: 생성 이벤트에 방금 만든 메모의 ID가 실려야 한다
+        XCTAssertEqual(received, [.create(memoIDs: [created.memoID])])
     }
 
     // MARK: - 배열 일괄 처리

--- a/Projects/Domain/Sources/Repositories/MemoUpdateType.swift
+++ b/Projects/Domain/Sources/Repositories/MemoUpdateType.swift
@@ -21,9 +21,20 @@ public enum MemoUpdateType: Equatable {
         }
     }
 
-    case create
-    case trash
-    case delete
-    case restore
+    case create(memoIDs: [UUID])
+    case trash(memoIDs: [UUID])
+    case delete(memoIDs: [UUID])
+    case restore(memoIDs: [UUID])
     case update(content: UpdateAttribute)
+
+    /// 이벤트가 가리키는 대상 메모 ID들. 동기화가 어떤 메모를 push/삭제할지 식별하는 데 사용.
+    public var memoIDs: [UUID] {
+        switch self {
+        case .create(let memoIDs): return memoIDs
+        case .trash(let memoIDs): return memoIDs
+        case .delete(let memoIDs): return memoIDs
+        case .restore(let memoIDs): return memoIDs
+        case .update(let content): return content.memoIDs
+        }
+    }
 }

--- a/Projects/Domain/Tests/DomainTests.swift
+++ b/Projects/Domain/Tests/DomainTests.swift
@@ -22,3 +22,25 @@ final class DomainModelInitTests: XCTestCase {
         XCTAssertLessThan(a, b)
     }
 }
+
+final class MemoUpdateTypeTests: XCTestCase {
+
+    func test_memoIDs는_각_케이스의_대상_메모ID를_반환한다() {
+        let a = UUID()
+        let b = UUID()
+
+        XCTAssertEqual(MemoUpdateType.create(memoIDs: [a]).memoIDs, [a])
+        XCTAssertEqual(MemoUpdateType.trash(memoIDs: [a, b]).memoIDs, [a, b])
+        XCTAssertEqual(MemoUpdateType.delete(memoIDs: [a]).memoIDs, [a])
+        XCTAssertEqual(MemoUpdateType.restore(memoIDs: [b]).memoIDs, [b])
+    }
+
+    func test_update_케이스의_memoIDs는_연관된_attribute의_memoIDs를_반환한다() {
+        let a = UUID()
+        let b = UUID()
+
+        XCTAssertEqual(MemoUpdateType.update(content: .titleText(memoIDs: [a])).memoIDs, [a])
+        XCTAssertEqual(MemoUpdateType.update(content: .favorite(memoIDs: [a, b])).memoIDs, [a, b])
+        XCTAssertEqual(MemoUpdateType.update(content: .category(memoIDs: [b])).memoIDs, [b])
+    }
+}


### PR DESCRIPTION
## 배경
- 기존 \`MemoUpdateType\`은 \`.update\` 케이스만 memoID를 실어보내고, \`.create\`/\`.trash\`/\`.delete\`/\`.restore\`는 연관값이 없어 \"무슨 종류의 변경\"인지만 알리고 대상 메모를 식별하지 못함.
- 메모 동기화에서 \"어떤 메모를 push/삭제할지\" 알아야 하므로, 모든 이벤트가 대상 memoID를 싣도록 확장. push 결합(후속 PR)의 선행 작업.

## 변경사항
- \`MemoUpdateType\` (Domain)
  - \`create\` / \`trash\` / \`delete\` / \`restore\`에 \`memoIDs: [UUID]\` 연관값 추가
  - 모든 케이스에서 대상 메모를 추출하는 top-level \`memoIDs\` computed property 추가
- \`MemoRepositoryImpl\` 발행 지점 7곳을 새 시그니처로 갱신
  - 단건 메서드는 \`[memo.memoID]\`, 배열 메서드는 \`memos.map(\.memoID)\` — batch 작업도 이벤트 1개에 ID 배열로 전달
- 테스트
  - DomainTests: \`memoIDs\` computed property가 각 케이스의 대상 ID를 반환하는지 검증
  - MemoRepositoryTests: 생성 이벤트에 방금 만든 메모 ID가 실리는지 검증 강화

## 테스트 방법
- \`tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'\`
- \`tuist test\` 전체 통과

## 리뷰 노트
- UI 구독 지점은 영향 없음 — \`PopupCardViewController\`는 \`.update\`만 패턴 매칭, \`MemoViewController\`는 이벤트 종류를 \`_\`로 무시. 발행 지점(\`MemoRepositoryImpl\`)과 테스트만 변경됨.
- enum 확장 방향은 기존 \`ImageUpdateType\`(\`.create(memoID:)\` 등)과 일관.
- 본 PR 단독으로는 런타임 동작 변화 없음 — publisher payload만 풍부해짐. 실제 push 결합·서버 전송은 후속 PR.