### PR TITLE
feat(sync): Firestore 기반 MemoRepository 도입

### DIFF
--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -63,22 +63,27 @@ struct AppEnvironment {
             onError: { error in assertionFailure("CategoryUUIDBackfiller 실패: \(error)") }
         )
 
-        let memoRepository = MemoRepositoryImpl(dataLayer: dataLayer)
-        self.memoRepository = memoRepository
-        // 카테고리는 인증 상태에 따라 Core Data ↔ Firestore 전환 (Firebase 미설정 환경에선 Core Data만).
-        // UI는 결과 Repository를 보고, SyncService에는 underlying Core Data impl을 넘겨 이중쓰기를 피한다.
+        // 카테고리·메모는 인증 상태에 따라 Core Data ↔ Firestore 전환 (Firebase 미설정 환경에선 Core Data만).
+        // UI는 결과 Repository를 보고, SyncService·ImageRepository에는 underlying Core Data impl을 넘겨 이중쓰기 / 의존 단순화.
+        let memoRepositoryCoreData = MemoRepositoryImpl(dataLayer: dataLayer)
         let categoryRepositoryCoreData = CategoryRepositoryImpl(dataLayer: dataLayer)
-        self.categoryRepository = SyncBootstrap.makeCategoryRepository(
+        let categoryRepository = SyncBootstrap.makeCategoryRepository(
             authService: authService,
             anonymousImpl: categoryRepositoryCoreData
         )
-        self.imageRepository = ImageRepositoryImpl(dataLayer: dataLayer, memoRepository: memoRepository)
+        self.categoryRepository = categoryRepository
+        self.memoRepository = SyncBootstrap.makeMemoRepository(
+            authService: authService,
+            anonymousImpl: memoRepositoryCoreData,
+            categoryResolver: categoryRepository
+        )
+        self.imageRepository = ImageRepositoryImpl(dataLayer: dataLayer, memoRepository: memoRepositoryCoreData)
 
         // FirebaseApp 설정이 있으면 Firestore 기반 동기화, 아니면 No-op fallback.
         // 인스턴스만 보관하고 실제 lifecycle 시작(start())은 AppDelegate에서 명시 호출.
         self.syncService = SyncBootstrap.makeSyncService(
             authService: authService,
-            memoRepository: memoRepository,
+            memoRepository: memoRepositoryCoreData,
             categoryRepository: categoryRepositoryCoreData
         )
     }

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
@@ -1,0 +1,455 @@
+//
+//  MemoRepositoryFirestoreImpl.swift
+//  NoteCard
+//
+
+import Combine
+import Domain
+import FirebaseFirestore
+import Foundation
+import Shared
+
+/// 한 사용자(`userID`)의 메모를 Firestore에서 읽고 쓰는 Repository.
+///
+/// 동작:
+/// - 생성 시 `users/<uid>/memos` 컬렉션에 `addSnapshotListener`를 건다.
+/// - 스냅샷은 **DTO 자체**를 in-memory에 보관(`snapshotDTOByID`)하고, 메서드 read 시점에
+///   `categoryResolver`로 카테고리를 동적으로 해석한다 — 카테고리 이름 변경 등이 자동 반영됨.
+/// - 쓰기는 SDK가 캐시 즉시 반영 + 서버 큐잉.
+///
+/// 미동기 항목(본 단계 외):
+/// - 이미지 바이너리 (`Memo.images`는 Firestore DTO에 포함되지 않음 — 후속 이미지 Repository에서)
+/// - 카테고리 modificationDate 갱신 부수효과 (categoryResolver의 책임으로 위임 가능 / 후속)
+public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Sendable {
+
+    private let firestore: Firestore
+    private let userID: String
+    private let categoryResolver: CategoryRepository
+
+    private let memoUpdatedSubject = PassthroughSubject<MemoUpdateType, Never>()
+    public var memoUpdatedPublisher: AnyPublisher<MemoUpdateType, Never> {
+        memoUpdatedSubject.eraseToAnyPublisher()
+    }
+
+    /// listener가 채우는 in-memory DTO 스냅샷. 카테고리는 read 시점에 해석.
+    private let snapshotLock = NSLock()
+    private var snapshotDTOByID: [UUID: FirestoreMemo] = [:]
+    private var listenerRegistration: ListenerRegistration?
+
+    public init(userID: String, categoryResolver: CategoryRepository, firestore: Firestore = .firestore()) {
+        self.userID = userID
+        self.categoryResolver = categoryResolver
+        self.firestore = firestore
+        startListening()
+    }
+
+    deinit {
+        listenerRegistration?.remove()
+    }
+
+    private var collection: CollectionReference {
+        firestore.collection("users").document(userID).collection("memos")
+    }
+
+    // MARK: - Listener
+
+    private func startListening() {
+        listenerRegistration = collection.addSnapshotListener { [weak self] snapshot, error in
+            guard let self else { return }
+            if let error {
+                print("[MemoRepoFirestore] listener error: \(error)")
+                return
+            }
+            guard let snapshot else { return }
+            self.handleSnapshot(snapshot)
+        }
+    }
+
+    private func handleSnapshot(_ snapshot: QuerySnapshot) {
+        var createdIDs: [UUID] = []
+        var trashedIDs: [UUID] = []
+        var restoredIDs: [UUID] = []
+        var updatedIDs: [UUID] = []
+        var deletedIDs: [UUID] = []
+
+        snapshotLock.lock()
+        for change in snapshot.documentChanges {
+            guard
+                let dto = try? change.document.data(as: FirestoreMemo.self),
+                let id = UUID(uuidString: dto.memoID)
+            else { continue }
+
+            switch change.type {
+            case .added:
+                snapshotDTOByID[id] = dto
+                if dto.isInTrash {
+                    // 휴지통 상태로 처음 등장(주로 listener 첫 스냅샷에서 기존 휴지통 메모 로드)
+                    trashedIDs.append(id)
+                } else {
+                    createdIDs.append(id)
+                }
+            case .modified:
+                let previous = snapshotDTOByID[id]
+                snapshotDTOByID[id] = dto
+                if let previous {
+                    if !previous.isInTrash && dto.isInTrash {
+                        trashedIDs.append(id)
+                    } else if previous.isInTrash && !dto.isInTrash {
+                        restoredIDs.append(id)
+                    } else {
+                        updatedIDs.append(id)
+                    }
+                } else {
+                    updatedIDs.append(id)
+                }
+            case .removed:
+                snapshotDTOByID.removeValue(forKey: id)
+                deletedIDs.append(id)
+            }
+        }
+        snapshotLock.unlock()
+
+        // 변경 종류별로 한 번씩 emit (UI는 디바운스 후 재조회하므로 coarse로 충분).
+        if !createdIDs.isEmpty { memoUpdatedSubject.send(.create(memoIDs: createdIDs)) }
+        if !trashedIDs.isEmpty { memoUpdatedSubject.send(.trash(memoIDs: trashedIDs)) }
+        if !restoredIDs.isEmpty { memoUpdatedSubject.send(.restore(memoIDs: restoredIDs)) }
+        if !updatedIDs.isEmpty {
+            // 내용 변화의 종류(title/text/favorite/category 등)를 documentChanges로 확정하기 어려워
+            // 가장 일반적인 .titleText로 coarse하게 emit. (UI는 IDs를 보지 않고 재조회.)
+            memoUpdatedSubject.send(.update(content: .titleText(memoIDs: updatedIDs)))
+        }
+        if !deletedIDs.isEmpty { memoUpdatedSubject.send(.delete(memoIDs: deletedIDs)) }
+    }
+
+    // MARK: - Lock 격리 (NSLock은 async 컨텍스트에서 직접 사용 불가)
+
+    private func cachedDTO(id: UUID) -> FirestoreMemo? {
+        snapshotLock.lock()
+        defer { snapshotLock.unlock() }
+        return snapshotDTOByID[id]
+    }
+
+    private func allSnapshotDTOs() -> [FirestoreMemo] {
+        snapshotLock.lock()
+        defer { snapshotLock.unlock() }
+        return Array(snapshotDTOByID.values)
+    }
+
+    // MARK: - Read
+
+    public func getMemo(id: UUID) async throws -> Memo {
+        guard let dto = cachedDTO(id: id), !dto.isInTrash else {
+            throw FirestoreRepositoryError.notFound
+        }
+        return try await resolve(dto)
+    }
+
+    public func getMemoIncludingTrash(id: UUID) async throws -> Memo {
+        guard let dto = cachedDTO(id: id) else {
+            throw FirestoreRepositoryError.notFound
+        }
+        return try await resolve(dto)
+    }
+
+    public func getAllMemos() async throws -> [Memo] {
+        let dtos = allSnapshotDTOs().filter { !$0.isInTrash }
+        let memos = try await resolveAll(dtos)
+        return Self.sortByModificationDateDesc(memos)
+    }
+
+    public func getAllMemos(inCategory category: Domain.Category?) async throws -> [Memo] {
+        let dtos = allSnapshotDTOs().filter { dto in
+            guard !dto.isInTrash else { return false }
+            if let category {
+                return dto.categoryIDs.contains(category.id.uuidString)
+            } else {
+                return dto.categoryIDs.isEmpty
+            }
+        }
+        let memos = try await resolveAll(dtos)
+        return Self.sortByModificationDateDesc(memos)
+    }
+
+    public func getAllMemosInTrash() async throws -> [Memo] {
+        let dtos = allSnapshotDTOs().filter { $0.isInTrash }
+        let memos = try await resolveAll(dtos)
+        return Self.sortByModificationDateDesc(memos)
+    }
+
+    public func searchMemo(searchText: String, inCategory category: Domain.Category?) async throws -> [Memo] {
+        guard !searchText.isEmpty else { return [] }
+        // 클라이언트 필터링 (Firestore는 substring 쿼리 불가).
+        let dtos = allSnapshotDTOs().filter { dto in
+            guard !dto.isInTrash else { return false }
+            if let category, !dto.categoryIDs.contains(category.id.uuidString) { return false }
+            let hit = dto.memoTitle.localizedCaseInsensitiveContains(searchText)
+                || dto.memoText.localizedCaseInsensitiveContains(searchText)
+            return hit
+        }
+        let memos = try await resolveAll(dtos)
+        return Self.sortByModificationDateDesc(memos)
+    }
+
+    public func getFavoriteMemos() async throws -> [Memo] {
+        let dtos = allSnapshotDTOs().filter { $0.isFavorite && !$0.isInTrash }
+        let memos = try await resolveAll(dtos)
+        return Self.sortByModificationDateDesc(memos)
+    }
+
+    // MARK: - Create
+
+    public func createNewMemo() async throws -> Memo {
+        let now = Date()
+        let memo = Memo(
+            memoID: UUID(),
+            creationDate: now,
+            modificationDate: now,
+            deletedDate: nil,
+            isFavorite: false,
+            isInTrash: false,
+            memoText: "",
+            memoTitle: "",
+            categories: [],
+            images: []
+        )
+        try await write(memo)
+        return memo
+        // listener .added → publisher emit, 호출자 별도 emit 불필요.
+    }
+
+    // MARK: - Soft delete (trash)
+
+    public func moveToTrash(_ memo: Memo) async throws {
+        try await collection.document(memo.memoID.uuidString).updateData(Self.trashPayload(now: Date()))
+    }
+
+    public func moveToTrash(_ memos: [Memo]) async throws {
+        let batch = firestore.batch()
+        let payload = Self.trashPayload(now: Date())
+        for memo in memos {
+            batch.updateData(payload, forDocument: collection.document(memo.memoID.uuidString))
+        }
+        try await batch.commit()
+    }
+
+    private static func trashPayload(now: Date) -> [String: Any] {
+        [
+            "isInTrash": true,
+            "isFavorite": false,
+            "deletedDate": Timestamp(date: now),
+            "categoryIDs": [String](),
+            "modificationDate": Timestamp(date: now),
+            "serverUpdatedAt": FieldValue.serverTimestamp()
+        ]
+    }
+
+    // MARK: - Hard delete
+
+    public func deleteMemo(_ memo: Memo) async throws {
+        try await collection.document(memo.memoID.uuidString).delete()
+        // NOTE: 로컬 이미지 파일 정리는 본 PR 범위 밖 (이미지 Repository가 Firebase Storage로 옮길 때 함께).
+    }
+
+    public func deleteMemos(_ memos: [Memo]) async throws {
+        let batch = firestore.batch()
+        for memo in memos {
+            batch.deleteDocument(collection.document(memo.memoID.uuidString))
+        }
+        try await batch.commit()
+    }
+
+    // MARK: - Restore
+
+    public func restore(_ memo: Memo) async throws {
+        try await collection.document(memo.memoID.uuidString).updateData(Self.restorePayload(now: Date()))
+    }
+
+    public func restore(_ memos: [Memo]) async throws {
+        let batch = firestore.batch()
+        let payload = Self.restorePayload(now: Date())
+        for memo in memos {
+            batch.updateData(payload, forDocument: collection.document(memo.memoID.uuidString))
+        }
+        try await batch.commit()
+    }
+
+    private static func restorePayload(now: Date) -> [String: Any] {
+        [
+            "isInTrash": false,
+            "deletedDate": FieldValue.delete(),
+            "modificationDate": Timestamp(date: now),
+            "serverUpdatedAt": FieldValue.serverTimestamp()
+        ]
+    }
+
+    // MARK: - Update: categories
+
+    public func replaceCategories(to memo: Memo, newCategories: Set<Domain.Category>) async throws {
+        try await collection.document(memo.memoID.uuidString).updateData([
+            "categoryIDs": newCategories.map(\.id.uuidString).sorted(),
+            "modificationDate": Timestamp(date: Date()),
+            "serverUpdatedAt": FieldValue.serverTimestamp()
+        ])
+        // NOTE: 기존 Core Data 구현은 영향받은 카테고리들의 modificationDate도 갱신. 본 PR에선 생략 (후속).
+    }
+
+    public func replaceCategories(to memos: [Memo], newCategories: Set<Domain.Category>) async throws {
+        let batch = firestore.batch()
+        let ids = newCategories.map(\.id.uuidString).sorted()
+        let now = Date()
+        for memo in memos {
+            batch.updateData([
+                "categoryIDs": ids,
+                "modificationDate": Timestamp(date: now),
+                "serverUpdatedAt": FieldValue.serverTimestamp()
+            ], forDocument: collection.document(memo.memoID.uuidString))
+        }
+        try await batch.commit()
+    }
+
+    public func addCategories(to memo: Memo, newCategories: Set<Domain.Category>) async throws {
+        try await collection.document(memo.memoID.uuidString).updateData([
+            "categoryIDs": FieldValue.arrayUnion(newCategories.map(\.id.uuidString)),
+            "modificationDate": Timestamp(date: Date()),
+            "serverUpdatedAt": FieldValue.serverTimestamp()
+        ])
+    }
+
+    public func addCategories(to memos: [Memo], newCategories: Set<Domain.Category>) async throws {
+        let batch = firestore.batch()
+        let ids = newCategories.map(\.id.uuidString)
+        let now = Date()
+        for memo in memos {
+            batch.updateData([
+                "categoryIDs": FieldValue.arrayUnion(ids),
+                "modificationDate": Timestamp(date: now),
+                "serverUpdatedAt": FieldValue.serverTimestamp()
+            ], forDocument: collection.document(memo.memoID.uuidString))
+        }
+        try await batch.commit()
+    }
+
+    public func removeCategories(to memo: Memo, newCategories: Set<Domain.Category>) async throws {
+        try await collection.document(memo.memoID.uuidString).updateData([
+            "categoryIDs": FieldValue.arrayRemove(newCategories.map(\.id.uuidString)),
+            "modificationDate": Timestamp(date: Date()),
+            "serverUpdatedAt": FieldValue.serverTimestamp()
+        ])
+    }
+
+    public func removeCategories(to memos: [Memo], newCategories: Set<Domain.Category>) async throws {
+        let batch = firestore.batch()
+        let ids = newCategories.map(\.id.uuidString)
+        let now = Date()
+        for memo in memos {
+            batch.updateData([
+                "categoryIDs": FieldValue.arrayRemove(ids),
+                "modificationDate": Timestamp(date: now),
+                "serverUpdatedAt": FieldValue.serverTimestamp()
+            ], forDocument: collection.document(memo.memoID.uuidString))
+        }
+        try await batch.commit()
+    }
+
+    // MARK: - Update: favorite / content
+
+    public func setFavorite(_ memo: Memo, to value: Bool) async throws {
+        try await collection.document(memo.memoID.uuidString).updateData([
+            "isFavorite": value,
+            "serverUpdatedAt": FieldValue.serverTimestamp()
+        ])
+    }
+
+    public func setFavorite(_ memos: [Memo], to value: Bool) async throws {
+        let batch = firestore.batch()
+        for memo in memos {
+            batch.updateData([
+                "isFavorite": value,
+                "serverUpdatedAt": FieldValue.serverTimestamp()
+            ], forDocument: collection.document(memo.memoID.uuidString))
+        }
+        try await batch.commit()
+    }
+
+    public func updateMemoContent(_ memo: Memo, newTitle: String?, newMemoText: String?) async throws {
+        var payload: [String: Any] = [
+            "modificationDate": Timestamp(date: Date()),
+            "serverUpdatedAt": FieldValue.serverTimestamp()
+        ]
+        if let newTitle { payload["memoTitle"] = newTitle }
+        if let newMemoText { payload["memoText"] = newMemoText }
+        try await collection.document(memo.memoID.uuidString).updateData(payload)
+    }
+
+    // MARK: - Migration
+
+    /// 외부 소스(예: 익명 Core Data)에서 받은 메모들을 dup-check 없이 Firestore에 import.
+    /// 문서 ID는 `memo.memoID.uuidString` — 같은 ID가 있으면 overwrite(멱등).
+    /// 카테고리 본문은 별도 컬렉션이라 본 메서드는 `categoryIDs`만 보존하며,
+    /// 이미지 바이너리는 본 단계 미동기(후속 이미지 Repository에서).
+    func importMemos(_ memos: [Memo]) async throws {
+        for memo in memos {
+            try await write(memo)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Memo → FirestoreMemo 페이로드로 직렬화해 `setData`. setData는 doc 존재 여부와 무관하게 작성.
+    private func write(_ memo: Memo) async throws {
+        var payload = try Firestore.Encoder().encode(FirestoreMemo(memo))
+        payload["serverUpdatedAt"] = FieldValue.serverTimestamp()
+        if memo.deletedDate == nil {
+            // FirestoreMemo.deletedDate가 Optional이라 nil이면 인코더가 키를 생략 →
+            // 휴지통에서 복원된 메모도 서버 기존 값이 보존되지 않도록 명시적 제거.
+            payload["deletedDate"] = FieldValue.delete()
+        }
+        try await collection.document(memo.memoID.uuidString).setData(payload)
+    }
+
+    /// 단일 DTO를 Memo로 해석 (categoryResolver로 카테고리 본문 채움).
+    private func resolve(_ dto: FirestoreMemo) async throws -> Memo {
+        let categories = await resolveCategories(for: dto)
+        guard let memo = dto.toDomain(categories: categories) else {
+            throw FirestoreRepositoryError.notFound
+        }
+        return memo
+    }
+
+    /// 여러 DTO를 Memo로 해석. 카테고리는 한 번씩만 lookup하도록 캐시.
+    private func resolveAll(_ dtos: [FirestoreMemo]) async throws -> [Memo] {
+        var categoryCache: [UUID: Domain.Category] = [:]
+        var memos: [Memo] = []
+        memos.reserveCapacity(dtos.count)
+        for dto in dtos {
+            var categories: Set<Domain.Category> = []
+            for uuid in dto.categoryUUIDs {
+                if let cached = categoryCache[uuid] {
+                    categories.insert(cached)
+                } else if let resolved = try? await categoryResolver.getCategory(id: uuid) {
+                    categoryCache[uuid] = resolved
+                    categories.insert(resolved)
+                }
+                // 해석 실패 시 그 카테고리는 누락된 채로 두고 진행 (도메인 모델에 nil 허용 안 함).
+            }
+            if let memo = dto.toDomain(categories: categories) {
+                memos.append(memo)
+            }
+        }
+        return memos
+    }
+
+    private func resolveCategories(for dto: FirestoreMemo) async -> Set<Domain.Category> {
+        var categories: Set<Domain.Category> = []
+        for uuid in dto.categoryUUIDs {
+            if let resolved = try? await categoryResolver.getCategory(id: uuid) {
+                categories.insert(resolved)
+            }
+        }
+        return categories
+    }
+
+    private static func sortByModificationDateDesc(_ memos: [Memo]) -> [Memo] {
+        memos.sorted { $0.modificationDate > $1.modificationDate }
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
@@ -395,16 +395,17 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
 
     // MARK: - Helpers
 
-    /// Memo → FirestoreMemo 페이로드로 직렬화해 `setData`. setData는 doc 존재 여부와 무관하게 작성.
+    /// Memo → FirestoreMemo 페이로드로 직렬화해 `setData(merge: true)`. merge면 doc 미존재 시 upsert,
+    /// 다른 기기가 추가한 필드는 보존하고, `FieldValue.delete()` 같은 sentinel도 그대로 동작.
     private func write(_ memo: Memo) async throws {
         var payload = try Firestore.Encoder().encode(FirestoreMemo(memo))
         payload["serverUpdatedAt"] = FieldValue.serverTimestamp()
         if memo.deletedDate == nil {
             // FirestoreMemo.deletedDate가 Optional이라 nil이면 인코더가 키를 생략 →
-            // 휴지통에서 복원된 메모도 서버 기존 값이 보존되지 않도록 명시적 제거.
+            // merge가 서버 기존 값을 보존하므로, 휴지통에서 복원된 메모는 명시적 제거 sentinel로 비워준다.
             payload["deletedDate"] = FieldValue.delete()
         }
-        try await collection.document(memo.memoID.uuidString).setData(payload)
+        try await collection.document(memo.memoID.uuidString).setData(payload, merge: true)
     }
 
     /// 단일 DTO를 Memo로 해석 (categoryResolver로 카테고리 본문 채움).

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryRouter.swift
@@ -1,0 +1,184 @@
+//
+//  MemoRepositoryRouter.swift
+//  NoteCard
+//
+
+import Combine
+import Domain
+import FirebaseFirestore
+import Foundation
+import Shared
+import SyncInterface
+
+/// 인증 상태에 맞춰 활성 `MemoRepository`를 갈아끼우는 래퍼.
+///
+/// - 비로그인: `anonymousImpl` (Core Data)에 위임.
+/// - 로그인: 해당 uid로 `MemoRepositoryFirestoreImpl` 생성, 카테고리 해석은 `categoryResolver`(보통 카테고리 Router)에 위임.
+/// - 전환 시 활성 impl의 `memoUpdatedPublisher`를 내부 subject로 forward해 외부 구독자에게 투명.
+/// - 로그인 시 익명 메모(휴지통 포함)를 Firestore로 1회 마이그레이션 (`UserDefaults` 마커로 기기+사용자별 보장).
+public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
+
+    private let authService: AuthService
+    private let anonymousImpl: MemoRepository
+    private let categoryResolver: CategoryRepository
+    private let firestore: Firestore
+
+    private let lock = NSLock()
+    private var _activeImpl: MemoRepository
+    private var _firestoreImpl: MemoRepositoryFirestoreImpl?
+    private var _authCancellable: AnyCancellable?
+    private var _publisherCancellable: AnyCancellable?
+
+    private let updatedSubject = PassthroughSubject<MemoUpdateType, Never>()
+    public var memoUpdatedPublisher: AnyPublisher<MemoUpdateType, Never> {
+        updatedSubject.eraseToAnyPublisher()
+    }
+
+    public init(
+        authService: AuthService,
+        anonymousImpl: MemoRepository,
+        categoryResolver: CategoryRepository,
+        firestore: Firestore = .firestore()
+    ) {
+        self.authService = authService
+        self.anonymousImpl = anonymousImpl
+        self.categoryResolver = categoryResolver
+        self.firestore = firestore
+        self._activeImpl = anonymousImpl
+        attachForwarding(from: anonymousImpl)
+        _authCancellable = authService.authStatePublisher.sink { [weak self] user in
+            self?.handleAuthChange(user: user)
+        }
+    }
+
+    private func handleAuthChange(user: AuthUser?) {
+        if let userID = user?.id {
+            let impl = MemoRepositoryFirestoreImpl(
+                userID: userID,
+                categoryResolver: categoryResolver,
+                firestore: firestore
+            )
+            lock.lock()
+            _firestoreImpl = impl
+            _activeImpl = impl
+            lock.unlock()
+            attachForwarding(from: impl)
+            triggerMigrationIfNeeded(to: impl, userID: userID)
+        } else {
+            lock.lock()
+            _firestoreImpl = nil
+            _activeImpl = anonymousImpl
+            lock.unlock()
+            attachForwarding(from: anonymousImpl)
+        }
+        // 백엔드 전환을 UI에 알려 재조회 유도.
+        updatedSubject.send(.update(content: .titleText(memoIDs: [])))
+    }
+
+    /// 익명 메모(휴지통 포함)를 새 Firestore impl로 이관. UserDefaults 마커로 기기+사용자별 1회.
+    private func triggerMigrationIfNeeded(to firestoreImpl: MemoRepositoryFirestoreImpl, userID: String) {
+        let markerKey = "sync.anonymousToFirestoreMemoMigration.\(userID)"
+        guard !UserDefaults.standard.bool(forKey: markerKey) else { return }
+        let source = anonymousImpl
+        Task { [weak firestoreImpl] in
+            guard let firestoreImpl else { return }
+            do {
+                let active = try await source.getAllMemos()
+                let trashed = try await source.getAllMemosInTrash()
+                let all = active + trashed
+                if !all.isEmpty {
+                    try await firestoreImpl.importMemos(all)
+                }
+                UserDefaults.standard.set(true, forKey: markerKey)
+            } catch {
+                print("[MemoRepositoryRouter] migration error: \(error)")
+            }
+        }
+    }
+
+    private func attachForwarding(from impl: MemoRepository) {
+        let newCancellable = impl.memoUpdatedPublisher.sink { [weak self] event in
+            self?.updatedSubject.send(event)
+        }
+        lock.lock()
+        _publisherCancellable?.cancel()
+        _publisherCancellable = newCancellable
+        lock.unlock()
+    }
+
+    private var current: MemoRepository {
+        lock.lock()
+        defer { lock.unlock() }
+        return _activeImpl
+    }
+
+    // MARK: - MemoRepository forwarding
+
+    public func createNewMemo() async throws -> Memo {
+        try await current.createNewMemo()
+    }
+
+    public func getMemo(id: UUID) async throws -> Memo {
+        try await current.getMemo(id: id)
+    }
+
+    public func getMemoIncludingTrash(id: UUID) async throws -> Memo {
+        try await current.getMemoIncludingTrash(id: id)
+    }
+
+    public func getAllMemos() async throws -> [Memo] {
+        try await current.getAllMemos()
+    }
+
+    public func getAllMemos(inCategory category: Domain.Category?) async throws -> [Memo] {
+        try await current.getAllMemos(inCategory: category)
+    }
+
+    public func getAllMemosInTrash() async throws -> [Memo] {
+        try await current.getAllMemosInTrash()
+    }
+
+    public func searchMemo(searchText: String, inCategory category: Domain.Category?) async throws -> [Memo] {
+        try await current.searchMemo(searchText: searchText, inCategory: category)
+    }
+
+    public func getFavoriteMemos() async throws -> [Memo] {
+        try await current.getFavoriteMemos()
+    }
+
+    public func moveToTrash(_ memo: Memo) async throws { try await current.moveToTrash(memo) }
+    public func moveToTrash(_ memos: [Memo]) async throws { try await current.moveToTrash(memos) }
+    public func deleteMemo(_ memo: Memo) async throws { try await current.deleteMemo(memo) }
+    public func deleteMemos(_ memos: [Memo]) async throws { try await current.deleteMemos(memos) }
+    public func restore(_ memo: Memo) async throws { try await current.restore(memo) }
+    public func restore(_ memos: [Memo]) async throws { try await current.restore(memos) }
+
+    public func replaceCategories(to memo: Memo, newCategories: Set<Domain.Category>) async throws {
+        try await current.replaceCategories(to: memo, newCategories: newCategories)
+    }
+    public func replaceCategories(to memos: [Memo], newCategories: Set<Domain.Category>) async throws {
+        try await current.replaceCategories(to: memos, newCategories: newCategories)
+    }
+    public func addCategories(to memo: Memo, newCategories: Set<Domain.Category>) async throws {
+        try await current.addCategories(to: memo, newCategories: newCategories)
+    }
+    public func addCategories(to memos: [Memo], newCategories: Set<Domain.Category>) async throws {
+        try await current.addCategories(to: memos, newCategories: newCategories)
+    }
+    public func removeCategories(to memo: Memo, newCategories: Set<Domain.Category>) async throws {
+        try await current.removeCategories(to: memo, newCategories: newCategories)
+    }
+    public func removeCategories(to memos: [Memo], newCategories: Set<Domain.Category>) async throws {
+        try await current.removeCategories(to: memos, newCategories: newCategories)
+    }
+
+    public func setFavorite(_ memo: Memo, to value: Bool) async throws {
+        try await current.setFavorite(memo, to: value)
+    }
+    public func setFavorite(_ memos: [Memo], to value: Bool) async throws {
+        try await current.setFavorite(memos, to: value)
+    }
+    public func updateMemoContent(_ memo: Memo, newTitle: String?, newMemoText: String?) async throws {
+        try await current.updateMemoContent(memo, newTitle: newTitle, newMemoText: newMemoText)
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
+++ b/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
@@ -62,4 +62,21 @@ public enum SyncBootstrap {
         }
         return CategoryRepositoryRouter(authService: authService, anonymousImpl: anonymousImpl)
     }
+
+    /// 메모용 동일 패턴. `categoryResolver`는 보통 `makeCategoryRepository`의 결과(라우터)를 그대로 전달해
+    /// 인증 상태에 맞춰 카테고리도 따라 전환되게 한다.
+    public static func makeMemoRepository(
+        authService: AuthService,
+        anonymousImpl: MemoRepository,
+        categoryResolver: CategoryRepository
+    ) -> MemoRepository {
+        guard FirebaseApp.app() != nil else {
+            return anonymousImpl
+        }
+        return MemoRepositoryRouter(
+            authService: authService,
+            anonymousImpl: anonymousImpl,
+            categoryResolver: categoryResolver
+        )
+    }
 }


### PR DESCRIPTION
## 배경
- 메모 데이터를 Firestore SDK(오프라인 캐시·실시간 listener) 기반으로 직접 다루도록 전환. 직전 카테고리 PR과 동일 패턴을 메모에 적용.
- 정책: 익명 사용자는 로컬(Core Data) 전용, Apple 로그인 후엔 Firestore. 재로그인 시 로컬→서버 재push 없음(SDK 기본 동작에 위임).
- 기존 메모 sync(`FirestoreSyncService`의 메모 push 경로)를 대체.

## 변경사항
- `MemoRepositoryFirestoreImpl` 추가 (22개 메서드)
  - `addSnapshotListener`로 실시간 read + 인메모리 DTO 스냅샷 (NSLock 보호)
  - read 시점에 `categoryResolver`로 카테고리 본문 동적 해석 → 카테고리 변경 자동 반영
  - documentChanges에서 isInTrash 전이 감지해 `.trash` / `.restore`, 그 외는 coarse `.update`
  - 정렬·검색은 클라이언트 측 (Firestore 쿼리는 substring 불가). 정렬은 `modificationDate` 내림차순 고정
  - `importMemos`: 마이그레이션 전용 dup-check 없는 `setData(merge:true)` (멱등 + sentinel 사용 가능)
  - `NSLock` 사용 구간을 동기 helper로 격리 (Swift 6 strict concurrency 대응)
- `MemoRepositoryRouter` 추가
  - `authStatePublisher` 구독 → 익명=Core Data / 로그인=Firestore 스위칭
  - 활성 impl의 `memoUpdatedPublisher`를 내부 subject로 republish
  - 로그인 시 익명 메모(휴지통 포함) → Firestore 1회 마이그레이션 (`UserDefaults` 마커로 기기+사용자별 보장)
- `SyncBootstrap.makeMemoRepository` 팩토리 추가 (Firebase 미설정 환경에선 익명 impl 그대로 반환)
- `AppEnvironment` 결선
  - 메모 Repository를 Router로 감싸 UI에 노출
  - `ImageRepository`와 `SyncService`에는 underlying Core Data impl 전달 (이중쓰기/의존 단순화)

## 테스트 방법
- `tuist generate --no-open`
- `xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` — 전체 빌드 성공
- 수동(시뮬레이터):
  - 익명 상태에서 메모 생성/수정/카테고리 부여 → 기존 Core Data 동작 그대로
  - Apple 로그인 → 익명 메모(휴지통 포함)가 Firebase Console `users/{uid}/memos`에 자동 import
  - Console에서 메모 추가/수정/삭제 → 앱에 실시간 반영
  - 앱에서 메모 만들기 / 수정 / 즐겨찾기 토글 / 카테고리 추가·제거 / 휴지통 / 영구 삭제 → Console에 즉시 반영
  - 카테고리 이름 변경 → 그 카테고리를 가진 메모 표시도 자동 갱신
  - 검색 (부분 문자열)
  - 로그아웃 → 익명 Core Data로 복귀
  - 재로그인 → 마이그레이션 재실행 안 함

## 리뷰 노트
- 본 PR 머지 시점에 이미지는 여전히 Core Data + 로컬 파일시스템 동작. 후속에서 Firebase Storage 기반으로 전환 예정.
- 미동기 항목(후속 작업): 이미지 바이너리 / 메모 카테고리 변경 시 카테고리 modificationDate 연쇄 갱신 / 메모 hard delete 시 로컬 이미지 파일 정리 / UserDefaults 정렬 설정 연동
- 본 PR 머지 후의 정리 후보: 이미지까지 Firestore-직접으로 옮긴 뒤 `users/{uid}/NoteCard.sqlite` (`AnonymousToUserMigrator`로 복사된 사용자별 Core Data store) 사용처가 모두 사라짐 → `AnonymousToUserMigrator` · `UserScopedDataLayer` per-user 분기 단순화 가능.
- 카테고리 PR과 동일한 Router·팩토리 패턴.