### PR TITLE
feat(sync): Firestore 기반 CategoryRepository 도입

### DIFF
--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -65,10 +65,10 @@ struct AppEnvironment {
 
         let memoRepository = MemoRepositoryImpl(dataLayer: dataLayer)
         self.memoRepository = memoRepository
-        // SPIKE: 옵션 B 검증 — 카테고리는 Router로 감싸 인증 상태에 따라 Core Data ↔ Firestore 전환.
-        // UI는 Router를 보고, SyncService에는 underlying Core Data impl을 넘겨 이중쓰기를 피한다.
+        // 카테고리는 인증 상태에 따라 Core Data ↔ Firestore 전환 (Firebase 미설정 환경에선 Core Data만).
+        // UI는 결과 Repository를 보고, SyncService에는 underlying Core Data impl을 넘겨 이중쓰기를 피한다.
         let categoryRepositoryCoreData = CategoryRepositoryImpl(dataLayer: dataLayer)
-        self.categoryRepository = CategoryRepositoryRouter(
+        self.categoryRepository = SyncBootstrap.makeCategoryRepository(
             authService: authService,
             anonymousImpl: categoryRepositoryCoreData
         )

--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -65,8 +65,13 @@ struct AppEnvironment {
 
         let memoRepository = MemoRepositoryImpl(dataLayer: dataLayer)
         self.memoRepository = memoRepository
-        let categoryRepository = CategoryRepositoryImpl(dataLayer: dataLayer)
-        self.categoryRepository = categoryRepository
+        // SPIKE: 옵션 B 검증 — 카테고리는 Router로 감싸 인증 상태에 따라 Core Data ↔ Firestore 전환.
+        // UI는 Router를 보고, SyncService에는 underlying Core Data impl을 넘겨 이중쓰기를 피한다.
+        let categoryRepositoryCoreData = CategoryRepositoryImpl(dataLayer: dataLayer)
+        self.categoryRepository = CategoryRepositoryRouter(
+            authService: authService,
+            anonymousImpl: categoryRepositoryCoreData
+        )
         self.imageRepository = ImageRepositoryImpl(dataLayer: dataLayer, memoRepository: memoRepository)
 
         // FirebaseApp 설정이 있으면 Firestore 기반 동기화, 아니면 No-op fallback.
@@ -74,7 +79,7 @@ struct AppEnvironment {
         self.syncService = SyncBootstrap.makeSyncService(
             authService: authService,
             memoRepository: memoRepository,
-            categoryRepository: categoryRepository
+            categoryRepository: categoryRepositoryCoreData
         )
     }
 

--- a/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
@@ -1,0 +1,246 @@
+//
+//  CategoryRepositoryFirestoreImpl.swift
+//  NoteCard
+//
+//  Spike — 옵션 B 검증용 Firestore 기반 CategoryRepository.
+//  목적: 실시간 listener의 UX·코드 부피·전환 안전성을 직접 느껴보기 위함.
+//  정식 채택 시 위치(모듈)·에러 모델·미구현 메서드를 재설계.
+//
+
+import Combine
+import Domain
+import FirebaseFirestore
+import Foundation
+import Shared
+
+/// 한 사용자(`userID`)의 카테고리를 Firestore에서 읽고 쓰는 Repository.
+///
+/// 동작:
+/// - 생성 시 `users/<uid>/categories` 컬렉션에 실시간 `addSnapshotListener`를 건다.
+/// - 서버/캐시에서 오는 스냅샷을 in-memory `snapshot`에 동기화하고, document 변경을
+///   `categoryUpdatedPublisher`로 emit (UI가 그걸 받아 다시 fetch).
+/// - 쓰기(`create`/`changeCategoryName`/`deleteCategory`)는 SDK가 캐시 즉시 반영 + 서버 큐잉.
+/// - 오프라인에서도 캐시로 동작하고 온라인 복귀 시 자동 sync.
+public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @unchecked Sendable {
+
+    private let firestore: Firestore
+    private let userID: String
+
+    private let categoryUpdatedSubject = PassthroughSubject<CategoryUpdateType, Never>()
+    public var categoryUpdatedPublisher: AnyPublisher<CategoryUpdateType, Never> {
+        categoryUpdatedSubject.eraseToAnyPublisher()
+    }
+
+    /// listener가 채우는 in-memory 스냅샷. 읽기/쓰기 모두 `snapshotLock`으로 보호.
+    private let snapshotLock = NSLock()
+    private var snapshotByID: [UUID: Domain.Category] = [:]
+    private var listenerRegistration: ListenerRegistration?
+
+    public init(userID: String, firestore: Firestore = .firestore()) {
+        self.userID = userID
+        self.firestore = firestore
+        startListening()
+    }
+
+    deinit {
+        listenerRegistration?.remove()
+    }
+
+    private var collection: CollectionReference {
+        firestore.collection("users").document(userID).collection("categories")
+    }
+
+    // MARK: - Listener
+
+    private func startListening() {
+        listenerRegistration = collection.addSnapshotListener { [weak self] snapshot, error in
+            guard let self else { return }
+            if let error {
+                // 스파이크에선 디버그 로그로만. 정식 채택 시 status로 surface.
+                print("[CategoryRepoFirestore] listener error: \(error)")
+                return
+            }
+            guard let snapshot else { return }
+            self.handleSnapshot(snapshot)
+        }
+    }
+
+    private func handleSnapshot(_ snapshot: QuerySnapshot) {
+        var createdIDs: [UUID] = []
+        var modifiedIDs: [UUID] = []
+        var deletedIDs: [UUID] = []
+
+        snapshotLock.lock()
+        for change in snapshot.documentChanges {
+            guard
+                let dto = try? change.document.data(as: FirestoreCategory.self),
+                let domain = dto.toDomain()
+            else { continue }
+
+            switch change.type {
+            case .added:
+                snapshotByID[domain.id] = domain
+                createdIDs.append(domain.id)
+            case .modified:
+                snapshotByID[domain.id] = domain
+                modifiedIDs.append(domain.id)
+            case .removed:
+                snapshotByID.removeValue(forKey: domain.id)
+                deletedIDs.append(domain.id)
+            }
+        }
+        snapshotLock.unlock()
+
+        // 변경 종류별로 한 번씩 emit (UI는 어차피 디바운스 후 재조회하므로 충분).
+        if !createdIDs.isEmpty {
+            categoryUpdatedSubject.send(.create(categoryIDs: createdIDs))
+        }
+        if !modifiedIDs.isEmpty {
+            categoryUpdatedSubject.send(.update(content: .name(categoryIDs: modifiedIDs)))
+        }
+        if !deletedIDs.isEmpty {
+            categoryUpdatedSubject.send(.delete(categoryIDs: deletedIDs))
+        }
+    }
+
+    // MARK: - Read
+
+    public func getCategory(id: UUID) async throws -> Domain.Category {
+        if let cached = cachedCategory(id: id) { return cached }
+        throw FirestoreRepositoryError.notFound
+    }
+
+    public func getAllCategories(
+        inOrderOf orderCriterion: CategoryProperties,
+        isAscending: Bool
+    ) async throws -> [Domain.Category] {
+        Self.sort(allSnapshotCategories(), by: orderCriterion, ascending: isAscending)
+    }
+
+    public func getAllCategories(
+        ofMemo memo: Memo,
+        inOrderOf orderCriterion: CategoryProperties,
+        isAscending: Bool
+    ) async throws -> [Domain.Category] {
+        // Memo가 들고 있는 카테고리 id로 필터. 메모 Repository가 Firestore로 옮겨갈 때 함께 점검.
+        let ids = Set(memo.categories.map(\.id))
+        let filtered = allSnapshotCategories().filter { ids.contains($0.id) }
+        return Self.sort(filtered, by: orderCriterion, ascending: isAscending)
+    }
+
+    public func searchCategory(
+        _ searchText: String,
+        inOrderOf orderCriterion: CategoryProperties,
+        isAscending: Bool
+    ) async throws -> [Domain.Category] {
+        // 클라이언트 필터링. Firestore는 substring 쿼리가 없어서 이게 정석 경로.
+        let filtered = allSnapshotCategories().filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+        return Self.sort(filtered, by: orderCriterion, ascending: isAscending)
+    }
+
+    public func memoCount(of category: Domain.Category) async throws -> Int {
+        // Memo Repository가 Firestore로 가면 그때 count_query/denormalized count 결정.
+        // 스파이크에선 0 반환 (UI는 표시만 0으로 뜸).
+        0
+    }
+
+    // MARK: - Write
+
+    public func create(name: String) async throws {
+        // 같은 이름 중복 방지 (Core Data 구현과 정책 맞춤).
+        let existingNames = snapshotNames()
+        guard !existingNames.contains(name) else {
+            throw FirestoreRepositoryError.duplicateName
+        }
+        let now = Date()
+        let category = Domain.Category(id: UUID(), name: name, creationDate: now, modificationDate: now)
+        var payload = try Firestore.Encoder().encode(FirestoreCategory(category))
+        payload["serverUpdatedAt"] = FieldValue.serverTimestamp()
+        try await collection.document(category.id.uuidString).setData(payload)
+        // listener가 .added로 받아 publisher emit. 호출자는 별도 emit 불필요.
+    }
+
+    public func changeCategoryName(_ category: Domain.Category, newName: String) async throws {
+        let existingNames = snapshotNames()
+        guard !existingNames.contains(newName) else {
+            throw FirestoreRepositoryError.duplicateName
+        }
+        try await collection.document(category.id.uuidString).updateData([
+            "name": newName,
+            "modificationDate": Timestamp(date: Date()),
+            "serverUpdatedAt": FieldValue.serverTimestamp()
+        ])
+    }
+
+    public func deleteCategory(_ category: Domain.Category) async throws {
+        try await collection.document(category.id.uuidString).delete()
+    }
+
+    public func updateModificationDate(of category: Domain.Category) async throws {
+        try await collection.document(category.id.uuidString).updateData([
+            "modificationDate": Timestamp(date: Date()),
+            "serverUpdatedAt": FieldValue.serverTimestamp()
+        ])
+    }
+
+    // MARK: - Migration
+
+    /// 외부 소스(예: 익명 Core Data)에서 받은 카테고리들을 dup-check 없이 Firestore에 import.
+    /// 문서 ID는 `category.id.uuidString` — 같은 ID가 있으면 overwrite(멱등).
+    /// 호출자가 "이번 사용자/기기에서 한 번만 호출" 보장하지 않으면 newer Firestore 데이터가
+    /// stale 로컬 데이터로 덮어쓰여 데이터 손실 위험 있음.
+    func importCategories(_ categories: [Domain.Category]) async throws {
+        for category in categories {
+            var payload = try Firestore.Encoder().encode(FirestoreCategory(category))
+            payload["serverUpdatedAt"] = FieldValue.serverTimestamp()
+            try await collection.document(category.id.uuidString).setData(payload)
+        }
+    }
+
+    // MARK: - Helpers
+
+    // 락 사용 구간을 동기 메서드로 격리한다 (NSLock은 async 컨텍스트에서 직접 사용 불가).
+
+    private func snapshotNames() -> Set<String> {
+        snapshotLock.lock()
+        defer { snapshotLock.unlock() }
+        return Set(snapshotByID.values.map(\.name))
+    }
+
+    private func cachedCategory(id: UUID) -> Domain.Category? {
+        snapshotLock.lock()
+        defer { snapshotLock.unlock() }
+        return snapshotByID[id]
+    }
+
+    private func allSnapshotCategories() -> [Domain.Category] {
+        snapshotLock.lock()
+        defer { snapshotLock.unlock() }
+        return Array(snapshotByID.values)
+    }
+
+    private static func sort(
+        _ categories: [Domain.Category],
+        by criterion: CategoryProperties,
+        ascending: Bool
+    ) -> [Domain.Category] {
+        categories.sorted { lhs, rhs in
+            let result: Bool
+            switch criterion {
+            case .name:
+                result = lhs.name < rhs.name
+            case .creationDate:
+                result = lhs.creationDate < rhs.creationDate
+            case .modificationDate:
+                result = lhs.modificationDate < rhs.modificationDate
+            }
+            return ascending ? result : !result
+        }
+    }
+}
+
+/// 스파이크 전용 에러. 정식 채택 시 도메인 에러 모델과 통합.
+public enum FirestoreRepositoryError: Error {
+    case notFound
+    case duplicateName
+}

--- a/Projects/Core/SyncImpl/Sources/CategoryRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/CategoryRepositoryRouter.swift
@@ -1,0 +1,168 @@
+//
+//  CategoryRepositoryRouter.swift
+//  NoteCard
+//
+//  Spike — 옵션 B 검증용 라우터.
+//  인증 상태에 따라 두 구현체(익명=CoreData / 로그인=Firestore) 사이를 스위칭한다.
+//  소비자는 단일 `CategoryRepository` 참조만 들고 있어도 백엔드 전환이 투명하게 처리됨.
+//
+
+import Combine
+import Domain
+import FirebaseFirestore
+import Foundation
+import Shared
+import SyncInterface
+
+/// 인증 상태에 맞춰 활성 `CategoryRepository`를 갈아끼우는 래퍼.
+///
+/// - 비로그인: `anonymousImpl` (Core Data)에 위임 — 모든 데이터 기기에 머무름.
+/// - 로그인: 해당 uid로 `CategoryRepositoryFirestoreImpl` 생성, 그쪽으로 위임 — 실시간 listener 동작.
+/// - 전환 시 활성 impl의 `categoryUpdatedPublisher`를 내부 subject로 forward해 외부 구독자는 영향 없음.
+///
+/// (스파이크라 익명→Firestore 마이그레이션은 별도 단계에서. 현재는 로그인 후 Firestore가 비어 있으면
+/// 홈 화면도 비어 보임.)
+public final class CategoryRepositoryRouter: CategoryRepository, @unchecked Sendable {
+
+    private let authService: AuthService
+    private let anonymousImpl: CategoryRepository
+    private let firestore: Firestore
+
+    private let lock = NSLock()
+    private var _activeImpl: CategoryRepository
+    private var _firestoreImpl: CategoryRepositoryFirestoreImpl?
+    private var _authCancellable: AnyCancellable?
+    private var _publisherCancellable: AnyCancellable?
+
+    private let updatedSubject = PassthroughSubject<CategoryUpdateType, Never>()
+    public var categoryUpdatedPublisher: AnyPublisher<CategoryUpdateType, Never> {
+        updatedSubject.eraseToAnyPublisher()
+    }
+
+    public init(
+        authService: AuthService,
+        anonymousImpl: CategoryRepository,
+        firestore: Firestore = .firestore()
+    ) {
+        self.authService = authService
+        self.anonymousImpl = anonymousImpl
+        self.firestore = firestore
+        self._activeImpl = anonymousImpl
+        attachForwarding(from: anonymousImpl)
+        // CurrentValueSubject auth publisher는 구독 즉시 현재 값을 동기 전달 → 첫 핸들링은 여기서.
+        _authCancellable = authService.authStatePublisher.sink { [weak self] user in
+            self?.handleAuthChange(user: user)
+        }
+    }
+
+    private func handleAuthChange(user: AuthUser?) {
+        if let userID = user?.id {
+            // 로그인 (또는 다른 uid로 전환) — Firestore impl 생성·교체.
+            let impl = CategoryRepositoryFirestoreImpl(userID: userID, firestore: firestore)
+            lock.lock()
+            _firestoreImpl = impl
+            _activeImpl = impl
+            lock.unlock()
+            attachForwarding(from: impl)
+            // 익명 → Firestore 1회 마이그레이션 (백그라운드)
+            triggerMigrationIfNeeded(to: impl, userID: userID)
+        } else {
+            // 로그아웃 — Firestore impl 해제, 익명으로 복귀.
+            lock.lock()
+            _firestoreImpl = nil
+            _activeImpl = anonymousImpl
+            lock.unlock()
+            attachForwarding(from: anonymousImpl)
+        }
+        // 백엔드가 바뀌었음을 UI에 알려 재조회 유도.
+        // (Core Data impl은 자발적 emit이 없고, Firestore listener도 첫 스냅샷 도착이 비동기라 둘 다 보조)
+        updatedSubject.send(.update(content: .name(categoryIDs: [])))
+    }
+
+    /// 익명 카테고리를 새 Firestore impl로 이관한다. UserDefaults 마커로 기기+사용자별 1회만 수행.
+    /// (재호출 시 stale 로컬이 newer Firestore를 덮어쓰는 데이터 손실 방지)
+    private func triggerMigrationIfNeeded(to firestoreImpl: CategoryRepositoryFirestoreImpl, userID: String) {
+        let markerKey = "sync.anonymousToFirestoreCategoryMigration.\(userID)"
+        guard !UserDefaults.standard.bool(forKey: markerKey) else { return }
+        let source = anonymousImpl
+        Task { [weak firestoreImpl] in
+            guard let firestoreImpl else { return }
+            do {
+                let anonymous = try await source.getAllCategories(inOrderOf: .modificationDate, isAscending: true)
+                if !anonymous.isEmpty {
+                    try await firestoreImpl.importCategories(anonymous)
+                }
+                UserDefaults.standard.set(true, forKey: markerKey)
+            } catch {
+                // 스파이크에선 로그만. 정식 채택 시 status로 surface.
+                print("[CategoryRepositoryRouter] migration error: \(error)")
+            }
+        }
+    }
+
+    /// 활성 impl의 `categoryUpdatedPublisher`를 외부 subject로 republish.
+    private func attachForwarding(from impl: CategoryRepository) {
+        let newCancellable = impl.categoryUpdatedPublisher.sink { [weak self] event in
+            self?.updatedSubject.send(event)
+        }
+        lock.lock()
+        _publisherCancellable?.cancel()
+        _publisherCancellable = newCancellable
+        lock.unlock()
+    }
+
+    private var current: CategoryRepository {
+        lock.lock()
+        defer { lock.unlock() }
+        return _activeImpl
+    }
+
+    // MARK: - CategoryRepository forwarding
+
+    public func create(name: String) async throws {
+        try await current.create(name: name)
+    }
+
+    public func getCategory(id: UUID) async throws -> Domain.Category {
+        try await current.getCategory(id: id)
+    }
+
+    public func getAllCategories(
+        inOrderOf orderCriterion: CategoryProperties,
+        isAscending: Bool
+    ) async throws -> [Domain.Category] {
+        try await current.getAllCategories(inOrderOf: orderCriterion, isAscending: isAscending)
+    }
+
+    public func getAllCategories(
+        ofMemo memo: Memo,
+        inOrderOf orderCriterion: CategoryProperties,
+        isAscending: Bool
+    ) async throws -> [Domain.Category] {
+        try await current.getAllCategories(ofMemo: memo, inOrderOf: orderCriterion, isAscending: isAscending)
+    }
+
+    public func searchCategory(
+        _ searchText: String,
+        inOrderOf orderCriterion: CategoryProperties,
+        isAscending: Bool
+    ) async throws -> [Domain.Category] {
+        try await current.searchCategory(searchText, inOrderOf: orderCriterion, isAscending: isAscending)
+    }
+
+    public func changeCategoryName(_ category: Domain.Category, newName: String) async throws {
+        try await current.changeCategoryName(category, newName: newName)
+    }
+
+    public func deleteCategory(_ category: Domain.Category) async throws {
+        try await current.deleteCategory(category)
+    }
+
+    public func memoCount(of category: Domain.Category) async throws -> Int {
+        try await current.memoCount(of: category)
+    }
+
+    public func updateModificationDate(of category: Domain.Category) async throws {
+        try await current.updateModificationDate(of: category)
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
+++ b/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
@@ -50,4 +50,16 @@ public enum SyncBootstrap {
     public static func makeNoOpSyncService() -> SyncService {
         NoOpSyncService()
     }
+
+    /// FirebaseApp 설정이 완료돼 있으면 인증 상태에 따라 Core Data ↔ Firestore를 스위칭하는 라우터를,
+    /// 아니면 익명 impl을 그대로 반환. (Firebase 미설정 환경에서 `.firestore()` fatalError 회피)
+    public static func makeCategoryRepository(
+        authService: AuthService,
+        anonymousImpl: CategoryRepository
+    ) -> CategoryRepository {
+        guard FirebaseApp.app() != nil else {
+            return anonymousImpl
+        }
+        return CategoryRepositoryRouter(authService: authService, anonymousImpl: anonymousImpl)
+    }
 }


### PR DESCRIPTION
## 배경
- 카테고리 데이터를 Firestore SDK(오프라인 캐시·실시간 listener) 기반으로 직접 다루도록 전환.
- 정책: 익명 사용자 데이터는 로컬(Core Data) 전용, Apple 로그인 후엔 Firestore. 재로그인 시 로컬→서버 재push 없음(SDK 기본 동작에 위임).
- 기존 카테고리 sync(`FirestoreSyncService`의 카테고리 push 경로)를 대체.

## 변경사항
- `CategoryRepositoryFirestoreImpl` 추가
  - `addSnapshotListener`로 실시간 read + 인메모리 스냅샷 캐시(NSLock 보호)
  - CRUD 쓰기 (`create`/`changeCategoryName`/`deleteCategory`/`updateModificationDate`)
  - 정렬·검색은 클라이언트 측 (Firestore 쿼리는 substring 불가)
  - `importCategories`: 마이그레이션 전용 dup-check 없는 직접 setData (멱등)
  - `NSLock` 사용 구간을 동기 helper로 격리 (Swift 6 strict concurrency 대응)
- `CategoryRepositoryRouter` 추가
  - `authStatePublisher` 구독 → 익명=Core Data / 로그인=Firestore 스위칭
  - 활성 impl의 `categoryUpdatedPublisher`를 내부 subject로 republish (소비자는 단일 참조 유지)
  - 백엔드 전환 직후 coarse 이벤트 emit → UI 재조회 유도
  - 로그인 시 익명 카테고리를 Firestore로 1회 마이그레이션 (`UserDefaults` 마커로 기기+사용자별 보장)
- `AppEnvironment` 결선
  - 카테고리 Repository를 Router로 감싸 UI에 노출
  - `SyncService`에는 underlying Core Data impl 전달 (로그인 시 이중쓰기 방지)

## 테스트 방법
- `tuist generate --no-open`
- `xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` — 전체 빌드 성공
- 수동(시뮬레이터):
  - 익명 상태에서 카테고리 생성 → 기존 Core Data 동작 그대로
  - Apple 로그인 → 익명 카테고리가 Firebase Console `users/{uid}/categories`에 자동 import
  - Console에서 카테고리 추가/수정/삭제 → 앱에 실시간 반영 (listener 동작 확인)
  - 앱에서 카테고리 생성/수정/삭제 → Console에 즉시 반영
  - 로그아웃 → 익명 Core Data로 복귀
  - 재로그인 → 마이그레이션 재실행 안 함 (`serverUpdatedAt` 그대로)

## 리뷰 노트
- 본 PR은 카테고리만 다룸. 메모/이미지 Repository는 후속에서 동일 패턴 적용 예정. 머지 시점에 메모는 여전히 Core Data 직접 동작, 메모 sync는 기존 `FirestoreSyncService`가 담당.
- `FirestoreSyncService` 제거는 후속. 메모/이미지까지 Firestore-직접으로 옮긴 뒤 일괄 제거.
- `AnonymousToUserMigrator`·`UserScopedDataLayer` per-user 분기 단순화도 후속. 익명 Core Data 단일 store만 남기는 방향.
- 미충족 메서드: `memoCount(of:)`는 0 반환, `getAllCategories(ofMemo:)`는 클라이언트 필터로 stub. 메모 Repository 결정 시 점검.
- 본 변경 검증 중 발견된 별도 UI 버그: `MemoViewController.textFieldDidEndEditing` (line 642-650)이 모든 에러를 duplicate name으로 표시. 별도 작업으로 처리.