### PR TITLE
feat(sync): 메모 변경을 Firestore로 push (단방향)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ Core Data는 가장 위험한 영역이다. 다음을 어기면 사용자 데이
 - `public class` 안의 `override` 메서드도 `public` 명시 (Swift 규칙).
 - ViewController 등 App 타겟 내부 코드는 internal로 충분 (cross-module 노출 불필요).
 - 주석은 최소화한다. 코드로 자명한 내용은 주석을 달지 않으며, 길고 장황한 주석은 금지. 꼭 필요한 "왜"(비자명한 제약·함정·의도)만 짧게 남긴다. 주석은 소스가 바뀌면 stale해지기 쉬우므로, 소스를 변경할 때 관련 주석도 함께 확인해 최신화한다.
+  - 예외: 테스트 코드의 `// given` / `// when` / `// then` 구획 주석은 테스트 구조를 드러내는 관례이므로, 자명해 보여도 제거하지 말고 유지한다.
 
 ## Commit / PR conventions
 

--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -70,7 +70,10 @@ struct AppEnvironment {
 
         // FirebaseApp 설정이 있으면 Firestore 기반 동기화, 아니면 No-op fallback.
         // 인스턴스만 보관하고 실제 lifecycle 시작(start())은 AppDelegate에서 명시 호출.
-        self.syncService = SyncBootstrap.makeSyncService(authService: authService)
+        self.syncService = SyncBootstrap.makeSyncService(
+            authService: authService,
+            memoRepository: memoRepository
+        )
     }
 
     /// Crashlytics를 켜고(가능하면) Amplitude 기반 `Analytics`를 만든다.

--- a/Projects/Core/SyncImpl/Sources/FirestoreMemoWriter.swift
+++ b/Projects/Core/SyncImpl/Sources/FirestoreMemoWriter.swift
@@ -7,12 +7,19 @@ import Domain
 import FirebaseFirestore
 import Foundation
 
+/// 메모 원격 쓰기 표면. `FirestoreSyncService`가 의존하며, 테스트에서 Firestore 실호출을
+/// 대체(mock)하기 위한 내부 seam. 모듈 외부로 노출하지 않는다.
+protocol MemoRemoteWriting: Sendable {
+    func upsert(_ memo: Memo, userID: String) async throws
+    func delete(memoID: UUID, userID: String) async throws
+}
+
 /// Firestore에 메모 문서를 push하는 얇은 wrapper.
 ///
 /// Document path: `users/{userID}/memos/{memoID}`. 페이로드는 `FirestoreMemo` Codable DTO를
 /// `Firestore.Encoder`로 인코딩한 dictionary에 server timestamp(`serverUpdatedAt`)를 더한다.
 /// `setData(merge: true)`라 서버에만 존재하는 필드(다른 기기가 추가한 미래 필드 등)는 보존된다.
