### PR TITLE
feat(sync): FirestoreMemo → Memo 역변환 추가

### DIFF
--- a/Projects/Core/SyncImpl/Sources/FirestoreMemo.swift
+++ b/Projects/Core/SyncImpl/Sources/FirestoreMemo.swift
@@ -40,4 +40,31 @@ public extension FirestoreMemo {
         self.deletedDate = memo.deletedDate
         self.categoryIDs = memo.categories.map(\.id.uuidString).sorted()
     }
+
+    /// 메모가 참조하는 카테고리들의 UUID. 호출자가 로컬 `Category` 본문을 resolve하는 데 사용.
+    /// 파싱 불가한 문자열은 제외한다.
+    var categoryUUIDs: [UUID] {
+        categoryIDs.compactMap(UUID.init(uuidString:))
+    }
+
+    /// 서버 DTO를 로컬 `Memo`로 되돌린다.
+    ///
+    /// 카테고리 본문은 별도 컬렉션이라 `categoryUUIDs`로 호출자가 resolve한 `Category` 집합을 주입한다.
+    /// 이미지는 메모 sub-collection으로 별도 동기화되므로 빈 집합으로 둔다(이후 이미지 동기화에서 채움).
+    /// `memoID`가 UUID로 파싱되지 않으면(손상된 문서) `nil`을 반환한다.
+    func toDomain(categories: Set<Domain.Category>) -> Memo? {
+        guard let id = UUID(uuidString: memoID) else { return nil }
+        return Memo(
+            memoID: id,
+            creationDate: creationDate,
+            modificationDate: modificationDate,
+            deletedDate: deletedDate,
+            isFavorite: isFavorite,
+            isInTrash: isInTrash,
+            memoText: memoText,
+            memoTitle: memoTitle,
+            categories: categories,
+            images: []
+        )
+    }
 }

--- a/Projects/Core/SyncImpl/Tests/FirestoreMemoTests.swift
+++ b/Projects/Core/SyncImpl/Tests/FirestoreMemoTests.swift
@@ -94,6 +94,77 @@ final class FirestoreMemoTests: XCTestCase {
         XCTAssertEqual(decoded, original)
     }
 
+    // MARK: - DTO → Domain (역변환)
+
+    func test_toDomain은_주입된_카테고리와_함께_모든_필드를_복원한다() throws {
+        // given
+        let memoID = UUID()
+        let creation = Date(timeIntervalSince1970: 1_000_000)
+        let modification = Date(timeIntervalSince1970: 1_000_500)
+        let deleted = Date(timeIntervalSince1970: 1_000_900)
+        let dto = FirestoreMemo(makeMemo(
+            id: memoID, title: "제목", text: "본문",
+            isFavorite: true, isInTrash: true,
+            creation: creation, modification: modification, deleted: deleted
+        ))
+        let categories: Set<Domain.Category> = [
+            Domain.Category(id: UUID(), name: "업무", creationDate: .now, modificationDate: .now)
+        ]
+
+        // when
+        let memo = try XCTUnwrap(dto.toDomain(categories: categories))
+
+        // then
+        XCTAssertEqual(memo.memoID, memoID)
+        XCTAssertEqual(memo.memoTitle, "제목")
+        XCTAssertEqual(memo.memoText, "본문")
+        XCTAssertTrue(memo.isFavorite)
+        XCTAssertTrue(memo.isInTrash)
+        XCTAssertEqual(memo.creationDate, creation)
+        XCTAssertEqual(memo.modificationDate, modification)
+        XCTAssertEqual(memo.deletedDate, deleted)
+        XCTAssertEqual(memo.categories, categories)
+        XCTAssertTrue(memo.images.isEmpty, "이미지는 별도 동기화이므로 비어 있어야 한다")
+    }
+
+    func test_memoID가_UUID가_아니면_toDomain은_nil을_반환한다() {
+        let dto = FirestoreMemo(
+            memoID: "not-a-uuid",
+            memoTitle: "", memoText: "",
+            isFavorite: false, isInTrash: false,
+            creationDate: .now, modificationDate: .now, deletedDate: nil,
+            categoryIDs: []
+        )
+        XCTAssertNil(dto.toDomain(categories: []))
+    }
+
+    func test_categoryUUIDs는_파싱가능한_ID만_UUID로_돌려준다() {
+        let valid = UUID()
+        let dto = FirestoreMemo(
+            memoID: UUID().uuidString,
+            memoTitle: "", memoText: "",
+            isFavorite: false, isInTrash: false,
+            creationDate: .now, modificationDate: .now, deletedDate: nil,
+            categoryIDs: [valid.uuidString, "broken"]
+        )
+        XCTAssertEqual(dto.categoryUUIDs, [valid])
+    }
+
+    func test_Memo_to_DTO_to_Memo_라운드트립이_원본과_같다() throws {
+        // given: 카테고리를 가진 메모
+        let categories: Set<Domain.Category> = [
+            Domain.Category(id: UUID(), name: "A", creationDate: .now, modificationDate: .now),
+            Domain.Category(id: UUID(), name: "B", creationDate: .now, modificationDate: .now),
+        ]
+        let original = makeMemo(title: "왕복", text: "검증", isFavorite: true, categories: categories)
+
+        // when: Memo → DTO → 같은 카테고리 주입해 복원
+        let restored = try XCTUnwrap(FirestoreMemo(original).toDomain(categories: categories))
+
+        // then: 이미지를 제외한 모든 필드가 원본과 동일
+        XCTAssertEqual(restored, original)
+    }
+
     // MARK: - 헬퍼
 
     private func makeMemo(


### PR DESCRIPTION
## 배경
- 현재 `FirestoreMemo`는 push용 인코딩(`init(_ memo:)`)만 있고, pull(서버 문서를 로컬로 반영)에 필요한 역변환이 없음.
- pull 작업(초기 동기화 + 실시간 listener)의 선행으로, 서버 DTO를 로컬 `Memo`로 되돌리는 변환을 추가.

## 변경사항
- `FirestoreMemo.toDomain(categories:)`
  - 서버 DTO → 로컬 `Memo` 복원
  - 카테고리 본문은 별도 컬렉션이라, 호출자가 resolve한 `Category` 집합을 주입받음
  - 이미지는 메모 sub-collection으로 별도 동기화되므로 빈 집합으로 둠
  - `memoID`가 UUID로 파싱되지 않으면(손상 문서) `nil` 반환
- `FirestoreMemo.categoryUUIDs`
  - `categoryIDs`를 `UUID`로 파싱(파싱 불가는 제외) — 호출자가 로컬 `Category` resolve에 사용
- 테스트 4종
  - 필드 복원 / 잘못된 memoID → nil / categoryUUIDs 파싱 / Memo→DTO→Memo 라운드트립

## 테스트 방법
- `tuist test` 전체 통과 (SyncImplTests 35개 포함)
- 자동 테스트로 검증되는 변경이라 실기기 수동 검증 불필요

## 리뷰 노트
- 역변환을 "카테고리 주입" 방식으로 분리한 이유: 카테고리 본문은 메모 문서에 없고 별도 컬렉션이라, FirestoreMemo 단독으로는 `Category`를 복원할 수 없음. 그래서 `categoryUUIDs`로 resolve 대상만 노출하고, 실제 `Set<Category>`는 호출자(service 레이어)가 로컬에서 resolve해 주입
- 본 PR 단독으로는 런타임 동작 변화 없음 — pull에서 호출할 변환만 추가. 후속: 초기 동기화(첫 로그인 전체 push/pull + 머지) → 실시간 listener