### PR TITLE
fix(coredata): 로그인 시 익명 store 전환 순서 수정

### DIFF
--- a/Projects/Data/Sources/CoreData/AnonymousToUserMigrator.swift
+++ b/Projects/Data/Sources/CoreData/AnonymousToUserMigrator.swift
@@ -7,21 +7,29 @@ import CoreData
 import Foundation
 
 /// 사용자가 처음 로그인할 때 익명 store(`anonymous.sqlite`)의 내용을 사용자 store(`users/<uid>/NoteCard.sqlite`)로 1회 이전한다.
-/// `UserScopedDataLayer`가 stack을 교체하기 직전에 호출한다.
+/// `UserScopedDataLayer`가 stack을 교체하는 과정에서 호출한다.
+///
+/// 이전은 두 단계로 나뉜다. 익명 store를 연 stack이 살아 있는 동안 파일을 삭제하면 sqlite 무결성이
+/// 깨지므로(`vnode unlinked while in use`), 복사와 정리를 분리해 호출자가 그 사이에 stack을 닫게 한다:
+/// 1. `copyIfNeeded` — 익명 → 사용자 store 복사 (삭제하지 않음)
+/// 2. (호출자가 익명 store를 연 stack을 닫음)
+/// 3. `cleanUpAnonymousStore` — 익명 store 파일 정리
 ///
 /// 정책:
