### PR TITLE
feat(sync): 메모 push 에러 매핑 + status 전이

### DIFF
--- a/Projects/Core/SyncImpl/Sources/FirestoreErrorMapper.swift
+++ b/Projects/Core/SyncImpl/Sources/FirestoreErrorMapper.swift
@@ -1,0 +1,28 @@
+//
+//  FirestoreErrorMapper.swift
+//  NoteCard
+//
+
+import FirebaseFirestore
+import Foundation
+import SyncInterface
+
+/// Firestore SDK가 던지는 저수준 에러를 도메인 에러(`SyncError`)로 변환한다.
+/// FirebaseFirestore 의존을 이 한 곳에 가둬, `FirestoreSyncService`는 SDK를 직접 import하지 않는다.
+enum FirestoreErrorMapper {
+
+    static func syncError(from error: Error) -> SyncError {
+        let nsError = error as NSError
+        guard nsError.domain == FirestoreErrorDomain,
+              let code = FirestoreErrorCode.Code(rawValue: nsError.code) else {
+            return .unknown(error)
+        }
+        switch code {
+        case .unavailable:       return .network
+        case .permissionDenied:  return .permissionDenied
+        case .resourceExhausted: return .quotaExceeded
+        case .unauthenticated:   return .unauthenticated
+        default:                 return .unknown(error)
+        }
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/FirestoreSyncService.swift
+++ b/Projects/Core/SyncImpl/Sources/FirestoreSyncService.swift
@@ -114,6 +114,7 @@ public final class FirestoreSyncService: SyncService, @unchecked Sendable {
     }
 
     private func performMemoSync(action: MemoSyncAction, userID: String) async {
+        statusSubject.send(.syncing)
         do {
             switch action {
             case .upsert(let memoIDs):
@@ -126,8 +127,9 @@ public final class FirestoreSyncService: SyncService, @unchecked Sendable {
                     try await memoWriter.delete(memoID: memoID, userID: userID)
                 }
             }
+            statusSubject.send(.upToDate)
         } catch {
-            // 에러 매핑과 .error status 전이는 후속 단계에서 결합. 현재는 best-effort push.
+            statusSubject.send(.error(FirestoreErrorMapper.syncError(from: error)))
         }
     }
 }

--- a/Projects/Core/SyncImpl/Tests/FirestoreErrorMapperTests.swift
+++ b/Projects/Core/SyncImpl/Tests/FirestoreErrorMapperTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+import FirebaseFirestore
+import SyncInterface
+@testable import SyncImpl
+
+/// Firestore SDK 에러 → `SyncError` 매핑을 검증한다.
+/// `SyncError`는 `unknown(Error)` 때문에 Equatable이 아니라, case 패턴 매칭으로 확인한다.
+final class FirestoreErrorMapperTests: XCTestCase {
+
+    private func firestoreError(_ code: FirestoreErrorCode.Code) -> NSError {
+        NSError(domain: FirestoreErrorDomain, code: code.rawValue)
+    }
+
+    func test_unavailable는_network로_매핑된다() {
+        guard case .network = FirestoreErrorMapper.syncError(from: firestoreError(.unavailable)) else {
+            return XCTFail("network로 매핑되어야 한다")
+        }
+    }
+
+    func test_permissionDenied는_permissionDenied로_매핑된다() {
+        guard case .permissionDenied = FirestoreErrorMapper.syncError(from: firestoreError(.permissionDenied)) else {
+            return XCTFail("permissionDenied로 매핑되어야 한다")
+        }
+    }
+
+    func test_resourceExhausted는_quotaExceeded로_매핑된다() {
+        guard case .quotaExceeded = FirestoreErrorMapper.syncError(from: firestoreError(.resourceExhausted)) else {
+            return XCTFail("quotaExceeded로 매핑되어야 한다")
+        }
+    }
+
+    func test_unauthenticated는_unauthenticated로_매핑된다() {
+        guard case .unauthenticated = FirestoreErrorMapper.syncError(from: firestoreError(.unauthenticated)) else {
+            return XCTFail("unauthenticated로 매핑되어야 한다")
+        }
+    }
+
+    func test_매핑되지_않은_Firestore_코드는_unknown이다() {
+        guard case .unknown = FirestoreErrorMapper.syncError(from: firestoreError(.dataLoss)) else {
+            return XCTFail("매핑 규칙에 없는 코드는 unknown이어야 한다")
+        }
+    }
+
+    func test_Firestore_도메인이_아닌_에러는_unknown이다() {
+        let other = NSError(domain: "SomeOtherDomain", code: 42)
+        guard case .unknown = FirestoreErrorMapper.syncError(from: other) else {
+            return XCTFail("Firestore 도메인이 아니면 unknown이어야 한다")
+        }
+    }
+}

--- a/Projects/Core/SyncImpl/Tests/FirestoreSyncServiceTests.swift
+++ b/Projects/Core/SyncImpl/Tests/FirestoreSyncServiceTests.swift
@@ -178,6 +178,49 @@ final class FirestoreSyncServiceTests: XCTestCase {
         XCTAssertTrue(writer.deletedMemoIDs.isEmpty)
     }
 
+    // MARK: - status 전이 (push)
+
+    func test_push_성공시_syncing을_거쳐_upToDate로_전이된다() async {
+        // given
+        auth.emit(.sample)
+        await sut.start()
+        memoRepository.stubMemo = Self.makeMemo(id: UUID())
+
+        var sawSyncing = false
+        let exp = expectation(description: "syncing → upToDate")
+        let cancellable = sut.statusPublisher.sink { status in
+            if status == .syncing { sawSyncing = true }
+            if status == .upToDate && sawSyncing { exp.fulfill() }
+        }
+        defer { cancellable.cancel() }
+
+        // when
+        memoRepository.emit(.update(content: .titleText(memoIDs: [UUID()])))
+
+        // then
+        await fulfillment(of: [exp], timeout: 1.0)
+    }
+
+    func test_push_실패시_error로_전이된다() async {
+        // given
+        auth.emit(.sample)
+        await sut.start()
+        memoRepository.stubMemo = Self.makeMemo(id: UUID())
+        writer.upsertError = NSError(domain: "Test", code: 1)
+
+        let exp = expectation(description: "error")
+        let cancellable = sut.statusPublisher.sink { status in
+            if case .error = status { exp.fulfill() }
+        }
+        defer { cancellable.cancel() }
+
+        // when
+        memoRepository.emit(.update(content: .titleText(memoIDs: [UUID()])))
+
+        // then
+        await fulfillment(of: [exp], timeout: 1.0)
+    }
+
     // MARK: - 헬퍼
 
     private static func makeMemo(id: UUID) -> Memo {
@@ -219,10 +262,12 @@ private final class MockMemoRemoteWriter: MemoRemoteWriting, @unchecked Sendable
     private(set) var lastUserID: String?
     var onUpsert: ((UUID) -> Void)?
     var onDelete: ((UUID) -> Void)?
+    var upsertError: Error?
 
     func upsert(_ memo: Memo, userID: String) async throws {
         upsertedMemoIDs.append(memo.memoID)
         lastUserID = userID
+        if let upsertError { throw upsertError }
         onUpsert?(memo.memoID)
     }
 


### PR DESCRIPTION
## 배경
- 단방향 push(PR #53)는 best-effort라 실패해도 조용히 무시되고, SyncStatus가 push 동작에 반응하지 않았음.
- push 결과를 사용자에게 노출할 수 있도록, Firestore 에러를 도메인 에러로 변환하고 push 진행에 따라 status를 전이.

## 변경사항
- `FirestoreErrorMapper` 신설
  - Firestore SDK 에러 → `SyncError` 변환 (network / permissionDenied / quotaExceeded / unauthenticated / unknown)
  - `FirebaseFirestore` 의존을 이 한 곳에 캡슐화 → `FirestoreSyncService`는 SDK를 직접 import하지 않음
- `FirestoreSyncService.performMemoSync` status 전이
  - push 시작 → `.syncing`
  - 성공 → `.upToDate`
  - 실패 → `.error(매핑된 SyncError)`
- 테스트
  - `FirestoreErrorMapperTests`: 코드별 매핑 + 비-Firestore 도메인 unknown 처리 (6종)
  - `FirestoreSyncServiceTests`: push 성공 시 syncing→upToDate, 실패 시 error 전이 (mock writer 에러 주입, 2종)

## 테스트 방법
- `tuist test` 전체 통과 (SyncImplTests 31개 포함)
- 자동 테스트로 검증되는 변경이라 실기기 수동 검증 불필요

## 리뷰 노트
- `SyncError`는 `unknown(Error)` 때문에 Equatable이 아니라, 매핑 테스트는 case 패턴 매칭으로 검증
- 본 PR로 status가 실제 전이하므로, 이후 `AccountDetailView`에 SyncStatus를 표시하면 사용자가 동기화 상태를 볼 수 있음 (별도 UI 작업)
- 후속 예정: 디바운스/배칭(타이핑 시 잦은 push 묶기) + pull(listener) + AccountDetail status 표시