-public final class FirestoreMemoWriter: @unchecked Sendable {
+public final class FirestoreMemoWriter: MemoRemoteWriting, @unchecked Sendable {
 
     private let firestore: Firestore
 
@@ -23,10 +30,18 @@ public final class FirestoreMemoWriter: @unchecked Sendable {
     /// 주어진 메모를 인증된 사용자의 store에 upsert한다.
     public func upsert(_ memo: Memo, userID: String) async throws {
         let payload = try Self.payload(for: memo)
-        let docRef = firestore
+        try await memoDocument(memoID: memo.memoID, userID: userID).setData(payload, merge: true)
+    }
+
+    /// 영구 삭제 메모는 로컬에서 이미 사라져 fetch가 불가능하므로 memoID로 직접 삭제한다.
+    public func delete(memoID: UUID, userID: String) async throws {
+        try await memoDocument(memoID: memoID, userID: userID).delete()
+    }
+
+    private func memoDocument(memoID: UUID, userID: String) -> DocumentReference {
+        firestore
             .collection("users").document(userID)
-            .collection("memos").document(memo.memoID.uuidString)
-        try await docRef.setData(payload, merge: true)
+            .collection("memos").document(memoID.uuidString)
     }
 
     /// Firestore에 쓸 dictionary 페이로드를 만든다.

--- a/Projects/Core/SyncImpl/Sources/FirestoreSyncService.swift
+++ b/Projects/Core/SyncImpl/Sources/FirestoreSyncService.swift
@@ -4,23 +4,41 @@
 //
 
 import Combine
+import Domain
 import Foundation
 import SyncInterface
 
 /// Firestore 기반 `SyncService` 구현.
 ///
-/// 본 단계의 책임은 status 노출과 인증 상태 동기화 lifecycle만이며, 실제 push/pull 로직(메모·카테고리·이미지)은
-/// 후속에서 결합된다. 인증된 사용자가 있으면 `.upToDate`, 없으면 `.disconnected`로 status를 자동 전이.
+/// status 노출과 인증 상태 lifecycle에 더해, 메모 변경 이벤트를 받아 Firestore로 단방향 push한다.
+/// 인증된 사용자가 있으면 `.upToDate`, 없으면 `.disconnected`로 status를 자동 전이.
+/// (pull(listener)·디바운스·에러 status 전이는 후속 단계에서 결합.)
 public final class FirestoreSyncService: SyncService, @unchecked Sendable {
 
+    /// 메모 변경 이벤트를 Firestore 작업으로 환산한 결과.
+    enum MemoSyncAction: Equatable {
+        case upsert(memoIDs: [UUID])
+        case delete(memoIDs: [UUID])
+    }
+
     private let authService: AuthService
+    private let memoRepository: MemoRepository
+    private let memoWriter: MemoRemoteWriting
+
     private let statusSubject = CurrentValueSubject<SyncStatus, Never>(.disconnected)
     private let stateLock = NSLock()
     /// `stateLock`으로 보호되는 mutable state. 직접 접근 금지.
     private var _authCancellable: AnyCancellable?
+    private var _memoCancellable: AnyCancellable?
 
-    public init(authService: AuthService) {
+    init(
+        authService: AuthService,
+        memoRepository: MemoRepository,
+        memoWriter: MemoRemoteWriting
+    ) {
         self.authService = authService
+        self.memoRepository = memoRepository
+        self.memoWriter = memoWriter
     }
 
     public var currentStatus: SyncStatus { statusSubject.value }
@@ -29,26 +47,35 @@ public final class FirestoreSyncService: SyncService, @unchecked Sendable {
         statusSubject.eraseToAnyPublisher()
     }
 
-    /// 인증 상태 구독을 시작한다. 이미 시작된 상태면 no-op (idempotent).
+    /// 인증 상태·메모 변경 구독을 시작한다. 이미 시작된 상태면 no-op (idempotent).
     public func start() async {
-        guard startSubscription() else { return }
+        guard startSubscriptions() else { return }
         // No-op AuthService처럼 첫 값을 즉시 emit하지 않는 publisher 대비 — 현재 상태 한 번 명시 반영.
         handleAuthChange(user: authService.currentUser)
     }
 
-    /// 인증 구독을 해제하고 `.disconnected`로 전이. listener를 정리하는 자리(후속 단계에서 확장).
+    /// 구독을 모두 해제하고 `.disconnected`로 전이. listener를 정리하는 자리(후속 단계에서 확장).
     public func stop() async {
-        cancelSubscription()?.cancel()
+        let cancellables = cancelSubscriptions()
+        cancellables.forEach { $0.cancel() }
         statusSubject.send(.disconnected)
     }
 
+    /// 메모 변경 이벤트를 Firestore 작업으로 환산한다.
+    static func syncAction(for event: MemoUpdateType) -> MemoSyncAction {
+        switch event {
+        case .delete(let memoIDs):
+            return .delete(memoIDs: memoIDs)
+        case .create, .trash, .restore, .update:
+            return .upsert(memoIDs: event.memoIDs)
+        }
+    }
+
+    // MARK: - Lock 격리 (async-context에서 NSLock 직접 사용 회피)
+
     /// `stateLock` 구간을 동기 메서드로 격리한다.
-    ///
-    /// `NSLock.lock()`/`unlock()`은 async 컨텍스트에서 호출 시 suspension point를 가로질러
-    /// acquire/release 스레드가 달라질 수 있어 unavailable(Swift 6에선 error). lock 구간을
-    /// suspension이 없는 동기 메서드 안에 가두면 그 위험이 원천 차단된다.
     /// - Returns: 이번 호출로 새로 구독을 시작했으면 `true`, 이미 시작돼 있었으면 `false`.
-    private func startSubscription() -> Bool {
+    private func startSubscriptions() -> Bool {
         stateLock.lock()
         defer { stateLock.unlock() }
         guard _authCancellable == nil else { return false }
@@ -56,19 +83,51 @@ public final class FirestoreSyncService: SyncService, @unchecked Sendable {
             .sink { [weak self] user in
                 self?.handleAuthChange(user: user)
             }
+        _memoCancellable = memoRepository.memoUpdatedPublisher
+            .sink { [weak self] event in
+                self?.handleMemoEvent(event)
+            }
         return true
     }
 
-    /// 구독을 해제하고 직전 cancellable을 반환한다(`cancel()`은 lock 밖에서 호출하도록 위임).
-    private func cancelSubscription() -> AnyCancellable? {
+    /// 구독들을 해제하고 직전 cancellable들을 반환한다(`cancel()`은 lock 밖에서 호출하도록 위임).
+    private func cancelSubscriptions() -> [AnyCancellable] {
         stateLock.lock()
         defer { stateLock.unlock() }
-        let previous = _authCancellable
+        let previous = [_authCancellable, _memoCancellable].compactMap { $0 }
         _authCancellable = nil
+        _memoCancellable = nil
         return previous
     }
 
+    // MARK: - 이벤트 처리
+
     private func handleAuthChange(user: AuthUser?) {
         statusSubject.send(user == nil ? .disconnected : .upToDate)
+    }
+
+    private func handleMemoEvent(_ event: MemoUpdateType) {
+        guard let userID = authService.currentUser?.id else { return }
+        Task { [weak self] in
+            await self?.performMemoSync(action: Self.syncAction(for: event), userID: userID)
+        }
+    }
+
+    private func performMemoSync(action: MemoSyncAction, userID: String) async {
+        do {
+            switch action {
+            case .upsert(let memoIDs):
+                for memoID in memoIDs {
+                    let memo = try await memoRepository.getMemoIncludingTrash(id: memoID)
+                    try await memoWriter.upsert(memo, userID: userID)
+                }
+            case .delete(let memoIDs):
+                for memoID in memoIDs {
+                    try await memoWriter.delete(memoID: memoID, userID: userID)
+                }
+            }
+        } catch {
+            // 에러 매핑과 .error status 전이는 후속 단계에서 결합. 현재는 best-effort push.
+        }
     }
 }

--- a/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
+++ b/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
@@ -3,6 +3,7 @@
 //  NoteCard
 //
 
+import Domain
 import Foundation
 import FirebaseCore
 import SyncInterface
@@ -28,11 +29,18 @@ public enum SyncBootstrap {
     }
 
     /// FirebaseApp 설정이 완료돼 있으면 Firestore 기반 `SyncService`를, 아니면 No-op 구현을 반환.
-    public static func makeSyncService(authService: AuthService) -> SyncService {
+    public static func makeSyncService(
+        authService: AuthService,
+        memoRepository: MemoRepository
+    ) -> SyncService {
         guard FirebaseApp.app() != nil else {
             return NoOpSyncService()
         }
-        return FirestoreSyncService(authService: authService)
+        return FirestoreSyncService(
+            authService: authService,
+            memoRepository: memoRepository,
+            memoWriter: FirestoreMemoWriter()
+        )
     }
 
     /// 명시적으로 No-op 구현을 만들고 싶을 때 (테스트·프리뷰 등).

--- a/Projects/Core/SyncImpl/Tests/FirestoreSyncServiceTests.swift
+++ b/Projects/Core/SyncImpl/Tests/FirestoreSyncServiceTests.swift
@@ -1,26 +1,35 @@
 import Combine
 import XCTest
+import Domain
 import SyncInterface
 @testable import SyncImpl
 
-/// `FirestoreSyncService`의 status 전이를 검증한다. Firestore 네트워크에는 접근하지 않으며
-/// `AuthService` 인증 상태 변경에 따른 lifecycle만 다룬다.
+/// `FirestoreSyncService`의 status 전이와 메모 push 결합을 검증한다.
+/// Firestore 네트워크에는 접근하지 않으며, 원격 쓰기는 `MockMemoRemoteWriter`로 대체한다.
 final class FirestoreSyncServiceTests: XCTestCase {
 
     private var auth: MockAuthService!
+    private var memoRepository: MockMemoRepository!
+    private var writer: MockMemoRemoteWriter!
     private var sut: FirestoreSyncService!
 
     override func setUp() {
         super.setUp()
         auth = MockAuthService()
-        sut = FirestoreSyncService(authService: auth)
+        memoRepository = MockMemoRepository()
+        writer = MockMemoRemoteWriter()
+        sut = FirestoreSyncService(authService: auth, memoRepository: memoRepository, memoWriter: writer)
     }
 
     override func tearDown() {
         sut = nil
+        writer = nil
+        memoRepository = nil
         auth = nil
         super.tearDown()
     }
+
+    // MARK: - status 전이
 
     func test_초기_status는_disconnected이다() {
         XCTAssertEqual(sut.currentStatus, .disconnected)
@@ -94,7 +103,7 @@ final class FirestoreSyncServiceTests: XCTestCase {
         auth.emit(.sample)
         await sut.start()
 
-        // when: 한 번 더 호출해도 추가 구독이 생기지 않는다 — emit 시 한 번만 전이
+        // when: 한 번 더 호출해도 추가 구독이 생기지 않는다
         await sut.start()
 
         // then
@@ -118,31 +127,153 @@ final class FirestoreSyncServiceTests: XCTestCase {
         XCTAssertTrue(received.contains(.upToDate))
         XCTAssertEqual(received.last, .disconnected)
     }
+
+    // MARK: - 메모 push 결합
+
+    func test_업데이트_이벤트가_오면_해당_메모를_upsert한다() async {
+        // given
+        auth.emit(.sample)
+        await sut.start()
+        let id = UUID()
+        memoRepository.stubMemo = Self.makeMemo(id: id)
+        let exp = expectation(description: "upsert 호출")
+        writer.onUpsert = { _ in exp.fulfill() }
+
+        // when
+        memoRepository.emit(.update(content: .titleText(memoIDs: [id])))
+
+        // then
+        await fulfillment(of: [exp], timeout: 1.0)
+        XCTAssertEqual(writer.upsertedMemoIDs, [id])
+        XCTAssertEqual(writer.lastUserID, "test-uid")
+    }
+
+    func test_삭제_이벤트가_오면_해당_메모를_delete한다() async {
+        // given
+        auth.emit(.sample)
+        await sut.start()
+        let id = UUID()
+        let exp = expectation(description: "delete 호출")
+        writer.onDelete = { _ in exp.fulfill() }
+
+        // when
+        memoRepository.emit(.delete(memoIDs: [id]))
+
+        // then
+        await fulfillment(of: [exp], timeout: 1.0)
+        XCTAssertEqual(writer.deletedMemoIDs, [id])
+        XCTAssertTrue(writer.upsertedMemoIDs.isEmpty)
+    }
+
+    func test_로그아웃_상태에서는_push하지_않는다() async {
+        // given: 인증되지 않은 상태
+        await sut.start()
+
+        // when: 메모 이벤트가 와도
+        memoRepository.emit(.update(content: .titleText(memoIDs: [UUID()])))
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        // then: userID가 없어 push하지 않는다
+        XCTAssertTrue(writer.upsertedMemoIDs.isEmpty)
+        XCTAssertTrue(writer.deletedMemoIDs.isEmpty)
+    }
+
+    // MARK: - 헬퍼
+
+    private static func makeMemo(id: UUID) -> Memo {
+        Memo(
+            memoID: id,
+            creationDate: .now,
+            modificationDate: .now,
+            deletedDate: nil,
+            isFavorite: false,
+            isInTrash: false,
+            memoText: "",
+            memoTitle: "",
+            categories: [],
+            images: []
+        )
+    }
 }
 
-// MARK: - Mock
+// MARK: - Mocks
 
 private final class MockAuthService: AuthService, @unchecked Sendable {
 
     private let subject = CurrentValueSubject<AuthUser?, Never>(nil)
 
     var currentUser: AuthUser? { subject.value }
+    var authStatePublisher: AnyPublisher<AuthUser?, Never> { subject.eraseToAnyPublisher() }
 
-    var authStatePublisher: AnyPublisher<AuthUser?, Never> {
-        subject.eraseToAnyPublisher()
-    }
-
-    func signInWithApple() async throws -> AuthUser {
-        fatalError("not used in tests")
-    }
-
+    func signInWithApple() async throws -> AuthUser { fatalError("not used in tests") }
     func signOut() async throws {}
-
     func deleteAccount() async throws {}
 
-    func emit(_ user: AuthUser?) {
-        subject.send(user)
+    func emit(_ user: AuthUser?) { subject.send(user) }
+}
+
+private final class MockMemoRemoteWriter: MemoRemoteWriting, @unchecked Sendable {
+
+    private(set) var upsertedMemoIDs: [UUID] = []
+    private(set) var deletedMemoIDs: [UUID] = []
+    private(set) var lastUserID: String?
+    var onUpsert: ((UUID) -> Void)?
+    var onDelete: ((UUID) -> Void)?
+
+    func upsert(_ memo: Memo, userID: String) async throws {
+        upsertedMemoIDs.append(memo.memoID)
+        lastUserID = userID
+        onUpsert?(memo.memoID)
     }
+
+    func delete(memoID: UUID, userID: String) async throws {
+        deletedMemoIDs.append(memoID)
+        lastUserID = userID
+        onDelete?(memoID)
+    }
+}
+
+/// `memoUpdatedPublisher`와 `getMemoIncludingTrash`만 실제로 동작하는 최소 구현.
+/// 나머지 메서드는 본 테스트에서 호출되지 않으므로 미구현.
+private final class MockMemoRepository: MemoRepository, @unchecked Sendable {
+
+    private let subject = PassthroughSubject<MemoUpdateType, Never>()
+    var stubMemo: Memo?
+
+    var memoUpdatedPublisher: AnyPublisher<MemoUpdateType, Never> { subject.eraseToAnyPublisher() }
+
+    func emit(_ event: MemoUpdateType) { subject.send(event) }
+
+    struct StubMemoNotFound: Error {}
+
+    func getMemoIncludingTrash(id: UUID) async throws -> Memo {
+        guard let stubMemo else { throw StubMemoNotFound() }
+        return stubMemo
+    }
+
+    // 이하 본 테스트에서 미사용
+    func createNewMemo() async throws -> Memo { fatalError("not used") }
+    func getMemo(id: UUID) async throws -> Memo { fatalError("not used") }
+    func getAllMemos() async throws -> [Memo] { fatalError("not used") }
+    func getAllMemos(inCategory category: Domain.Category?) async throws -> [Memo] { fatalError("not used") }
+    func getAllMemosInTrash() async throws -> [Memo] { fatalError("not used") }
+    func searchMemo(searchText: String, inCategory category: Domain.Category?) async throws -> [Memo] { fatalError("not used") }
+    func getFavoriteMemos() async throws -> [Memo] { fatalError("not used") }
+    func moveToTrash(_ memo: Memo) async throws { fatalError("not used") }
+    func moveToTrash(_ memos: [Memo]) async throws { fatalError("not used") }
+    func deleteMemo(_ memo: Memo) async throws { fatalError("not used") }
+    func deleteMemos(_ memos: [Memo]) async throws { fatalError("not used") }
+    func restore(_ memo: Memo) async throws { fatalError("not used") }
+    func restore(_ memos: [Memo]) async throws { fatalError("not used") }
+    func replaceCategories(to: Memo, newCategories: Set<Domain.Category>) async throws { fatalError("not used") }
+    func replaceCategories(to: [Memo], newCategories: Set<Domain.Category>) async throws { fatalError("not used") }
+    func addCategories(to: Memo, newCategories: Set<Domain.Category>) async throws { fatalError("not used") }
+    func addCategories(to: [Memo], newCategories: Set<Domain.Category>) async throws { fatalError("not used") }
+    func removeCategories(to: Memo, newCategories: Set<Domain.Category>) async throws { fatalError("not used") }
+    func removeCategories(to: [Memo], newCategories: Set<Domain.Category>) async throws { fatalError("not used") }
+    func setFavorite(_ memo: Memo, to value: Bool) async throws { fatalError("not used") }
+    func setFavorite(_ memos: [Memo], to value: Bool) async throws { fatalError("not used") }
+    func updateMemoContent(_ memo: Memo, newTitle: String?, newMemoText: String?) async throws { fatalError("not used") }
 }
 
 private extension AuthUser {

--- a/Projects/Core/SyncImpl/Tests/MemoSyncActionTests.swift
+++ b/Projects/Core/SyncImpl/Tests/MemoSyncActionTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+import Domain
+@testable import SyncImpl
+
+/// `FirestoreSyncService.syncAction(for:)`이 메모 변경 이벤트를 올바른 Firestore 작업으로 환산하는지 검증한다.
+final class MemoSyncActionTests: XCTestCase {
+
+    func test_삭제_이벤트는_delete_액션으로_환산된다() {
+        let a = UUID()
+        let b = UUID()
+        XCTAssertEqual(
+            FirestoreSyncService.syncAction(for: .delete(memoIDs: [a, b])),
+            .delete(memoIDs: [a, b])
+        )
+    }
+
+    func test_생성_휴지통_복원_이벤트는_upsert_액션으로_환산된다() {
+        let id = UUID()
+        XCTAssertEqual(FirestoreSyncService.syncAction(for: .create(memoIDs: [id])), .upsert(memoIDs: [id]))
+        XCTAssertEqual(FirestoreSyncService.syncAction(for: .trash(memoIDs: [id])), .upsert(memoIDs: [id]))
+        XCTAssertEqual(FirestoreSyncService.syncAction(for: .restore(memoIDs: [id])), .upsert(memoIDs: [id]))
+    }
+
+    func test_업데이트_이벤트는_연관_attribute의_memoID로_upsert된다() {
+        let id = UUID()
+        XCTAssertEqual(
+            FirestoreSyncService.syncAction(for: .update(content: .titleText(memoIDs: [id]))),
+            .upsert(memoIDs: [id])
+        )
+        XCTAssertEqual(
+            FirestoreSyncService.syncAction(for: .update(content: .category(memoIDs: [id]))),
+            .upsert(memoIDs: [id])
+        )
+    }
+}

--- a/Projects/Data/Sources/Repositories/MemoRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/MemoRepositoryImpl.swift
@@ -145,6 +145,22 @@ public extension MemoRepositoryImpl {
             try fetchMemoEntity(id: id).toDomain()
         }
     }
+
+    func getMemoIncludingTrash(id: UUID) async throws -> Memo {
+        try await context.perform { [unowned self] in
+            let request = MemoEntity.fetchRequest()
+            request.predicate = memoIDEquals(to: id)
+            let found = try self.context.fetch(request)
+            switch found.count {
+            case 0:
+                throw MemoEntityError.memoNotFound(id: id)
+            case 1:
+                return found.first!.toDomain()
+            default:
+                throw MemoEntityError.duplicateMemoDetected
+            }
+        }
+    }
     
     func getAllMemos() async throws -> [Memo]  {
         try await context.perform { [unowned self] in

--- a/Projects/Data/Tests/MemoRepositoryTests.swift
+++ b/Projects/Data/Tests/MemoRepositoryTests.swift
@@ -73,6 +73,45 @@ final class MemoRepositoryTests: XCTestCase {
         }
     }
 
+    func test_getMemo는_휴지통_메모를_가져오지_못한다() async throws {
+        // given: 휴지통으로 보낸 메모
+        let memo = try await sut.createNewMemo()
+        try await sut.moveToTrash(memo)
+
+        // when / then: getMemo는 notDeleted 조건이라 에러를 던진다
+        do {
+            _ = try await sut.getMemo(id: memo.memoID)
+            XCTFail("휴지통 메모는 getMemo로 가져올 수 없어야 한다")
+        } catch {
+            // 에러 발생 — 통과
+        }
+    }
+
+    func test_getMemoIncludingTrash는_휴지통_메모도_가져온다() async throws {
+        // given: 휴지통으로 보낸 메모
+        let memo = try await sut.createNewMemo()
+        try await sut.moveToTrash(memo)
+
+        // when
+        let fetched = try await sut.getMemoIncludingTrash(id: memo.memoID)
+
+        // then
+        XCTAssertEqual(fetched.memoID, memo.memoID)
+        XCTAssertTrue(fetched.isInTrash)
+    }
+
+    func test_getMemoIncludingTrash는_살아있는_메모도_가져온다() async throws {
+        // given
+        let memo = try await sut.createNewMemo()
+
+        // when
+        let fetched = try await sut.getMemoIncludingTrash(id: memo.memoID)
+
+        // then
+        XCTAssertEqual(fetched.memoID, memo.memoID)
+        XCTAssertFalse(fetched.isInTrash)
+    }
+
     func test_전체_조회시_휴지통_메모는_제외된다() async throws {
         // given: 일반 메모 1개와 휴지통으로 보낸 메모 1개
         let kept = try await sut.createNewMemo()

--- a/Projects/Domain/Sources/Repositories/MemoRepository.swift
+++ b/Projects/Domain/Sources/Repositories/MemoRepository.swift
@@ -16,6 +16,7 @@ public protocol MemoRepository: Sendable {
     func createNewMemo() async throws -> Memo
 
     func getMemo(id: UUID) async throws -> Memo
+    func getMemoIncludingTrash(id: UUID) async throws -> Memo
     func getAllMemos() async throws -> [Memo]
     func getAllMemos(inCategory category: Category?) async throws -> [Memo]
     func getAllMemosInTrash() async throws -> [Memo]


### PR DESCRIPTION
## 배경
- Firestore 동기화 v1에서 로컬 메모 변경을 클라우드로 올리는 첫 동작. \`FirestoreSyncService\`가 \`memoUpdatedPublisher\`를 구독해 이벤트별로 Firestore에 push.
- 앞선 PR들에서 인터페이스 / DTO / Writer / Service 셸 / composition root 연결이 끝나, 이제 실제 push를 결합.

## 변경사항
- \`getMemoIncludingTrash(id:)\` (Domain + Data)
  - notDeleted 조건 없는 단건 조회. 휴지통(.trash) 메모도 push해야 하므로 필요 (기존 getMemo는 살아있는 메모만 반환)
- \`FirestoreMemoWriter.delete(memoID:userID:)\`
  - 영구 삭제 메모의 document 제거. 메모가 로컬에서 사라져 fetch 불가하므로 memoID로 직접 삭제
  - \`MemoRemoteWriting\` 내부 protocol 도입 (테스트 seam, 모듈 외부 비노출)
- \`FirestoreSyncService\` push 결합
  - create/update/trash/restore → 메모 fetch 후 upsert, delete → document 삭제
  - 인증된 사용자가 없으면(로그아웃) push하지 않음
  - 이벤트 → 작업 환산을 syncAction(for:) 순수 함수로 분리
- composition root: SyncBootstrap.makeSyncService에 memoRepository 주입, AppEnvironment 연결
- 테스트: status 전이 8 + push 결합 3(upsert/delete/로그아웃 시 미push) + 매핑 3 + DTO/Writer 등
- docs: 테스트의 given/when/then 구획 주석은 유지하도록 AGENTS.md 명시

## 테스트 방법
- \`tuist test\` 전체 통과 (SyncImplTests 포함)
- 실기기 검증 완료 (Firestore Console에서 확인)
  - 로그인 후 메모 생성/수정 → \`users/{uid}/memos/{memoID}\` document 생성·갱신
  - 휴지통 → \`isInTrash: true\` + deletedDate, 복원 → \`isInTrash: false\` + deletedDate 제거
  - 영구 삭제 → document 제거
  - ※ Firestore Security Rules 설정 필요 (인증 사용자가 자기 \`users/{uid}\` 아래만 R/W)

## 리뷰 노트
- **단방향 push만** — pull(listener) 미구현이라 다른 기기에서 기존 데이터를 받아오지 못함 (의도된 후속 작업)
- **initial push 없음** — 이벤트 기반이라 로그인 *전*부터 있던 메모는 자동 업로드되지 않음. 로그인 시 전체 업로드는 후속
- **디바운스·에러 status 전이 없음** — 매 이벤트 push(best-effort), Firestore Error → SyncError 매핑과 .syncing/.error 전이는 후속
- \`MemoRemoteWriting\` 추상화는 Firestore 실호출(FirebaseApp 미설정 시 크래시)을 테스트에서 mock으로 대체하기 위한 내부 seam — 모듈 외부 노출용 Interface/Impl 분리가 아님
- 별개 known issue: 로그인 시 익명 store 전환 과정의 sqlite \`vnode unlinked\` 경고는 본 PR과 무관(기존 코드)하며 별도 PR로 수정 예정