### PR TITLE
feat(sync): 카테고리 변경 Firestore push 결합

### DIFF
--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -65,14 +65,16 @@ struct AppEnvironment {
 
         let memoRepository = MemoRepositoryImpl(dataLayer: dataLayer)
         self.memoRepository = memoRepository
-        self.categoryRepository = CategoryRepositoryImpl(dataLayer: dataLayer)
+        let categoryRepository = CategoryRepositoryImpl(dataLayer: dataLayer)
+        self.categoryRepository = categoryRepository
         self.imageRepository = ImageRepositoryImpl(dataLayer: dataLayer, memoRepository: memoRepository)
 
         // FirebaseApp 설정이 있으면 Firestore 기반 동기화, 아니면 No-op fallback.
         // 인스턴스만 보관하고 실제 lifecycle 시작(start())은 AppDelegate에서 명시 호출.
         self.syncService = SyncBootstrap.makeSyncService(
             authService: authService,
-            memoRepository: memoRepository
+            memoRepository: memoRepository,
+            categoryRepository: categoryRepository
         )
     }
 

--- a/Projects/Core/SyncImpl/Sources/FirestoreSyncService.swift
+++ b/Projects/Core/SyncImpl/Sources/FirestoreSyncService.swift
@@ -10,7 +10,7 @@ import SyncInterface
 
 /// Firestore 기반 `SyncService` 구현.
 ///
-/// status 노출과 인증 상태 lifecycle에 더해, 메모 변경 이벤트를 받아 Firestore로 단방향 push한다.
+/// status 노출과 인증 상태 lifecycle에 더해, 메모·카테고리 변경 이벤트를 받아 Firestore로 단방향 push한다.
 /// 인증된 사용자가 있으면 `.upToDate`, 없으면 `.disconnected`로 status를 자동 전이.
 /// (pull(listener)·디바운스·에러 status 전이는 후속 단계에서 결합.)
 public final class FirestoreSyncService: SyncService, @unchecked Sendable {
@@ -21,24 +21,37 @@ public final class FirestoreSyncService: SyncService, @unchecked Sendable {
         case delete(memoIDs: [UUID])
     }
 
+    /// 카테고리 변경 이벤트를 Firestore 작업으로 환산한 결과.
+    enum CategorySyncAction: Equatable {
+        case upsert(categoryIDs: [UUID])
+        case delete(categoryIDs: [UUID])
+    }
+
     private let authService: AuthService
     private let memoRepository: MemoRepository
     private let memoWriter: MemoRemoteWriting
+    private let categoryRepository: CategoryRepository
+    private let categoryWriter: CategoryRemoteWriting
 
     private let statusSubject = CurrentValueSubject<SyncStatus, Never>(.disconnected)
     private let stateLock = NSLock()
     /// `stateLock`으로 보호되는 mutable state. 직접 접근 금지.
     private var _authCancellable: AnyCancellable?
     private var _memoCancellable: AnyCancellable?
+    private var _categoryCancellable: AnyCancellable?
 
     init(
         authService: AuthService,
         memoRepository: MemoRepository,
-        memoWriter: MemoRemoteWriting
+        memoWriter: MemoRemoteWriting,
+        categoryRepository: CategoryRepository,
+        categoryWriter: CategoryRemoteWriting
     ) {
         self.authService = authService
         self.memoRepository = memoRepository
         self.memoWriter = memoWriter
+        self.categoryRepository = categoryRepository
+        self.categoryWriter = categoryWriter
     }
 
     public var currentStatus: SyncStatus { statusSubject.value }
@@ -71,6 +84,16 @@ public final class FirestoreSyncService: SyncService, @unchecked Sendable {
         }
     }
 
+    /// 카테고리 변경 이벤트를 Firestore 작업으로 환산한다.
+    static func syncAction(for event: CategoryUpdateType) -> CategorySyncAction {
+        switch event {
+        case .delete(let categoryIDs):
+            return .delete(categoryIDs: categoryIDs)
+        case .create, .update:
+            return .upsert(categoryIDs: event.categoryIDs)
+        }
+    }
+
     // MARK: - Lock 격리 (async-context에서 NSLock 직접 사용 회피)
 
     /// `stateLock` 구간을 동기 메서드로 격리한다.
