### PR TITLE
feat(sync): Category Firestore DTO + Writer

### DIFF
--- a/Projects/Core/SyncImpl/Sources/FirestoreCategory.swift
+++ b/Projects/Core/SyncImpl/Sources/FirestoreCategory.swift
@@ -1,0 +1,40 @@
+//
+//  FirestoreCategory.swift
+//  NoteCard
+//
+
+import Domain
+import Foundation
+
+/// Firestore에 저장되는 카테고리 문서의 스키마.
+///
+/// Document path: `users/{uid}/categories/{categoryID}`.
+/// `serverUpdatedAt`은 Firestore에 쓸 때 `FieldValue.serverTimestamp()`로 채우는 보조 timestamp라
+/// 이 DTO에는 포함하지 않는다. 카테고리는 다른 엔티티를 참조하지 않아 메모와 달리 관계 필드가 없다.
+public struct FirestoreCategory: Codable, Equatable, Sendable {
+    public let categoryID: String
+    public let name: String
+    public let creationDate: Date
+    public let modificationDate: Date
+}
+
+public extension FirestoreCategory {
+
+    init(_ category: Domain.Category) {
+        self.categoryID = category.id.uuidString
+        self.name = category.name
+        self.creationDate = category.creationDate
+        self.modificationDate = category.modificationDate
+    }
+
+    /// 서버 DTO를 로컬 `Category`로 되돌린다. `categoryID`가 UUID로 파싱되지 않으면(손상 문서) `nil`.
+    func toDomain() -> Domain.Category? {
+        guard let id = UUID(uuidString: categoryID) else { return nil }
+        return Domain.Category(
+            id: id,
+            name: name,
+            creationDate: creationDate,
+            modificationDate: modificationDate
+        )
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/FirestoreCategoryWriter.swift
+++ b/Projects/Core/SyncImpl/Sources/FirestoreCategoryWriter.swift
@@ -1,0 +1,52 @@
+//
+//  FirestoreCategoryWriter.swift
+//  NoteCard
+//
+
+import Domain
+import FirebaseFirestore
+import Foundation
+
+/// 카테고리 원격 쓰기 표면. `FirestoreSyncService`가 의존하며, 테스트에서 Firestore 실호출을
+/// 대체(mock)하기 위한 내부 seam. 모듈 외부로 노출하지 않는다.
+protocol CategoryRemoteWriting: Sendable {
+    func upsert(_ category: Domain.Category, userID: String) async throws
+    func delete(categoryID: UUID, userID: String) async throws
+}
+
+/// Firestore에 카테고리 문서를 push하는 얇은 wrapper.
+///
+/// Document path: `users/{userID}/categories/{categoryID}`. `setData(merge: true)`라
+/// 서버에만 존재하는 미래 필드는 보존된다. 카테고리는 nil이 될 수 있는 필드가 없어 메모처럼
+/// `FieldValue.delete()`로 정리할 항목은 없다.
+public final class FirestoreCategoryWriter: CategoryRemoteWriting, @unchecked Sendable {
+
+    private let firestore: Firestore
+
+    public init(firestore: Firestore = .firestore()) {
+        self.firestore = firestore
+    }
+
+    public func upsert(_ category: Domain.Category, userID: String) async throws {
+        let payload = try Self.payload(for: category)
+        try await categoryDocument(categoryID: category.id, userID: userID).setData(payload, merge: true)
+    }
+
+    public func delete(categoryID: UUID, userID: String) async throws {
+        try await categoryDocument(categoryID: categoryID, userID: userID).delete()
+    }
+
+    private func categoryDocument(categoryID: UUID, userID: String) -> DocumentReference {
+        firestore
+            .collection("users").document(userID)
+            .collection("categories").document(categoryID.uuidString)
+    }
+
+    /// Firestore에 쓸 dictionary 페이로드. server timestamp(`serverUpdatedAt`)는 SDK sentinel로 넣고
+    /// 실제 시각은 Firestore가 commit 시점에 채운다.
+    static func payload(for category: Domain.Category) throws -> [String: Any] {
+        var dict = try Firestore.Encoder().encode(FirestoreCategory(category))
+        dict["serverUpdatedAt"] = FieldValue.serverTimestamp()
+        return dict
+    }
+}

--- a/Projects/Core/SyncImpl/Tests/FirestoreCategoryTests.swift
+++ b/Projects/Core/SyncImpl/Tests/FirestoreCategoryTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+import Domain
+@testable import SyncImpl
+
+/// Domain `Category` ↔ `FirestoreCategory` 변환과 Codable 라운드트립을 검증한다.
+final class FirestoreCategoryTests: XCTestCase {
+
+    func test_도메인_카테고리의_모든_필드가_DTO에_복사된다() {
+        let id = UUID()
+        let creation = Date(timeIntervalSince1970: 1_000_000)
+        let modification = Date(timeIntervalSince1970: 1_000_500)
+        let category = Domain.Category(id: id, name: "업무", creationDate: creation, modificationDate: modification)
+
+        let dto = FirestoreCategory(category)
+
+        XCTAssertEqual(dto.categoryID, id.uuidString)
+        XCTAssertEqual(dto.name, "업무")
+        XCTAssertEqual(dto.creationDate, creation)
+        XCTAssertEqual(dto.modificationDate, modification)
+    }
+
+    func test_toDomain은_모든_필드를_복원한다() throws {
+        let id = UUID()
+        let creation = Date(timeIntervalSince1970: 1_000_000)
+        let modification = Date(timeIntervalSince1970: 1_000_500)
+        let dto = FirestoreCategory(
+            Domain.Category(id: id, name: "개인", creationDate: creation, modificationDate: modification)
+        )
+
+        let category = try XCTUnwrap(dto.toDomain())
+
+        XCTAssertEqual(category.id, id)
+        XCTAssertEqual(category.name, "개인")
+        XCTAssertEqual(category.creationDate, creation)
+        XCTAssertEqual(category.modificationDate, modification)
+    }
+
+    func test_categoryID가_UUID가_아니면_toDomain은_nil을_반환한다() {
+        let dto = FirestoreCategory(
+            categoryID: "not-a-uuid",
+            name: "",
+            creationDate: .now,
+            modificationDate: .now
+        )
+        XCTAssertNil(dto.toDomain())
+    }
+
+    func test_JSON_라운드트립_후에도_모든_필드가_동일하다() throws {
+        let original = FirestoreCategory(
+            Domain.Category(id: UUID(), name: "왕복", creationDate: .now, modificationDate: .now)
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(FirestoreCategory.self, from: encoded)
+
+        XCTAssertEqual(decoded, original)
+    }
+}

--- a/Projects/Core/SyncImpl/Tests/FirestoreCategoryWriterTests.swift
+++ b/Projects/Core/SyncImpl/Tests/FirestoreCategoryWriterTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+import Domain
+import FirebaseFirestore
+@testable import SyncImpl
+
+/// `FirestoreCategoryWriter.payload(for:)`의 변환 결과를 검증한다.
+/// 실제 네트워크 push는 Firestore 통합 환경이 필요해 단위 테스트로 다루지 않는다.
+final class FirestoreCategoryWriterTests: XCTestCase {
+
+    func test_payload는_카테고리의_모든_필드를_포함한다() throws {
+        let id = UUID()
+        let creation = Date(timeIntervalSince1970: 1_000_000)
+        let modification = Date(timeIntervalSince1970: 1_000_500)
+        let category = Domain.Category(id: id, name: "업무", creationDate: creation, modificationDate: modification)
+
+        let payload = try FirestoreCategoryWriter.payload(for: category)
+
+        XCTAssertEqual(payload["categoryID"] as? String, id.uuidString)
+        XCTAssertEqual(payload["name"] as? String, "업무")
+    }
+
+    func test_payload의_날짜는_Firestore_Timestamp로_인코딩된다() throws {
+        let creation = Date(timeIntervalSince1970: 1_000_000)
+        let modification = Date(timeIntervalSince1970: 1_000_500)
+        let category = Domain.Category(id: UUID(), name: "", creationDate: creation, modificationDate: modification)
+
+        let payload = try FirestoreCategoryWriter.payload(for: category)
+
+        let creationTimestamp = try XCTUnwrap(payload["creationDate"] as? Timestamp)
+        let modificationTimestamp = try XCTUnwrap(payload["modificationDate"] as? Timestamp)
+        XCTAssertEqual(creationTimestamp.dateValue(), creation)
+        XCTAssertEqual(modificationTimestamp.dateValue(), modification)
+    }
+
+    func test_payload는_server_timestamp_sentinel을_포함한다() throws {
+        let category = Domain.Category(id: UUID(), name: "", creationDate: .now, modificationDate: .now)
+
+        let payload = try FirestoreCategoryWriter.payload(for: category)
+
+        let sentinel = try XCTUnwrap(payload["serverUpdatedAt"])
+        XCTAssertTrue(sentinel is FieldValue)
+    }
+}


### PR DESCRIPTION
## 배경
- 카테고리 sync 부품. 초기 동기화에서 메모가 categoryIDs로 카테고리를 참조하므로, 카테고리가 메모보다 먼저 동기화돼야 함.
- 메모(FirestoreMemo / FirestoreMemoWriter)와 동일 패턴.

## 변경사항
- `FirestoreCategory` DTO
  - Document path: `users/{uid}/categories/{categoryID}`
  - `init(_ category:)` encode + `toDomain()` decode. 카테고리는 다른 엔티티 참조가 없어 메모와 달리 관계 필드 없음
  - `categoryID`가 UUID로 파싱 안 되면 `toDomain`은 nil (손상 문서 방어)
- `FirestoreCategoryWriter` + `CategoryRemoteWriting`
  - `upsert`/`delete`를 categories 경로에 수행
  - `payload(for:)`로 dictionary 구성 분리 — `Firestore.Encoder`로 Date→Timestamp 변환, `serverUpdatedAt` sentinel 추가
  - `CategoryRemoteWriting` 내부 protocol (테스트 seam, 모듈 외부 비노출) — 메모 `MemoRemoteWriting`과 동일
- 테스트 7종 (DTO 4 + Writer payload 3)

## 테스트 방법
- `tuist test` 전체 통과 (SyncImplTests 42개 포함)
- 자동 테스트로 검증되는 변경이라 실기기 수동 검증 불필요

## 리뷰 노트
- 카테고리는 nil이 될 수 있는 필드가 없어, 메모의 `deletedDate`처럼 `FieldValue.delete()`로 정리할 항목이 없음 (그만큼 단순)
- 본 PR 단독으로는 런타임 동작 변화 없음 — 호출 주체(FirestoreSyncService 카테고리 결합)가 아직 없음. 후속: 카테고리 push 결합 + composition root → 초기 동기화(카테고리→메모)