### PR TITLE
feat(domain): CategoryUpdateType에 대상 categoryID 추가

### DIFF
--- a/Projects/Data/Sources/Repositories/CategoryRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/CategoryRepositoryImpl.swift
@@ -93,13 +93,14 @@ public extension CategoryRepositoryImpl {
         guard !allCategoryNames.contains(name) else {
             throw CoreDataError.duplicateCategoryDetected
         }
+        let newID = UUID()
         try await context.perform { [unowned self] in
             let newCategory = CategoryEntity(context: self.context)
-            newCategory.categoryID = UUID()
+            newCategory.categoryID = newID
             newCategory.name = name
             try self.context.save()
         }
-        categoryUpdatedSubject.send(.create)
+        categoryUpdatedSubject.send(.create(categoryIDs: [newID]))
     }
     
     func getAllCategories(inOrderOf orderCriterion: CategoryProperties, isAscending: Bool) async throws -> [Domain.Category] {
@@ -156,7 +157,7 @@ public extension CategoryRepositoryImpl {
             context.delete(categoryEntity)
             try context.save()
         }
-        categoryUpdatedSubject.send(.delete)
+        categoryUpdatedSubject.send(.delete(categoryIDs: [category.id]))
     }
     
     func memoCount(of category: Domain.Category) async throws -> Int {

--- a/Projects/Data/Tests/CategoryRepositoryTests.swift
+++ b/Projects/Data/Tests/CategoryRepositoryTests.swift
@@ -208,8 +208,9 @@ final class CategoryRepositoryTests: XCTestCase {
         // when
         try await sut.create(name: "업무")
 
-        // then
-        XCTAssertEqual(received, [.create])
+        // then: 생성 이벤트에 방금 만든 카테고리의 ID가 실려야 한다
+        let created = try await category(named: "업무")
+        XCTAssertEqual(received, [.create(categoryIDs: [created.id])])
     }
 
     func test_카테고리_이름을_변경하면_퍼블리셔로_업데이트_이벤트가_방출된다() async throws {
@@ -239,7 +240,7 @@ final class CategoryRepositoryTests: XCTestCase {
         try await sut.deleteCategory(work)
 
         // then
-        XCTAssertEqual(received, [.delete])
+        XCTAssertEqual(received, [.delete(categoryIDs: [work.id])])
     }
 
     func test_수정일_갱신시_퍼블리셔로_업데이트_이벤트가_방출된다() async throws {

--- a/Projects/Domain/Sources/Repositories/CategoryUpdateType.swift
+++ b/Projects/Domain/Sources/Repositories/CategoryUpdateType.swift
@@ -19,7 +19,16 @@ public enum CategoryUpdateType: Equatable {
         }
     }
 
-    case create
-    case delete
+    case create(categoryIDs: [UUID])
+    case delete(categoryIDs: [UUID])
     case update(content: UpdateAttribute)
+
+    /// 이벤트가 가리키는 대상 카테고리 ID들. 동기화가 어떤 카테고리를 push/삭제할지 식별하는 데 사용.
+    public var categoryIDs: [UUID] {
+        switch self {
+        case .create(let categoryIDs): return categoryIDs
+        case .delete(let categoryIDs): return categoryIDs
+        case .update(let content): return content.categoryIDs
+        }
+    }
 }

--- a/Projects/Domain/Tests/DomainTests.swift
+++ b/Projects/Domain/Tests/DomainTests.swift
@@ -44,3 +44,16 @@ final class MemoUpdateTypeTests: XCTestCase {
         XCTAssertEqual(MemoUpdateType.update(content: .category(memoIDs: [b])).memoIDs, [b])
     }
 }
+
+final class CategoryUpdateTypeTests: XCTestCase {
+
+    func test_categoryIDs는_각_케이스의_대상_카테고리ID를_반환한다() {
+        let a = UUID()
+        let b = UUID()
+
+        XCTAssertEqual(CategoryUpdateType.create(categoryIDs: [a]).categoryIDs, [a])
+        XCTAssertEqual(CategoryUpdateType.delete(categoryIDs: [a, b]).categoryIDs, [a, b])
+        XCTAssertEqual(CategoryUpdateType.update(content: .name(categoryIDs: [a])).categoryIDs, [a])
+        XCTAssertEqual(CategoryUpdateType.update(content: .modificationDate(categoryIDs: [b])).categoryIDs, [b])
+    }
+}


### PR DESCRIPTION
## 배경
- 카테고리 sync(push/pull)의 선행 작업. 기존 `CategoryUpdateType`은 `.update`만 categoryID를 싣고 `.create`/`.delete`는 연관값이 없어, 동기화가 "어떤 카테고리를 push/삭제할지" 식별하지 못함.
- 메모(`MemoUpdateType`)에 했던 것과 동일한 확장.

## 변경사항
- `CategoryUpdateType` (Domain)
  - `.create` / `.delete`에 `categoryIDs: [UUID]` 연관값 추가
  - 모든 케이스에서 대상 카테고리를 추출하는 top-level `categoryIDs` computed property 추가
- `CategoryRepositoryImpl` 발행 갱신
  - `create`: 새 UUID를 perform 밖으로 빼서 `.create(categoryIDs: [newID])`
  - `deleteCategory`: `.delete(categoryIDs: [category.id])`
- 테스트
  - DomainTests: `categoryIDs` computed property가 각 케이스의 대상 ID를 반환하는지 검증
  - CategoryRepositoryTests: 생성/삭제 이벤트에 대상 카테고리 ID가 실리는지 검증 갱신

## 테스트 방법
- `tuist test` 전체 통과 (35개)
- 자동 테스트로 검증되는 변경이라 실기기 수동 검증 불필요

## 리뷰 노트
- 구독처 영향 없음 — 유일한 categoryUpdatedPublisher 구독자인 홈 화면은 이벤트를 `Void`로 매핑해 받으므로 `.create`/`.delete` 패턴 매칭에 영향 없음. 발행 지점(CategoryRepositoryImpl)과 테스트만 변경됨
- 카테고리 sync 부품의 1단계. 후속: `FirestoreCategory` DTO + Writer + `FirestoreSyncService` 카테고리 push 결합 → 초기 동기화(카테고리→메모)