@@ -87,6 +110,10 @@ public final class FirestoreSyncService: SyncService, @unchecked Sendable {
             .sink { [weak self] event in
                 self?.handleMemoEvent(event)
             }
+        _categoryCancellable = categoryRepository.categoryUpdatedPublisher
+            .sink { [weak self] event in
+                self?.handleCategoryEvent(event)
+            }
         return true
     }
 
@@ -94,9 +121,10 @@ public final class FirestoreSyncService: SyncService, @unchecked Sendable {
     private func cancelSubscriptions() -> [AnyCancellable] {
         stateLock.lock()
         defer { stateLock.unlock() }
-        let previous = [_authCancellable, _memoCancellable].compactMap { $0 }
+        let previous = [_authCancellable, _memoCancellable, _categoryCancellable].compactMap { $0 }
         _authCancellable = nil
         _memoCancellable = nil
+        _categoryCancellable = nil
         return previous
     }
 
@@ -125,6 +153,33 @@ public final class FirestoreSyncService: SyncService, @unchecked Sendable {
             case .delete(let memoIDs):
                 for memoID in memoIDs {
                     try await memoWriter.delete(memoID: memoID, userID: userID)
+                }
+            }
+            statusSubject.send(.upToDate)
+        } catch {
+            statusSubject.send(.error(FirestoreErrorMapper.syncError(from: error)))
+        }
+    }
+
+    private func handleCategoryEvent(_ event: CategoryUpdateType) {
+        guard let userID = authService.currentUser?.id else { return }
+        Task { [weak self] in
+            await self?.performCategorySync(action: Self.syncAction(for: event), userID: userID)
+        }
+    }
+
+    private func performCategorySync(action: CategorySyncAction, userID: String) async {
+        statusSubject.send(.syncing)
+        do {
+            switch action {
+            case .upsert(let categoryIDs):
+                for categoryID in categoryIDs {
+                    let category = try await categoryRepository.getCategory(id: categoryID)
+                    try await categoryWriter.upsert(category, userID: userID)
+                }
+            case .delete(let categoryIDs):
+                for categoryID in categoryIDs {
+                    try await categoryWriter.delete(categoryID: categoryID, userID: userID)
                 }
             }
             statusSubject.send(.upToDate)

--- a/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
+++ b/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
@@ -31,7 +31,8 @@ public enum SyncBootstrap {
     /// FirebaseApp 설정이 완료돼 있으면 Firestore 기반 `SyncService`를, 아니면 No-op 구현을 반환.
     public static func makeSyncService(
         authService: AuthService,
-        memoRepository: MemoRepository
+        memoRepository: MemoRepository,
+        categoryRepository: CategoryRepository
     ) -> SyncService {
         guard FirebaseApp.app() != nil else {
             return NoOpSyncService()
@@ -39,7 +40,9 @@ public enum SyncBootstrap {
         return FirestoreSyncService(
             authService: authService,
             memoRepository: memoRepository,
-            memoWriter: FirestoreMemoWriter()
+            memoWriter: FirestoreMemoWriter(),
+            categoryRepository: categoryRepository,
+            categoryWriter: FirestoreCategoryWriter()
         )
     }
 

--- a/Projects/Core/SyncImpl/Tests/CategorySyncActionTests.swift
+++ b/Projects/Core/SyncImpl/Tests/CategorySyncActionTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+import Domain
+@testable import SyncImpl
+
+/// `FirestoreSyncService.syncAction(for:)`이 카테고리 변경 이벤트를 올바른 Firestore 작업으로 환산하는지 검증한다.
+final class CategorySyncActionTests: XCTestCase {
+
+    func test_삭제_이벤트는_delete_액션으로_환산된다() {
+        let a = UUID()
+        let b = UUID()
+        XCTAssertEqual(
+            FirestoreSyncService.syncAction(for: .delete(categoryIDs: [a, b])),
+            .delete(categoryIDs: [a, b])
+        )
+    }
+
+    func test_생성_이벤트는_upsert_액션으로_환산된다() {
+        let id = UUID()
+        XCTAssertEqual(
+            FirestoreSyncService.syncAction(for: .create(categoryIDs: [id])),
+            .upsert(categoryIDs: [id])
+        )
+    }
+
+    func test_업데이트_이벤트는_연관_attribute의_categoryID로_upsert된다() {
+        let id = UUID()
+        XCTAssertEqual(
+            FirestoreSyncService.syncAction(for: .update(content: .name(categoryIDs: [id]))),
+            .upsert(categoryIDs: [id])
+        )
+        XCTAssertEqual(
+            FirestoreSyncService.syncAction(for: .update(content: .modificationDate(categoryIDs: [id]))),
+            .upsert(categoryIDs: [id])
+        )
+    }
+}

--- a/Projects/Core/SyncImpl/Tests/FirestoreSyncServiceTests.swift
+++ b/Projects/Core/SyncImpl/Tests/FirestoreSyncServiceTests.swift
@@ -1,6 +1,7 @@
 import Combine
 import XCTest
 import Domain
+import Shared
 import SyncInterface
 @testable import SyncImpl
 
@@ -11,6 +12,8 @@ final class FirestoreSyncServiceTests: XCTestCase {
     private var auth: MockAuthService!
     private var memoRepository: MockMemoRepository!
     private var writer: MockMemoRemoteWriter!
+    private var categoryRepository: MockCategoryRepository!
+    private var categoryWriter: MockCategoryRemoteWriter!
     private var sut: FirestoreSyncService!
 
     override func setUp() {
@@ -18,11 +21,21 @@ final class FirestoreSyncServiceTests: XCTestCase {
         auth = MockAuthService()
         memoRepository = MockMemoRepository()
         writer = MockMemoRemoteWriter()
-        sut = FirestoreSyncService(authService: auth, memoRepository: memoRepository, memoWriter: writer)
+        categoryRepository = MockCategoryRepository()
+        categoryWriter = MockCategoryRemoteWriter()
+        sut = FirestoreSyncService(
+            authService: auth,
+            memoRepository: memoRepository,
+            memoWriter: writer,
+            categoryRepository: categoryRepository,
+            categoryWriter: categoryWriter
+        )
     }
 
     override func tearDown() {
         sut = nil
+        categoryWriter = nil
+        categoryRepository = nil
         writer = nil
         memoRepository = nil
         auth = nil
@@ -221,7 +234,98 @@ final class FirestoreSyncServiceTests: XCTestCase {
         await fulfillment(of: [exp], timeout: 1.0)
     }
 
+    // MARK: - 카테고리 push 결합
+
+    func test_카테고리_생성_이벤트가_오면_해당_카테고리를_upsert한다() async {
+        // given
+        auth.emit(.sample)
+        await sut.start()
+        let id = UUID()
+        categoryRepository.stubCategory = Self.makeCategory(id: id)
+        let exp = expectation(description: "upsert 호출")
+        categoryWriter.onUpsert = { _ in exp.fulfill() }
+
+        // when
+        categoryRepository.emit(.create(categoryIDs: [id]))
+
+        // then
+        await fulfillment(of: [exp], timeout: 1.0)
+        XCTAssertEqual(categoryWriter.upsertedCategoryIDs, [id])
+        XCTAssertEqual(categoryWriter.lastUserID, "test-uid")
+    }
+
+    func test_카테고리_이름변경_이벤트가_오면_해당_카테고리를_upsert한다() async {
+        // given
+        auth.emit(.sample)
+        await sut.start()
+        let id = UUID()
+        categoryRepository.stubCategory = Self.makeCategory(id: id)
+        let exp = expectation(description: "upsert 호출")
+        categoryWriter.onUpsert = { _ in exp.fulfill() }
+
+        // when
+        categoryRepository.emit(.update(content: .name(categoryIDs: [id])))
+
+        // then
+        await fulfillment(of: [exp], timeout: 1.0)
+        XCTAssertEqual(categoryWriter.upsertedCategoryIDs, [id])
+    }
+
+    func test_카테고리_삭제_이벤트가_오면_해당_카테고리를_delete한다() async {
+        // given
+        auth.emit(.sample)
+        await sut.start()
+        let id = UUID()
+        let exp = expectation(description: "delete 호출")
+        categoryWriter.onDelete = { _ in exp.fulfill() }
+
+        // when
+        categoryRepository.emit(.delete(categoryIDs: [id]))
+
+        // then
+        await fulfillment(of: [exp], timeout: 1.0)
+        XCTAssertEqual(categoryWriter.deletedCategoryIDs, [id])
+        XCTAssertTrue(categoryWriter.upsertedCategoryIDs.isEmpty)
+    }
+
+    func test_로그아웃_상태에서는_카테고리를_push하지_않는다() async {
+        // given: 인증되지 않은 상태
+        await sut.start()
+
+        // when: 카테고리 이벤트가 와도
+        categoryRepository.emit(.create(categoryIDs: [UUID()]))
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        // then: userID가 없어 push하지 않는다
+        XCTAssertTrue(categoryWriter.upsertedCategoryIDs.isEmpty)
+        XCTAssertTrue(categoryWriter.deletedCategoryIDs.isEmpty)
+    }
+
+    func test_카테고리_push_실패시_error로_전이된다() async {
+        // given
+        auth.emit(.sample)
+        await sut.start()
+        categoryRepository.stubCategory = Self.makeCategory(id: UUID())
+        categoryWriter.upsertError = NSError(domain: "Test", code: 1)
+
+        let exp = expectation(description: "error")
+        let cancellable = sut.statusPublisher.sink { status in
+            if case .error = status { exp.fulfill() }
+        }
+        defer { cancellable.cancel() }
+
+        // when
+        categoryRepository.emit(.create(categoryIDs: [UUID()]))
+
+        // then
+        await fulfillment(of: [exp], timeout: 1.0)
+    }
+
     // MARK: - 헬퍼
+
+    private static func makeCategory(id: UUID) -> Domain.Category {
+        Domain.Category(id: id, name: "", creationDate: .now, modificationDate: .now)
+    }
 
     private static func makeMemo(id: UUID) -> Memo {
         Memo(
@@ -319,6 +423,58 @@ private final class MockMemoRepository: MemoRepository, @unchecked Sendable {
     func setFavorite(_ memo: Memo, to value: Bool) async throws { fatalError("not used") }
     func setFavorite(_ memos: [Memo], to value: Bool) async throws { fatalError("not used") }
     func updateMemoContent(_ memo: Memo, newTitle: String?, newMemoText: String?) async throws { fatalError("not used") }
+}
+
+private final class MockCategoryRemoteWriter: CategoryRemoteWriting, @unchecked Sendable {
+
+    private(set) var upsertedCategoryIDs: [UUID] = []
+    private(set) var deletedCategoryIDs: [UUID] = []
+    private(set) var lastUserID: String?
+    var onUpsert: ((UUID) -> Void)?
+    var onDelete: ((UUID) -> Void)?
+    var upsertError: Error?
+
+    func upsert(_ category: Domain.Category, userID: String) async throws {
+        upsertedCategoryIDs.append(category.id)
+        lastUserID = userID
+        if let upsertError { throw upsertError }
+        onUpsert?(category.id)
+    }
+
+    func delete(categoryID: UUID, userID: String) async throws {
+        deletedCategoryIDs.append(categoryID)
+        lastUserID = userID
+        onDelete?(categoryID)
+    }
+}
+
+/// `categoryUpdatedPublisher`와 `getCategory(id:)`만 실제로 동작하는 최소 구현.
+/// 나머지 메서드는 본 테스트에서 호출되지 않으므로 미구현.
+private final class MockCategoryRepository: CategoryRepository, @unchecked Sendable {
+
+    private let subject = PassthroughSubject<CategoryUpdateType, Never>()
+    var stubCategory: Domain.Category?
+
+    var categoryUpdatedPublisher: AnyPublisher<CategoryUpdateType, Never> { subject.eraseToAnyPublisher() }
+
+    func emit(_ event: CategoryUpdateType) { subject.send(event) }
+
+    struct StubCategoryNotFound: Error {}
+
+    func getCategory(id: UUID) async throws -> Domain.Category {
+        guard let stubCategory else { throw StubCategoryNotFound() }
+        return stubCategory
+    }
+
+    // 이하 본 테스트에서 미사용
+    func create(name: String) async throws { fatalError("not used") }
+    func getAllCategories(inOrderOf orderCriterion: CategoryProperties, isAscending: Bool) async throws -> [Domain.Category] { fatalError("not used") }
+    func getAllCategories(ofMemo memo: Memo, inOrderOf orderCriterion: CategoryProperties, isAscending: Bool) async throws -> [Domain.Category] { fatalError("not used") }
+    func searchCategory(_ searchText: String, inOrderOf orderCriterion: CategoryProperties, isAscending: Bool) async throws -> [Domain.Category] { fatalError("not used") }
+    func changeCategoryName(_ category: Domain.Category, newName: String) async throws { fatalError("not used") }
+    func deleteCategory(_ category: Domain.Category) async throws { fatalError("not used") }
+    func memoCount(of category: Domain.Category) async throws -> Int { fatalError("not used") }
+    func updateModificationDate(of category: Domain.Category) async throws { fatalError("not used") }
 }
 
 private extension AuthUser {

--- a/Projects/Data/Sources/Repositories/CategoryRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/CategoryRepositoryImpl.swift
@@ -103,6 +103,12 @@ public extension CategoryRepositoryImpl {
         categoryUpdatedSubject.send(.create(categoryIDs: [newID]))
     }
     
+    func getCategory(id: UUID) async throws -> Domain.Category {
+        try await context.perform { [unowned self] in
+            try fetchCategoryEntity(id: id).toDomain()
+        }
+    }
+
     func getAllCategories(inOrderOf orderCriterion: CategoryProperties, isAscending: Bool) async throws -> [Domain.Category] {
         try await context.perform { [unowned self] in
             let request = CategoryEntity.fetchRequest()

--- a/Projects/Domain/Sources/Repositories/CategoryRepository.swift
+++ b/Projects/Domain/Sources/Repositories/CategoryRepository.swift
@@ -14,7 +14,9 @@ public protocol CategoryRepository: Sendable {
     var categoryUpdatedPublisher: AnyPublisher<CategoryUpdateType, Never> { get }
 
     func create(name: String) async throws
-    
+
+    func getCategory(id: UUID) async throws -> Category
+
     func getAllCategories(
         inOrderOf orderCriterion: CategoryProperties,
         isAscending: Bool


### PR DESCRIPTION
## 배경
- 메모 단방향 push에 이어, 카테고리 변경(생성·이름변경·삭제)도 Firestore로 push하도록 결합. 이로써 동기화 대상 두 엔티티(메모·카테고리)가 모두 push 경로를 갖춤.
- 초기 동기화(카테고리→메모 순 전체 업로드)의 선행 부품 — 카테고리 원격 쓰기 표면(`FirestoreCategoryWriter`, DTO)은 직전 PR에서 도입됨.

## 변경사항
- `CategoryRepository`에 `getCategory(id:)` 단건 조회 추가
  - Domain 프로토콜 + `CategoryRepositoryImpl` 구현 (기존 private `fetchCategoryEntity(id:)` 재사용)
  - 카테고리 변경 이벤트의 `categoryID`로 도메인 객체를 resolve하기 위함 (메모 path의 `getMemoIncludingTrash(id:)`에 대응)
- `FirestoreSyncService`에 카테고리 push 결합
  - `CategorySyncAction`(upsert/delete) + `syncAction(for: CategoryUpdateType)` 환산 — create·update → upsert, delete → delete
  - `categoryUpdatedPublisher` 구독 추가 (`stateLock` 보호 구간의 `_categoryCancellable`로 lifecycle 관리)
  - `performCategorySync`: `getCategory(id:)`로 resolve 후 upsert / delete, `.syncing` → `.upToDate` / 실패 시 `.error` status 전이
- composition root 결선
  - `SyncBootstrap.makeSyncService`에 `categoryRepository` 파라미터 + `FirestoreCategoryWriter` 주입
  - `AppEnvironment`에서 `categoryRepository` 전달
- 테스트
  - `FirestoreSyncServiceTests`: 카테고리 push 결합 4종 (생성/이름변경 upsert, 삭제 delete, 로그아웃 시 no-push, 실패 시 error 전이)
  - `CategorySyncActionTests`: 이벤트→액션 매핑 3종

## 테스트 방법
- `tuist generate --no-open`
- `tuist test SyncImpl` — 50종 전부 통과 (신규 카테고리 push 8종 포함)
- `xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` — Data·AppEnvironment 컴파일 확인

## 리뷰 노트
- push는 메모 path와 동일하게 인증된 사용자가 있을 때만 동작 (로그아웃 상태에선 이벤트 무시).
- pull(실시간 listener)·디바운스·초기 전체 동기화는 본 PR 범위 밖 — 후속 단계에서 결합.
- `getCategory(id:)`는 trash 개념이 없는 카테고리라 메모의 `getMemoIncludingTrash`보다 단순 (휴지통 필터 불필요).