### PR TITLE
fix(home): 로그인 후 홈 화면이 변경을 반영하지 않던 문제 수정

### DIFF
--- a/NoteCard/Presentation/HomeView/HomeViewController.swift
+++ b/NoteCard/Presentation/HomeView/HomeViewController.swift
@@ -54,10 +54,6 @@ class HomeViewController: UIViewController {
     private var diffableDataSource: DiffableDataSource!
     
     private var cancellables: Set<AnyCancellable> = []
-    private lazy var coreDataChangePublisher = NotificationCenter.default.publisher(
-        for: .NSManagedObjectContextDidSave,
-        object: environment.coreDataStack.backgroundContext
-    )
 
     private let environment: AppEnvironment
 
@@ -257,15 +253,6 @@ class HomeViewController: UIViewController {
     }
     
     private func bind() {
-//        coreDataChangePublisher.sink { [weak self] _ in
-//            guard let self else { return }
-//            Task {
-//                try await self.fetchData()
-//                self.applySnapshot()
-//            }
-//        }
-//        .store(in: &cancellables)
-        
         ThemeManager.shared.currentThemePublisher
             .sink { [weak self] color in
                 guard let self else { return }
@@ -278,12 +265,19 @@ class HomeViewController: UIViewController {
                     cell.setNeedsLayout()
                 }
             }.store(in: &cancellables)
-        
-        let coreDataChangeStream = coreDataChangePublisher.map { _ in return () }
-        let orderSettingChangeStream = OrderSettingManager.shared.orderSettingChangedPublisher
-        
-        coreDataChangeStream
-            .merge(with: orderSettingChangeStream)
+
+        // 홈은 메모·카테고리·이미지 세 도메인과 정렬 설정을 모두 표시하므로, 각 Repository publisher와
+        // 정렬 변경 스트림을 Void로 합쳐 구독한다. Repository publisher는 stack 교체(로그인)에도 끊기지
+        // 않아, 사용자별 store로 바뀐 뒤에도 변경이 반영된다. 연속 변경은 debounce로 한 번에 묶는다.
+        let changeStreams: [AnyPublisher<Void, Never>] = [
+            environment.memoRepository.memoUpdatedPublisher.map { _ in () }.eraseToAnyPublisher(),
+            environment.categoryRepository.categoryUpdatedPublisher.map { _ in () }.eraseToAnyPublisher(),
+            environment.imageRepository.imageUpdatedPublisher.map { _ in () }.eraseToAnyPublisher(),
+            OrderSettingManager.shared.orderSettingChangedPublisher.map { _ in () }.eraseToAnyPublisher(),
+        ]
+
+        Publishers.MergeMany(changeStreams)
+            .debounce(for: .milliseconds(500), scheduler: RunLoop.main)
             .sink { [weak self] _ in
                 guard let self else { return }
                 Task {


### PR DESCRIPTION
## 배경
- 홈 화면이 `NSManagedObjectContextDidSave`(CoreData 저장 알림)를 직접 구독했는데, `object:`에 lazy 캡처된 특정 stack의 context가 묶여 있었음.
- 로그인 시 stack이 사용자 store로 교체되면, 홈은 여전히 옛(익명) context만 바라봐 새 stack의 변경 알림을 못 받음 → 로그인 후 메모 수정 등이 홈에 반영되지 않던 문제.

## 변경사항
- stack에 묶인 `coreDataChangePublisher`(`NSManagedObjectContextDidSave`) 구독 제거
- 메모/카테고리/이미지 Repository publisher + 정렬 설정 변경을 `Void`로 merge해 구독
  - Repository는 `AppEnvironment`가 단일 인스턴스로 유지하고 내부에서 매번 `currentStack`을 참조하므로, stack 교체에도 publisher 구독이 끊기지 않음
  - 홈은 세 도메인(메모/카테고리/이미지 개수)과 정렬을 모두 표시하므로 세 publisher + 정렬 스트림을 모두 구독
- 0.5초 debounce로 연속 변경(메모 생성+이미지 추가 등)을 한 번에 묶어 갱신
- stack에 묶인 lazy 프로퍼티 제거로, 다른 메모 화면(PopupCard·MemoView)과 동일한 publisher 구독 패턴으로 통일

## 테스트 방법
- `tuist test` 전체 통과 (회귀 없음)
- 시뮬레이터 검증 완료
  - 익명 상태: 메모/카테고리/이미지 변경 → 홈 즉시 반영 (회귀 없음)
  - 로그인 후: 메모/카테고리/이미지 변경 → 홈 반영 (이전엔 안 되던 것)
  - 정렬 변경 → 약 0.5초 후 반영, 매끄러운 갱신

## 리뷰 노트
- HomeViewController만 CoreData 저장 알림을 직접 구독하던 유일한 화면이었음. 이번 변경으로 Repository publisher 구독으로 통일됨
- 별개 known issue (본 PR 범위 밖): 로그아웃 등 **세션/stack 전환** 시에는 데이터 mutation이 아니라 Repository publisher가 발행되지 않아 홈이 stale하게 남고, 옛 메모 탭 시 `memoNotFound`가 발생. 화면이 stack 교체(`currentStackPublisher`)를 구독하지 않는 별도 축의 문제로, 세션 전환 화면 갱신 작업에서 처리 예정