-/// - 익명 store에 파일이 없으면 no-op.
-/// - 사용자 store가 *이미 존재*하면 no-op (sync 작업 단계에서 클라우드 데이터와 합쳐질 책임. 이번 단계 범위 밖).
-/// - target이 비어 있을 때만 `replacePersistentStore`로 단순 이전. 성공 시 익명 store는 비움.
+/// - 익명 store에 파일이 없으면 복사 안 함.
+/// - 사용자 store가 *이미 존재*하면 복사 안 함 (sync 작업 단계에서 클라우드 데이터와 합쳐질 책임. 이번 단계 범위 밖).
 public enum AnonymousToUserMigrator {
 
-    public static func migrateIfNeeded(
+    /// 익명 store를 사용자 store로 복사한다. 익명 store는 삭제하지 않는다(정리는 `cleanUpAnonymousStore`).
+    /// - Returns: 복사를 수행했으면 `true`(이후 정리 대상), 조건 미충족·실패로 skip하면 `false`.
+    @discardableResult
+    public static func copyIfNeeded(
         anonymousStoreURL: URL,
         userStoreURL: URL,
         onError: (Error) -> Void = { _ in }
-    ) {
-        guard FileManager.default.fileExists(atPath: anonymousStoreURL.path) else { return }
-        guard !FileManager.default.fileExists(atPath: userStoreURL.path) else { return }
+    ) -> Bool {
+        guard FileManager.default.fileExists(atPath: anonymousStoreURL.path) else { return false }
+        guard !FileManager.default.fileExists(atPath: userStoreURL.path) else { return false }
 
         do {
             let coordinator = try makeCoordinator()
@@ -36,14 +44,21 @@ public enum AnonymousToUserMigrator {
                 sourceOptions: nil,
                 type: .sqlite
             )
-            // 익명 store는 비움 — 다음 익명 사용을 위해 깨끗한 상태로 둠.
-            // destroyPersistentStore만으로는 잔여 파일이 남는 경우가 있어 명시적으로 제거.
-            try? coordinator.destroyPersistentStore(at: anonymousStoreURL, type: .sqlite, options: nil)
-            for suffix in ["", "-wal", "-shm"] {
-                try? FileManager.default.removeItem(atPath: anonymousStoreURL.path + suffix)
-            }
+            return true
         } catch {
             onError(error)
+            return false
+        }
+    }
+
+    /// 익명 store를 비운다 — 다음 익명 사용을 위해 깨끗한 상태로 둠.
+    /// `copyIfNeeded` 성공 후, 익명 store를 연 stack이 닫힌 뒤에 호출해야 한다.
+    /// `destroyPersistentStore`만으로는 잔여 파일이 남는 경우가 있어 `-wal`/`-shm`까지 명시적으로 제거.
+    public static func cleanUpAnonymousStore(at anonymousStoreURL: URL) {
+        let coordinator = try? makeCoordinator()
+        try? coordinator?.destroyPersistentStore(at: anonymousStoreURL, type: .sqlite, options: nil)
+        for suffix in ["", "-wal", "-shm"] {
+            try? FileManager.default.removeItem(atPath: anonymousStoreURL.path + suffix)
         }
     }
 

--- a/Projects/Data/Sources/CoreData/CoreDataStack.swift
+++ b/Projects/Data/Sources/CoreData/CoreDataStack.swift
@@ -78,6 +78,17 @@ public final class CoreDataStack: ObservableObject {
     
     public private(set) lazy var backgroundContext = persistentContainer.newBackgroundContext()
 
+    /// persistent store를 coordinator에서 제거해 열린 파일 핸들을 닫는다.
+    ///
+    /// 익명 store를 삭제하기 전에 호출해, 파일을 연 채로 unlink되어 sqlite 무결성이 깨지는
+    /// 상황(`vnode unlinked while in use`)을 방지한다. 호출 후 이 stack은 더 이상 사용하지 않는다.
+    public func close() {
+        let coordinator = persistentContainer.persistentStoreCoordinator
+        for store in coordinator.persistentStores {
+            try? coordinator.remove(store)
+        }
+    }
+
     // MARK: - Core Data Saving support
 
     public func saveContext () {

--- a/Projects/Data/Sources/CoreData/UserScopedDataLayer.swift
+++ b/Projects/Data/Sources/CoreData/UserScopedDataLayer.swift
@@ -65,16 +65,29 @@ public final class UserScopedDataLayer {
             .dropFirst()
             .sink { [weak self] userID in
                 guard let self else { return }
+                let previousStack = self.stackSubject.value
+                let anonymousStoreURL = Self.storeURL(for: nil, in: self.storeDirectory)
+
                 // 로그인 직후라면 익명 데이터를 사용자 store로 흡수 (target이 비어 있을 때만).
+                // 복사는 익명 store를 연 기존 stack이 살아 있어도 안전(읽기)하다.
+                var didAbsorbAnonymous = false
                 if let userID {
-                    AnonymousToUserMigrator.migrateIfNeeded(
-                        anonymousStoreURL: Self.storeURL(for: nil, in: self.storeDirectory),
+                    didAbsorbAnonymous = AnonymousToUserMigrator.copyIfNeeded(
+                        anonymousStoreURL: anonymousStoreURL,
                         userStoreURL: Self.storeURL(for: userID, in: self.storeDirectory),
                         onError: self.onMigrationError
                     )
                 }
+
                 let newStack = Self.makeStack(for: userID, in: self.storeDirectory)
                 self.stackSubject.send(newStack)
+
+                // 익명 store 파일을 삭제하기 전에, 그것을 연 이전 stack을 먼저 닫는다.
+                // (새 stack으로 교체한 *뒤*라 외부는 이미 새 stack을 참조하므로, 이전 stack을 닫아도 안전.)
+                if didAbsorbAnonymous {
+                    previousStack.close()
+                    AnonymousToUserMigrator.cleanUpAnonymousStore(at: anonymousStoreURL)
+                }
             }
     }
 

--- a/Projects/Data/Tests/AnonymousToUserMigratorTests.swift
+++ b/Projects/Data/Tests/AnonymousToUserMigratorTests.swift
@@ -3,7 +3,7 @@ import CoreData
 import Domain
 @testable import Data
 
-/// `AnonymousToUserMigrator`가 익명 store를 사용자 store로 1회 이전하는지 검증.
+/// `AnonymousToUserMigrator`의 복사(`copyIfNeeded`)·정리(`cleanUpAnonymousStore`)를 검증.
 final class AnonymousToUserMigratorTests: XCTestCase {
 
     private var tempDir: URL!
@@ -18,60 +18,66 @@ final class AnonymousToUserMigratorTests: XCTestCase {
         try? FileManager.default.removeItem(at: tempDir)
     }
 
-    func test_익명_store가_있고_사용자_store가_없으면_이전된다() async throws {
+    func test_익명_store가_있고_사용자_store가_없으면_복사된다() async throws {
         let anonURL = tempDir.appendingPathComponent("anonymous.sqlite")
         let userURL = tempDir.appendingPathComponent("users/uid123/NoteCard.sqlite")
         try await createStore(memoCount: 2, at: anonURL)
 
-        AnonymousToUserMigrator.migrateIfNeeded(
+        let didCopy = AnonymousToUserMigrator.copyIfNeeded(
             anonymousStoreURL: anonURL,
             userStoreURL: userURL
         )
 
+        XCTAssertTrue(didCopy)
         XCTAssertTrue(FileManager.default.fileExists(atPath: userURL.path))
         let count = try await memoCount(at: userURL)
         XCTAssertEqual(count, 2)
     }
 
-    func test_익명_store가_없으면_no_op() {
+    func test_익명_store가_없으면_복사하지_않는다() {
         let anonURL = tempDir.appendingPathComponent("anonymous.sqlite") // 존재하지 않음
         let userURL = tempDir.appendingPathComponent("users/uid123/NoteCard.sqlite")
 
-        AnonymousToUserMigrator.migrateIfNeeded(
+        let didCopy = AnonymousToUserMigrator.copyIfNeeded(
             anonymousStoreURL: anonURL,
             userStoreURL: userURL
         )
 
+        XCTAssertFalse(didCopy)
         XCTAssertFalse(FileManager.default.fileExists(atPath: userURL.path))
     }
 
-    func test_사용자_store가_이미_있으면_익명이_있어도_skip() async throws {
+    func test_사용자_store가_이미_있으면_익명이_있어도_복사하지_않는다() async throws {
         let anonURL = tempDir.appendingPathComponent("anonymous.sqlite")
         let userURL = tempDir.appendingPathComponent("users/uid123/NoteCard.sqlite")
         try await createStore(memoCount: 5, at: userURL)
         try await createStore(memoCount: 2, at: anonURL)
 
-        AnonymousToUserMigrator.migrateIfNeeded(
+        let didCopy = AnonymousToUserMigrator.copyIfNeeded(
             anonymousStoreURL: anonURL,
             userStoreURL: userURL
         )
 
+        XCTAssertFalse(didCopy)
         // 사용자 store는 원래 5개 그대로
         let count = try await memoCount(at: userURL)
         XCTAssertEqual(count, 5)
-        // 익명 store도 그대로 (skip이라 destroy 안 됨)
+        // 익명 store도 그대로 (복사 skip이라 정리 안 함)
         XCTAssertTrue(FileManager.default.fileExists(atPath: anonURL.path))
     }
 
-    func test_마이그레이션_성공시_익명_store_파일들이_삭제된다() async throws {
+    func test_복사_후_cleanUp하면_익명_store_파일들이_삭제된다() async throws {
         let anonURL = tempDir.appendingPathComponent("anonymous.sqlite")
         let userURL = tempDir.appendingPathComponent("users/uid123/NoteCard.sqlite")
         try await createStore(memoCount: 1, at: anonURL)
 
-        AnonymousToUserMigrator.migrateIfNeeded(
+        let didCopy = AnonymousToUserMigrator.copyIfNeeded(
             anonymousStoreURL: anonURL,
             userStoreURL: userURL
         )
+        XCTAssertTrue(didCopy)
+
+        AnonymousToUserMigrator.cleanUpAnonymousStore(at: anonURL)
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: anonURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: anonURL.path + "-wal"))
@@ -79,7 +85,7 @@ final class AnonymousToUserMigratorTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: userURL.path))
     }
 
-    func test_마이그레이션_실패시_익명이_보존되고_사용자_store는_안_만들어진다() async throws {
+    func test_복사_실패시_익명이_보존되고_사용자_store는_안_만들어진다() async throws {
         let anonURL = tempDir.appendingPathComponent("anonymous.sqlite")
         try await createStore(memoCount: 1, at: anonURL)
 
@@ -89,12 +95,13 @@ final class AnonymousToUserMigratorTests: XCTestCase {
         let userURL = fileBlocker.appendingPathComponent("sub").appendingPathComponent("NoteCard.sqlite")
 
         var capturedError: Error?
-        AnonymousToUserMigrator.migrateIfNeeded(
+        let didCopy = AnonymousToUserMigrator.copyIfNeeded(
             anonymousStoreURL: anonURL,
             userStoreURL: userURL,
             onError: { capturedError = $0 }
         )
 
+        XCTAssertFalse(didCopy)
         XCTAssertNotNil(capturedError, "실패 시 onError로 에러가 전달되어야 한다.")
         XCTAssertFalse(FileManager.default.fileExists(atPath: userURL.path), "실패 시 사용자 store를 만들면 안 된다.")
         XCTAssertTrue(FileManager.default.fileExists(atPath: anonURL.path), "실패 시 익명 원본은 보존돼야 한다.")
@@ -112,11 +119,8 @@ final class AnonymousToUserMigratorTests: XCTestCase {
         for _ in 0..<memoCount {
             _ = try await repo.createNewMemo()
         }
-        // 프로덕션에선 마이그레이션 시점에 익명 store가 닫혀 있다. 테스트도 동일하게 닫아준다.
-        let coordinator = stack.persistentContainer.persistentStoreCoordinator
-        for store in coordinator.persistentStores {
-            try coordinator.remove(store)
-        }
+        // 프로덕션에선 정리(cleanUp) 전에 UserScopedDataLayer가 익명 stack을 닫는다. 테스트도 동일하게 닫아준다.
+        stack.close()
     }
 
     private func memoCount(at url: URL) async throws -> Int {

--- a/Projects/Data/Tests/UserScopedDataLayerTests.swift
+++ b/Projects/Data/Tests/UserScopedDataLayerTests.swift
@@ -79,6 +79,24 @@ final class UserScopedDataLayerTests: XCTestCase {
         XCTAssertTrue(layer.currentStack === initialStack)
     }
 
+    func test_로그인하면_익명_데이터가_사용자_store로_흡수되고_익명_store는_정리된다() async throws {
+        // given: 익명 상태에서 메모 1개 생성
+        let provider = MockUserIDProvider(initial: nil)
+        let layer = UserScopedDataLayer(userIDProvider: provider, storeDirectory: tempDirectory)
+        let anonRepo = MemoRepositoryImpl(dataLayer: layer)
+        _ = try await anonRepo.createNewMemo()
+        let anonURL = tempDirectory.appendingPathComponent("anonymous.sqlite")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: anonURL.path))
+
+        // when: 로그인
+        provider.setUserID("userA")
+
+        // then: 익명 메모가 사용자 store로 흡수되고, 익명 store 파일은 정리된다
+        let userMemos = try await MemoRepositoryImpl(dataLayer: layer).getAllMemos()
+        XCTAssertEqual(userMemos.count, 1, "익명 메모가 사용자 store로 흡수돼야 한다.")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: anonURL.path), "익명 store는 정리돼야 한다.")
+    }
+
     func test_서로_다른_사용자의_stack은_데이터가_격리된다() async throws {
         // given
         let provider = MockUserIDProvider(initial: "userA")


### PR DESCRIPTION
## 배경
- 기존 메모가 있는 익명 사용자가 처음 로그인할 때, 익명 store(`anonymous.sqlite`)를 연 stack이 살아 있는 채로 그 파일을 삭제 → sqlite `vnode unlinked while in use` 경고 + `invalidated open fd` (데이터 무결성 위험).
- 실기기 로그인 테스트에서 표면화된 기존 버그(R1 AnonymousToUserMigrator 작업). 메모 동기화와는 무관.

## 변경사항
- `CoreDataStack.close()` 추가 — coordinator에서 persistent store를 제거해 열린 파일 핸들을 닫음
- `AnonymousToUserMigrator`를 두 단계로 분리
  - `copyIfNeeded(...) -> Bool` — 익명 → 사용자 store 복사만 (삭제 안 함)
  - `cleanUpAnonymousStore(at:)` — 익명 store 파일 정리 (destroy + `-wal`/`-shm` 제거)
- `UserScopedDataLayer` 로그인 시 순서 재배치
  - 복사 → 새 stack 교체(send) → 이전(익명) stack `close()` → 익명 store 삭제
  - 삭제 시점엔 익명 파일을 연 stack이 없고, currentStack이 닫힌 상태인 윈도우도 없음
- 테스트
  - `AnonymousToUserMigratorTests`: 분리된 copy/cleanup API로 갱신
  - `UserScopedDataLayerTests`: 로그인 시 익명 흡수 + 익명 store 정리 통합 검증 추가

## 테스트 방법
- `tuist test` 전체 통과 (Data 테스트 포함)
- 시뮬레이터 검증 완료
  - 익명 상태로 메모 생성 → 로그인 시 `vnode unlinked` 경고 사라짐 확인
  - sqlite 파일이 익명 → 사용자 경로로 정상 이동, 익명 메모 보존
  - ※ `vnode` 경고는 파일시스템 레벨 동작이라 시뮬레이터·실기기 동일

## 리뷰 노트
- 핵심은 "익명 store 삭제 전에 그것을 연 stack을 먼저 닫는다"는 순서. 복사는 stack이 열려 있어도 읽기라 안전하고, 새 stack 교체를 삭제보다 앞에 둬 외부가 항상 유효한 stack을 참조하도록 함
- 별개 미해결: 로그인 직후 홈 화면 즉시 미반영 — HomeViewController가 stack에 묶인 CoreData Notification을 구독해 stack 교체를 못 따라가는 문제. 본 PR과 무관하며 별도 작업으로 다룰 예정