### PR TITLE
feat(sync): Firestore + Firebase Storage 기반 ImageRepository 도입

### DIFF
--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -63,21 +63,29 @@ struct AppEnvironment {
             onError: { error in assertionFailure("CategoryUUIDBackfiller 실패: \(error)") }
         )
 
-        // 카테고리·메모는 인증 상태에 따라 Core Data ↔ Firestore 전환 (Firebase 미설정 환경에선 Core Data만).
-        // UI는 결과 Repository를 보고, SyncService·ImageRepository에는 underlying Core Data impl을 넘겨 이중쓰기 / 의존 단순화.
+        // 카테고리·메모·이미지는 인증 상태에 따라 Core Data ↔ Firestore 전환 (Firebase 미설정 환경에선 Core Data만).
+        // UI는 결과 Repository를 보고, SyncService에는 underlying Core Data impl을 넘겨 이중쓰기를 피한다.
         let memoRepositoryCoreData = MemoRepositoryImpl(dataLayer: dataLayer)
         let categoryRepositoryCoreData = CategoryRepositoryImpl(dataLayer: dataLayer)
+        let imageRepositoryCoreData = ImageRepositoryImpl(dataLayer: dataLayer, memoRepository: memoRepositoryCoreData)
         let categoryRepository = SyncBootstrap.makeCategoryRepository(
             authService: authService,
             anonymousImpl: categoryRepositoryCoreData
         )
         self.categoryRepository = categoryRepository
+        // 이미지 Router는 메모 Router의 의존성이라 먼저 생성.
+        let imageRepository = SyncBootstrap.makeImageRepository(
+            authService: authService,
+            anonymousImpl: imageRepositoryCoreData,
+            anonymousMemoRepository: memoRepositoryCoreData
+        )
+        self.imageRepository = imageRepository
         self.memoRepository = SyncBootstrap.makeMemoRepository(
             authService: authService,
             anonymousImpl: memoRepositoryCoreData,
-            categoryResolver: categoryRepository
+            categoryResolver: categoryRepository,
+            imageResolver: imageRepository
         )
-        self.imageRepository = ImageRepositoryImpl(dataLayer: dataLayer, memoRepository: memoRepositoryCoreData)
 
         // FirebaseApp 설정이 있으면 Firestore 기반 동기화, 아니면 No-op fallback.
         // 인스턴스만 보관하고 실제 lifecycle 시작(start())은 AppDelegate에서 명시 호출.

--- a/NoteCard/Presentation/MemoDetailView/MemoDetailViewController.swift
+++ b/NoteCard/Presentation/MemoDetailView/MemoDetailViewController.swift
@@ -49,6 +49,57 @@ class MemoDetailViewController: UIViewController {
     private let cancelBarButtonItem = UIBarButtonItem()
     private let completeBarButtonItem = UIBarButtonItem()
     private let imageBarButtonItem = UIBarButtonItem()
+
+    private var isSaving = false
+    private lazy var savingIndicator: UIActivityIndicatorView = {
+        let view = UIActivityIndicatorView(style: .medium)
+        view.hidesWhenStopped = true
+        return view
+    }()
+    private let savingProgressLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .white
+        label.font = .systemFont(ofSize: 15, weight: .medium)
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    private var savingTotalAdds = 0
+    private var savingTotalDeletes = 0
+    private var savingCompletedAdds = 0
+    private var savingCompletedDeletes = 0
+    private lazy var savingOverlayView: UIView = {
+        let overlay = UIView()
+        overlay.backgroundColor = UIColor.black.withAlphaComponent(0.3)
+        overlay.translatesAutoresizingMaskIntoConstraints = false
+        let indicator = UIActivityIndicatorView(style: .large)
+        indicator.color = .white
+        indicator.startAnimating()
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        overlay.addSubview(indicator)
+        overlay.addSubview(savingProgressLabel)
+        NSLayoutConstraint.activate([
+            indicator.centerXAnchor.constraint(equalTo: overlay.centerXAnchor),
+            indicator.centerYAnchor.constraint(equalTo: overlay.centerYAnchor, constant: -16),
+            savingProgressLabel.topAnchor.constraint(equalTo: indicator.bottomAnchor, constant: 12),
+            savingProgressLabel.centerXAnchor.constraint(equalTo: overlay.centerXAnchor),
+            savingProgressLabel.leadingAnchor.constraint(greaterThanOrEqualTo: overlay.leadingAnchor, constant: 24),
+            savingProgressLabel.trailingAnchor.constraint(lessThanOrEqualTo: overlay.trailingAnchor, constant: -24)
+        ])
+        return overlay
+    }()
+
+    private func refreshSavingProgressLabel() {
+        var lines: [String] = []
+        if savingTotalAdds > 0 {
+            lines.append(String(format: L10n.MemoDetail.uploadingImagesFormat, savingCompletedAdds, savingTotalAdds))
+        }
+        if savingTotalDeletes > 0 {
+            lines.append(String(format: L10n.MemoDetail.deletingImagesFormat, savingCompletedDeletes, savingTotalDeletes))
+        }
+        savingProgressLabel.text = lines.joined(separator: "\n")
+    }
     
     init(type: MemoDetailType, environment: AppEnvironment) {
         self.detailType = type
@@ -135,6 +186,21 @@ private extension MemoDetailViewController {
         cancelBarButtonItem.primaryAction = cancelAction
         
         let completeAction = UIAction(title: L10n.Common.done) { _ in
+            guard !self.isSaving else { return }
+            self.isSaving = true
+            self.cancelBarButtonItem.isEnabled = false
+            self.completeBarButtonItem.isEnabled = false
+            self.imageBarButtonItem.isEnabled = false
+            self.savingIndicator.startAnimating()
+            self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.savingIndicator)
+            self.navigationController?.interactivePopGestureRecognizer?.isEnabled = false
+            self.view.addSubview(self.savingOverlayView)
+            NSLayoutConstraint.activate([
+                self.savingOverlayView.topAnchor.constraint(equalTo: self.view.topAnchor),
+                self.savingOverlayView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+                self.savingOverlayView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+                self.savingOverlayView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
+            ])
             Task {
                 do {
                     try await self.updateMemoContent()
@@ -322,22 +388,26 @@ private extension MemoDetailViewController {
             throw CoreDataError.objectNotFound
         }
         let imageRepository = environment.imageRepository
+        let totalAdds = editableImageModels.reduce(into: 0) { count, item in
+            if case .pendingAddition = item { count += 1 }
+        }
+        let totalDeletes = editableImageModels.reduce(into: 0) { count, item in
+            if case .pendingDeletion = item { count += 1 }
+        }
+        await MainActor.run {
+            self.savingTotalAdds = totalAdds
+            self.savingTotalDeletes = totalDeletes
+            self.savingCompletedAdds = 0
+            self.savingCompletedDeletes = 0
+            self.refreshSavingProgressLabel()
+        }
         try await withThrowingTaskGroup(of: Void.self) { group in
             for (index, item) in editableImageModels.enumerated() {
                 group.addTask {
                     switch item {
                     case .existing(model: let model):
-                        /**
-                         `model`은 `ImageUIModel` 타입
-                         `model`을 바탕으로 `ImageEntity`를 불러온 후 이 레코드의 `index`를 `item.offset`으로 업데이트
-                         */
                         try await imageRepository.updateImageIndex(model.info, newIndex: index)
                     case .pendingAddition(model: let model):
-                        /**
-                         `model`은 `ImageUITemporaryModel` 타입
-                         `model`을 바탕으로 새 이미지 파일과 `ImageEntity`를 생성한 후에 각각 `FileManager`, `CoreData`에 저장.
-                         저장 시 index 정보는 `item.offset`
-                         */
                         let _ = try await imageRepository.createImage(
                             from: model.pickerResult,
                             for: memo,
@@ -346,16 +416,20 @@ private extension MemoDetailViewController {
                             orderIndex: index,
                             isTemporary: false
                         )
+                        await MainActor.run {
+                            self.savingCompletedAdds += 1
+                            self.refreshSavingProgressLabel()
+                        }
                     case .pendingDeletion(model: let model):
-                        /**
-                         `model`은 `ImageUIModel` 타입
-                         model을 바탕으로 `ImageEntity`를 불러온 후 이 이 레코드의 데이터 및 이미지 파일 삭제
-                         */
                         try await imageRepository.deleteImage(model.info)
+                        await MainActor.run {
+                            self.savingCompletedDeletes += 1
+                            self.refreshSavingProgressLabel()
+                        }
                     }
                 }
-                try await group.waitForAll()
             }
+            try await group.waitForAll()
         }
     }
     

--- a/Projects/Core/Shared/Resources/Localizable.xcstrings
+++ b/Projects/Core/Shared/Resources/Localizable.xcstrings
@@ -783,6 +783,23 @@
         }
       }
     },
+    "memoDetail.deletingImagesFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deleting %1$d of %2$d images"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이미지 %1$d / %2$d 삭제 중"
+          }
+        }
+      }
+    },
     "memoDetail.memoIsEmpty": {
       "extractionState": "manual",
       "localizations": {
@@ -796,6 +813,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "메모 내용이 없습니다."
+          }
+        }
+      }
+    },
+    "memoDetail.uploadingImagesFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uploading %1$d of %2$d images"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이미지 %1$d / %2$d 업로드 중"
           }
         }
       }

--- a/Projects/Core/Shared/Sources/Localization/L10n.swift
+++ b/Projects/Core/Shared/Sources/Localization/L10n.swift
@@ -92,6 +92,8 @@ public enum L10n {
         public static let addMemo = "memoDetail.addMemo".localized()
         public static let imageLimitExceeded = "memoDetail.imageLimitExceeded".localized()
         public static let imageLimitMessage = "memoDetail.imageLimitMessage".localized()
+        public static let uploadingImagesFormat = "memoDetail.uploadingImagesFormat".localized()
+        public static let deletingImagesFormat = "memoDetail.deletingImagesFormat".localized()
     }
 
     public enum Settings {

--- a/Projects/Core/SyncImpl/Project.swift
+++ b/Projects/Core/SyncImpl/Project.swift
@@ -9,8 +9,10 @@ let project = Project.module(
     dependencies: [
         .module(.syncInterface),
         .module(.domain),
+        .module(.data),
         .external(name: "FirebaseAuth"),
         .external(name: "FirebaseFirestore"),
+        .external(name: "FirebaseStorage"),
     ],
     hasTests: true
 )

--- a/Projects/Core/SyncImpl/Sources/FirestoreMemoImage.swift
+++ b/Projects/Core/SyncImpl/Sources/FirestoreMemoImage.swift
@@ -1,0 +1,56 @@
+//
+//  FirestoreMemoImage.swift
+//  NoteCard
+//
+
+import Domain
+import Foundation
+
+/// Firestore에 저장되는 이미지 메타데이터 문서의 스키마.
+///
+/// Document path: `users/{uid}/memos/{memoID}/images/{imageID}` (메모의 sub-collection).
+/// 바이너리(원본·썸네일)는 Firebase Storage에서 별도 관리:
+/// - 원본: `users/{uid}/memos/{memoID}/{imageID}.<fileExtension>`
+/// - 썸네일: `users/{uid}/memos/{memoID}/{thumbnailID}.jpeg`
+///
+/// 도메인 `MemoImageInfo`의 임시 편집 상태 필드(`temporaryOrderIndex`·`isTemporaryAppended`·`isTemporaryDeleted`)는
+/// UI 메모리에서만 사용되고 저장 시점엔 항상 settled 값(각각 `orderIndex`·`false`·`false`)으로 정착되므로
+/// 본 DTO에서 제외. `toDomain()` 복원 시 그 settled 기본값으로 채워 동작은 동일.
+public struct FirestoreMemoImage: Codable, Equatable, Sendable {
+    public let imageID: String
+    public let thumbnailID: String
+    public let memoID: String
+    public let orderIndex: Int
+    public let fileExtension: String
+}
+
+public extension FirestoreMemoImage {
+
+    init(_ info: MemoImageInfo) {
+        self.imageID = info.id.uuidString
+        self.thumbnailID = info.thumbnailID.uuidString
+        self.memoID = info.memoID.uuidString
+        self.orderIndex = info.orderIndex
+        self.fileExtension = info.fileExtension
+    }
+
+    /// 서버 DTO를 로컬 `MemoImageInfo`로 되돌린다. UUID 파싱 실패 시 `nil`.
+    /// 임시 편집 상태 필드는 settled 기본값으로 채움.
+    func toDomain() -> MemoImageInfo? {
+        guard
+            let id = UUID(uuidString: imageID),
+            let thumbnailUUID = UUID(uuidString: thumbnailID),
+            let memoUUID = UUID(uuidString: memoID)
+        else { return nil }
+        return MemoImageInfo(
+            id: id,
+            thumbnailID: thumbnailUUID,
+            temporaryOrderIndex: orderIndex,
+            orderIndex: orderIndex,
+            memoID: memoUUID,
+            isTemporaryDeleted: false,
+            isTemporaryAppended: false,
+            fileExtension: fileExtension
+        )
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
@@ -1,0 +1,227 @@
+//
+//  ImageRepositoryFirestoreImpl.swift
+//  NoteCard
+//
+
+import Combine
+import Data
+import Domain
+import FirebaseFirestore
+import FirebaseStorage
+import Foundation
+import PhotosUI
+import Shared
+import UIKit
+import UniformTypeIdentifiers
+
+/// 한 사용자(`userID`)의 이미지를 Firestore(메타) + Firebase Storage(바이너리)에서 관리하는 Repository.
+///
+/// 동작:
+/// - 메타데이터: Firestore `users/<uid>/memos/<memoID>/images/<imageID>` sub-collection.
+///   본 PR에선 listener 미사용 — `getAllImageInfo(for:)`가 `getDocuments()`로 매번 fetch
+///   (Firestore SDK가 캐시 자동 관리, 오프라인에서도 동작). 실시간 cross-device 동기화는 후속.
+/// - 바이너리: Firebase Storage `users/<uid>/memos/<memoID>/<id>.<ext>`. 다운로드 시 로컬 파일시스템(`ImageFileHandler`)에
+///   캐시해 다음 호출은 디스크에서 즉시 반환. 캐시 위치는 익명 모드와 동일 경로.
+/// - `imageUpdatedPublisher`는 우리가 직접 호출한 쓰기에 대해서만 emit (listener 없음).
+public final class ImageRepositoryFirestoreImpl: ImageRepository, @unchecked Sendable {
+
+    private let firestore: Firestore
+    private let storage: Storage
+    private let userID: String
+
+    private let imageUpdatedSubject = PassthroughSubject<ImageUpdateType, Never>()
+    public var imageUpdatedPublisher: AnyPublisher<ImageUpdateType, Never> {
+        imageUpdatedSubject.eraseToAnyPublisher()
+    }
+
+    public init(userID: String, firestore: Firestore = .firestore(), storage: Storage = .storage()) {
+        self.userID = userID
+        self.firestore = firestore
+        self.storage = storage
+    }
+
+    // MARK: - Path helpers
+
+    private func imageCollection(for memoID: UUID) -> CollectionReference {
+        firestore
+            .collection("users").document(userID)
+            .collection("memos").document(memoID.uuidString)
+            .collection("images")
+    }
+
+    private func originalStorageRef(memoID: UUID, imageID: UUID, fileExtension: String) -> StorageReference {
+        storage.reference(withPath: "users/\(userID)/memos/\(memoID.uuidString)/\(imageID.uuidString).\(fileExtension)")
+    }
+
+    private func thumbnailStorageRef(memoID: UUID, thumbnailID: UUID) -> StorageReference {
+        storage.reference(withPath: "users/\(userID)/memos/\(memoID.uuidString)/\(thumbnailID.uuidString).jpeg")
+    }
+
+    // MARK: - Create
+
+    public func createImage(
+        from pickerResult: PHPickerResult,
+        for memo: Memo,
+        originalImageID: UUID? = nil,
+        thumbnailID: UUID? = nil,
+        orderIndex: Int,
+        isTemporary: Bool
+    ) async throws -> MemoImageInfo {
+        let (originalData, originalType) = try await ImageFileHandler.prepareImageData(from: pickerResult.itemProvider)
+        let thumbnailData = try ImageFileHandler.createThumbnailData(from: originalData)
+
+        let imageID = originalImageID ?? UUID()
+        let thumbID = thumbnailID ?? UUID()
+        guard let ext = originalType.preferredFilenameExtension else {
+            throw ImageFileError.imageFileExtensionError
+        }
+
+        // 1) 로컬 파일시스템에 저장 (캐시 + 즉시 표시용)
+        let memoDirectory = try ImageFileHandler.getDirectory(for: memo.memoID)
+        try ImageFileHandler.save(data: originalData, to: memoDirectory, with: imageID, fileExtension: ext)
+        try ImageFileHandler.save(data: thumbnailData, to: memoDirectory, with: thumbID, fileExtension: "jpeg")
+
+        let info = MemoImageInfo(
+            id: imageID,
+            thumbnailID: thumbID,
+            temporaryOrderIndex: orderIndex,
+            orderIndex: orderIndex,
+            memoID: memo.memoID,
+            isTemporaryDeleted: false,
+            isTemporaryAppended: isTemporary,
+            fileExtension: ext
+        )
+
+        // 2) Firebase Storage에 바이너리 업로드 (원본+썸네일 병렬)
+        async let originalUpload: StorageMetadata = originalStorageRef(
+            memoID: memo.memoID, imageID: imageID, fileExtension: ext
+        ).putDataAsync(originalData)
+        async let thumbnailUpload: StorageMetadata = thumbnailStorageRef(
+            memoID: memo.memoID, thumbnailID: thumbID
+        ).putDataAsync(thumbnailData)
+        _ = try await (originalUpload, thumbnailUpload)
+
+        // 3) Firestore에 메타데이터 doc 작성
+        var payload = try Firestore.Encoder().encode(FirestoreMemoImage(info))
+        payload["serverUpdatedAt"] = FieldValue.serverTimestamp()
+        try await imageCollection(for: memo.memoID).document(imageID.uuidString).setData(payload, merge: true)
+
+        imageUpdatedSubject.send(.create(memoID: memo.memoID))
+        return info
+    }
+
+    // MARK: - Read
+
+    public func getImage(from imageInfo: MemoImageInfo) async throws -> UIImage {
+        try await loadImage(memoID: imageInfo.memoID,
+                            id: imageInfo.id,
+                            fileExtension: imageInfo.fileExtension,
+                            thumbnail: false)
+    }
+
+    public func getThumbnailImage(from imageInfo: MemoImageInfo) async throws -> UIImage {
+        try await loadImage(memoID: imageInfo.memoID,
+                            id: imageInfo.thumbnailID,
+                            fileExtension: "jpeg",
+                            thumbnail: true)
+    }
+
+    /// 로컬 캐시 우선, 없으면 Storage에서 받아와 로컬에 캐시한 뒤 반환.
+    private func loadImage(memoID: UUID, id: UUID, fileExtension: String, thumbnail: Bool) async throws -> UIImage {
+        let memoDirectory = try ImageFileHandler.getDirectory(for: memoID)
+        let localURL = memoDirectory
+            .appendingPathComponent(id.uuidString)
+            .appendingPathExtension(fileExtension)
+
+        if FileManager.default.fileExists(atPath: localURL.path) {
+            return try ImageFileHandler.loadUIImage(from: localURL)
+        }
+
+        // Storage에서 다운로드 → 로컬 저장 → load
+        let ref = thumbnail
+            ? thumbnailStorageRef(memoID: memoID, thumbnailID: id)
+            : originalStorageRef(memoID: memoID, imageID: id, fileExtension: fileExtension)
+        let data = try await ref.data(maxSize: 50 * 1024 * 1024)
+        try ImageFileHandler.save(data: data, to: memoDirectory, with: id, fileExtension: fileExtension)
+        return try ImageFileHandler.loadUIImage(from: localURL)
+    }
+
+    public func getAllImageInfo(for memo: Memo) async throws -> [MemoImageInfo] {
+        let snapshot = try await imageCollection(for: memo.memoID)
+            .order(by: "orderIndex")
+            .getDocuments()
+        return snapshot.documents.compactMap { doc in
+            try? doc.data(as: FirestoreMemoImage.self)
+        }.compactMap { $0.toDomain() }
+    }
+
+    // MARK: - Update
+
+    public func updateImageIndex(_ image: MemoImageInfo, newIndex: Int) async throws {
+        try await imageCollection(for: image.memoID)
+            .document(image.id.uuidString)
+            .updateData([
+                "orderIndex": newIndex,
+                "serverUpdatedAt": FieldValue.serverTimestamp()
+            ])
+        imageUpdatedSubject.send(.update(memoID: image.memoID))
+    }
+
+    // MARK: - Delete
+
+    public func deleteImage(_ imageInfo: MemoImageInfo) async throws {
+        // 순서: Storage → Firestore → 로컬. 일부 실패해도 다음 단계 시도 (try? 사용 안 함 — 호출자에 에러 전달).
+        // Storage 객체가 이미 없으면 .delete()가 throw하지만 spike에선 호출자가 catch해 처리하면 충분.
+        try? await originalStorageRef(memoID: imageInfo.memoID,
+                                      imageID: imageInfo.id,
+                                      fileExtension: imageInfo.fileExtension).delete()
+        try? await thumbnailStorageRef(memoID: imageInfo.memoID, thumbnailID: imageInfo.thumbnailID).delete()
+
+        try await imageCollection(for: imageInfo.memoID)
+            .document(imageInfo.id.uuidString)
+            .delete()
+
+        // 로컬 캐시 정리 (실패해도 무시)
+        let originalURL = try? ImageFileHandler.getFileURL(for: imageInfo, thumbnail: false)
+        let thumbnailURL = try? ImageFileHandler.getFileURL(for: imageInfo, thumbnail: true)
+        if let originalURL { try? ImageFileHandler.delete(at: originalURL) }
+        if let thumbnailURL { try? ImageFileHandler.delete(at: thumbnailURL) }
+
+        imageUpdatedSubject.send(.delete(memoID: imageInfo.memoID))
+    }
+
+    // MARK: - Migration
+
+    /// 외부 소스(익명 Core Data)에서 받은 이미지들을 Firestore + Storage로 import.
+    /// 로컬 파일이 있어야 업로드 가능 — 누락된 이미지는 스킵하고 계속.
+    /// 멱등: 같은 ID에 대해선 setData(merge:true)로 메타데이터 덮어쓰기, Storage는 동일 경로 putData로 덮어쓰기.
+    func importImages(_ images: [MemoImageInfo]) async throws {
+        for info in images {
+            do {
+                try await migrateImage(info)
+            } catch {
+                // 한 장 실패해도 다음 진행 — 누락 이미지 등 흔한 케이스. 로그만 남김.
+                print("[ImageRepoFirestore] import skipped for \(info.id): \(error)")
+            }
+        }
+    }
+
+    private func migrateImage(_ info: MemoImageInfo) async throws {
+        let originalURL = try ImageFileHandler.getFileURL(for: info, thumbnail: false)
+        let thumbnailURL = try ImageFileHandler.getFileURL(for: info, thumbnail: true)
+        let originalData = try Data(contentsOf: originalURL)
+        let thumbnailData = try Data(contentsOf: thumbnailURL)
+
+        async let originalUpload: StorageMetadata = originalStorageRef(
+            memoID: info.memoID, imageID: info.id, fileExtension: info.fileExtension
+        ).putDataAsync(originalData)
+        async let thumbnailUpload: StorageMetadata = thumbnailStorageRef(
+            memoID: info.memoID, thumbnailID: info.thumbnailID
+        ).putDataAsync(thumbnailData)
+        _ = try await (originalUpload, thumbnailUpload)
+
+        var payload = try Firestore.Encoder().encode(FirestoreMemoImage(info))
+        payload["serverUpdatedAt"] = FieldValue.serverTimestamp()
+        try await imageCollection(for: info.memoID).document(info.id.uuidString).setData(payload, merge: true)
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
@@ -1,0 +1,161 @@
+//
+//  ImageRepositoryRouter.swift
+//  NoteCard
+//
+
+import Combine
+import Domain
+import FirebaseFirestore
+import FirebaseStorage
+import Foundation
+import PhotosUI
+import Shared
+import SyncInterface
+import UIKit
+
+/// 인증 상태에 맞춰 활성 `ImageRepository`를 갈아끼우는 래퍼.
+///
+/// - 비로그인: `anonymousImpl` (Core Data + 로컬 파일시스템)에 위임.
+/// - 로그인: 해당 uid로 `ImageRepositoryFirestoreImpl` 생성, 그쪽으로 위임.
+/// - 전환 시 활성 impl의 `imageUpdatedPublisher`를 내부 subject로 forward.
+/// - 로그인 시 익명 이미지(전 메모 + 휴지통)를 Storage + Firestore로 1회 마이그레이션.
+///   메모 마이그레이션과 병렬로 진행되므로, 익명 enumeration은 `anonymousMemoRepository`를 직접 조회.
+public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
+
+    private let authService: AuthService
+    private let anonymousImpl: ImageRepository
+    private let anonymousMemoRepository: MemoRepository
+    private let firestore: Firestore
+    private let storage: Storage
+
+    private let lock = NSLock()
+    private var _activeImpl: ImageRepository
+    private var _firestoreImpl: ImageRepositoryFirestoreImpl?
+    private var _authCancellable: AnyCancellable?
+    private var _publisherCancellable: AnyCancellable?
+
+    private let updatedSubject = PassthroughSubject<ImageUpdateType, Never>()
+    public var imageUpdatedPublisher: AnyPublisher<ImageUpdateType, Never> {
+        updatedSubject.eraseToAnyPublisher()
+    }
+
+    public init(
+        authService: AuthService,
+        anonymousImpl: ImageRepository,
+        anonymousMemoRepository: MemoRepository,
+        firestore: Firestore = .firestore(),
+        storage: Storage = .storage()
+    ) {
+        self.authService = authService
+        self.anonymousImpl = anonymousImpl
+        self.anonymousMemoRepository = anonymousMemoRepository
+        self.firestore = firestore
+        self.storage = storage
+        self._activeImpl = anonymousImpl
+        attachForwarding(from: anonymousImpl)
+        _authCancellable = authService.authStatePublisher.sink { [weak self] user in
+            self?.handleAuthChange(user: user)
+        }
+    }
+
+    private func handleAuthChange(user: AuthUser?) {
+        if let userID = user?.id {
+            let impl = ImageRepositoryFirestoreImpl(userID: userID, firestore: firestore, storage: storage)
+            lock.lock()
+            _firestoreImpl = impl
+            _activeImpl = impl
+            lock.unlock()
+            attachForwarding(from: impl)
+            triggerMigrationIfNeeded(to: impl, userID: userID)
+        } else {
+            lock.lock()
+            _firestoreImpl = nil
+            _activeImpl = anonymousImpl
+            lock.unlock()
+            attachForwarding(from: anonymousImpl)
+        }
+    }
+
+    /// 익명 이미지를 새 Firestore impl로 이관. UserDefaults 마커로 기기+사용자별 1회.
+    private func triggerMigrationIfNeeded(to firestoreImpl: ImageRepositoryFirestoreImpl, userID: String) {
+        let markerKey = "sync.anonymousToFirestoreImageMigration.\(userID)"
+        guard !UserDefaults.standard.bool(forKey: markerKey) else { return }
+        let memoRepo = anonymousMemoRepository
+        let imageRepo = anonymousImpl
+        Task { [weak firestoreImpl] in
+            guard let firestoreImpl else { return }
+            do {
+                // 활성 메모 + 휴지통 메모 양쪽에서 이미지 수집
+                let active = try await memoRepo.getAllMemos()
+                let trashed = try await memoRepo.getAllMemosInTrash()
+                var collected: [MemoImageInfo] = []
+                for memo in active + trashed {
+                    let images = try await imageRepo.getAllImageInfo(for: memo)
+                    collected.append(contentsOf: images)
+                }
+                if !collected.isEmpty {
+                    try await firestoreImpl.importImages(collected)
+                }
+                UserDefaults.standard.set(true, forKey: markerKey)
+            } catch {
+                print("[ImageRepositoryRouter] migration error: \(error)")
+            }
+        }
+    }
+
+    private func attachForwarding(from impl: ImageRepository) {
+        let newCancellable = impl.imageUpdatedPublisher.sink { [weak self] event in
+            self?.updatedSubject.send(event)
+        }
+        lock.lock()
+        _publisherCancellable?.cancel()
+        _publisherCancellable = newCancellable
+        lock.unlock()
+    }
+
+    private var current: ImageRepository {
+        lock.lock()
+        defer { lock.unlock() }
+        return _activeImpl
+    }
+
+    // MARK: - ImageRepository forwarding
+
+    public func createImage(
+        from pickerResult: PHPickerResult,
+        for memo: Memo,
+        originalImageID: UUID?,
+        thumbnailID: UUID?,
+        orderIndex: Int,
+        isTemporary: Bool
+    ) async throws -> MemoImageInfo {
+        try await current.createImage(
+            from: pickerResult,
+            for: memo,
+            originalImageID: originalImageID,
+            thumbnailID: thumbnailID,
+            orderIndex: orderIndex,
+            isTemporary: isTemporary
+        )
+    }
+
+    public func getImage(from imageInfo: MemoImageInfo) async throws -> UIImage {
+        try await current.getImage(from: imageInfo)
+    }
+
+    public func getThumbnailImage(from imageInfo: MemoImageInfo) async throws -> UIImage {
+        try await current.getThumbnailImage(from: imageInfo)
+    }
+
+    public func getAllImageInfo(for memo: Memo) async throws -> [MemoImageInfo] {
+        try await current.getAllImageInfo(for: memo)
+    }
+
+    public func updateImageIndex(_ image: MemoImageInfo, newIndex: Int) async throws {
+        try await current.updateImageIndex(image, newIndex: newIndex)
+    }
+
+    public func deleteImage(_ imageInfo: MemoImageInfo) async throws {
+        try await current.deleteImage(imageInfo)
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
@@ -25,6 +25,7 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
     private let firestore: Firestore
     private let userID: String
     private let categoryResolver: CategoryRepository
+    private let imageResolver: ImageRepository
 
     private let memoUpdatedSubject = PassthroughSubject<MemoUpdateType, Never>()
     public var memoUpdatedPublisher: AnyPublisher<MemoUpdateType, Never> {
@@ -36,9 +37,15 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
     private var snapshotDTOByID: [UUID: FirestoreMemo] = [:]
     private var listenerRegistration: ListenerRegistration?
 
-    public init(userID: String, categoryResolver: CategoryRepository, firestore: Firestore = .firestore()) {
+    public init(
+        userID: String,
+        categoryResolver: CategoryRepository,
+        imageResolver: ImageRepository,
+        firestore: Firestore = .firestore()
+    ) {
         self.userID = userID
         self.categoryResolver = categoryResolver
+        self.imageResolver = imageResolver
         self.firestore = firestore
         startListening()
     }
@@ -408,36 +415,36 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
         try await collection.document(memo.memoID.uuidString).setData(payload, merge: true)
     }
 
-    /// 단일 DTO를 Memo로 해석 (categoryResolver로 카테고리 본문 채움).
+    /// 단일 DTO를 Memo로 해석 — 카테고리 본문 + 이미지 목록을 함께 채움.
+    /// 이미지는 sub-collection 쿼리(SDK 자동 캐시)라 매번 네트워크 호출은 아님.
     private func resolve(_ dto: FirestoreMemo) async throws -> Memo {
         let categories = await resolveCategories(for: dto)
-        guard let memo = dto.toDomain(categories: categories) else {
+        guard var memo = dto.toDomain(categories: categories) else {
             throw FirestoreRepositoryError.notFound
+        }
+        if let images = try? await imageResolver.getAllImageInfo(for: memo) {
+            memo.images = Set(images)
         }
         return memo
     }
 
-    /// 여러 DTO를 Memo로 해석. 카테고리는 한 번씩만 lookup하도록 캐시.
+    /// 여러 DTO를 Memo로 해석 — `TaskGroup`으로 병렬 처리해 cold cache에서도 첫 로드 latency 최소화.
+    /// 카테고리·이미지 해석이 dto별로 독립이고, categoryResolver(메모리 스냅샷)·imageResolver(SDK 캐시 쿼리)
+    /// 둘 다 thread-safe라 안전.
     private func resolveAll(_ dtos: [FirestoreMemo]) async throws -> [Memo] {
-        var categoryCache: [UUID: Domain.Category] = [:]
-        var memos: [Memo] = []
-        memos.reserveCapacity(dtos.count)
-        for dto in dtos {
-            var categories: Set<Domain.Category> = []
-            for uuid in dto.categoryUUIDs {
-                if let cached = categoryCache[uuid] {
-                    categories.insert(cached)
-                } else if let resolved = try? await categoryResolver.getCategory(id: uuid) {
-                    categoryCache[uuid] = resolved
-                    categories.insert(resolved)
+        try await withThrowingTaskGroup(of: Memo?.self) { group in
+            for dto in dtos {
+                group.addTask { [self] in
+                    try? await self.resolve(dto)
                 }
-                // 해석 실패 시 그 카테고리는 누락된 채로 두고 진행 (도메인 모델에 nil 허용 안 함).
             }
-            if let memo = dto.toDomain(categories: categories) {
-                memos.append(memo)
+            var memos: [Memo] = []
+            memos.reserveCapacity(dtos.count)
+            for try await memo in group {
+                if let memo { memos.append(memo) }
             }
+            return memos
         }
-        return memos
     }
 
     private func resolveCategories(for dto: FirestoreMemo) async -> Set<Domain.Category> {

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryRouter.swift
@@ -13,7 +13,7 @@ import SyncInterface
 /// 인증 상태에 맞춰 활성 `MemoRepository`를 갈아끼우는 래퍼.
 ///
 /// - 비로그인: `anonymousImpl` (Core Data)에 위임.
-/// - 로그인: 해당 uid로 `MemoRepositoryFirestoreImpl` 생성, 카테고리 해석은 `categoryResolver`(보통 카테고리 Router)에 위임.
+/// - 로그인: 해당 uid로 `MemoRepositoryFirestoreImpl` 생성, 카테고리·이미지 해석은 각 resolver Router에 위임.
 /// - 전환 시 활성 impl의 `memoUpdatedPublisher`를 내부 subject로 forward해 외부 구독자에게 투명.
 /// - 로그인 시 익명 메모(휴지통 포함)를 Firestore로 1회 마이그레이션 (`UserDefaults` 마커로 기기+사용자별 보장).
 public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
@@ -21,6 +21,7 @@ public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
     private let authService: AuthService
     private let anonymousImpl: MemoRepository
     private let categoryResolver: CategoryRepository
+    private let imageResolver: ImageRepository
     private let firestore: Firestore
 
     private let lock = NSLock()
@@ -38,11 +39,13 @@ public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
         authService: AuthService,
         anonymousImpl: MemoRepository,
         categoryResolver: CategoryRepository,
+        imageResolver: ImageRepository,
         firestore: Firestore = .firestore()
     ) {
         self.authService = authService
         self.anonymousImpl = anonymousImpl
         self.categoryResolver = categoryResolver
+        self.imageResolver = imageResolver
         self.firestore = firestore
         self._activeImpl = anonymousImpl
         attachForwarding(from: anonymousImpl)
@@ -56,6 +59,7 @@ public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
             let impl = MemoRepositoryFirestoreImpl(
                 userID: userID,
                 categoryResolver: categoryResolver,
+                imageResolver: imageResolver,
                 firestore: firestore
             )
             lock.lock()

--- a/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
+++ b/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
@@ -63,12 +63,13 @@ public enum SyncBootstrap {
         return CategoryRepositoryRouter(authService: authService, anonymousImpl: anonymousImpl)
     }
 
-    /// 메모용 동일 패턴. `categoryResolver`는 보통 `makeCategoryRepository`의 결과(라우터)를 그대로 전달해
-    /// 인증 상태에 맞춰 카테고리도 따라 전환되게 한다.
+    /// 메모용 동일 패턴. `categoryResolver`·`imageResolver`는 보통 각각 `makeCategoryRepository` /
+    /// `makeImageRepository`의 결과(라우터)를 그대로 전달해 인증 상태에 맞춰 함께 전환되게 한다.
     public static func makeMemoRepository(
         authService: AuthService,
         anonymousImpl: MemoRepository,
-        categoryResolver: CategoryRepository
+        categoryResolver: CategoryRepository,
+        imageResolver: ImageRepository
     ) -> MemoRepository {
         guard FirebaseApp.app() != nil else {
             return anonymousImpl
@@ -76,7 +77,25 @@ public enum SyncBootstrap {
         return MemoRepositoryRouter(
             authService: authService,
             anonymousImpl: anonymousImpl,
-            categoryResolver: categoryResolver
+            categoryResolver: categoryResolver,
+            imageResolver: imageResolver
+        )
+    }
+
+    /// 이미지용 동일 패턴. `anonymousMemoRepository`는 로그인 시 익명 이미지 enumeration을 위해 필요
+    /// (이미지가 메모 sub-collection으로 묶이는 구조라 메모 목록부터 알아야 함).
+    public static func makeImageRepository(
+        authService: AuthService,
+        anonymousImpl: ImageRepository,
+        anonymousMemoRepository: MemoRepository
+    ) -> ImageRepository {
+        guard FirebaseApp.app() != nil else {
+            return anonymousImpl
+        }
+        return ImageRepositoryRouter(
+            authService: authService,
+            anonymousImpl: anonymousImpl,
+            anonymousMemoRepository: anonymousMemoRepository
         )
     }
 }


### PR DESCRIPTION
## 배경
- 이미지(메타데이터 + 바이너리)를 Firestore + Firebase Storage로 직접 다루도록 전환. 카테고리·메모 PR과 동일 패턴을 이미지에 적용.
- 정책: 익명 사용자는 로컬(Core Data + 파일시스템), Apple 로그인 후엔 Firestore + Storage. 재로그인 시 로컬→서버 재push 없음(SDK 기본 동작에 위임).
- 메타데이터는 메모 sub-collection(`users/{uid}/memos/{memoID}/images/{imageID}`), 바이너리는 Storage(`users/{uid}/memos/{memoID}/{id}.<ext>`).

## 변경사항
- `ImageRepositoryFirestoreImpl` 추가
  - listener 미사용 — `getAllImageInfo`가 `getDocuments`로 매번 fetch (Firestore SDK 자동 캐시)
  - 로컬 파일시스템(`<Documents>/<memoID>/...`)을 다운로드 캐시로 재활용 — 익명 모드와 동일 경로
  - `getImage`: 로컬 캐시 우선, miss 시 Storage에서 받아 로컬 저장 후 반환
  - `createImage`: 로컬 저장 + Storage 원본·썸네일 **병렬 업로드**(`async let`) + Firestore 메타 작성
  - `importImages`: 마이그레이션 전용 dup-check 없는 `setData(merge:true)` (멱등), Storage 업로드 병렬
- `ImageRepositoryRouter` 추가 (auth 상태 스위칭 + 마이그레이션)
  - 로그인 시 익명 이미지(활성+휴지통 모든 메모)를 Storage+Firestore로 1회 이관 (`UserDefaults` 마커로 기기+사용자별 보장)
  - 익명 이미지 enumeration을 위해 익명 `MemoRepository`도 받음
- `FirestoreMemoImage` DTO: 식별자(`imageID`/`thumbnailID`/`memoID`) + `orderIndex` + `fileExtension`만 저장. 임시 편집 상태 필드(`temporaryOrderIndex`/`isTemporaryAppended`/`isTemporaryDeleted`)는 UI 메모리에서만 쓰이고 저장 시점엔 항상 settled 값이라 DTO에서 제외, 복원 시 settled 기본값으로 채움
- `MemoRepositoryFirestoreImpl`에 `imageResolver` 의존성 추가
  - Firestore 모드 메모 로드 시 sub-collection 쿼리로 `Memo.images` 채움 (홈 화면 이미지 개수 표시 정상화)
  - `resolveAll`을 `TaskGroup`으로 병렬화해 cold cache 첫 로드 latency 최소화
- `SyncBootstrap.makeImageRepository` / `makeMemoRepository` 팩토리 시그니처 업데이트 (Firebase 미설정 시 익명 impl 그대로 반환)
- `AppEnvironment`: 이미지 Router를 메모 Router보다 먼저 생성해 의존성 순서 정렬
- `MemoDetailViewController` 저장 흐름 개선
  - 재진입 가드(`isSaving`) + 바 버튼 비활성화 + 완료 자리 스피너 + 화면 전체 반투명 오버레이로 모든 인터랙션 차단
  - `interactivePopGestureRecognizer` 비활성화로 스와이프 뒤로가기 차단
  - `updateImages`의 `group.waitForAll()`을 for 루프 밖으로 이동 → 실제 병렬 업로드로 동작
  - 오버레이에 진행 카운트 라벨 추가 — 추가/삭제가 있을 때만 해당 줄 표시 (`이미지 N/M 업로드 중` / `이미지 N/M 삭제 중`)
- L10n: `memoDetail.uploadingImagesFormat` / `memoDetail.deletingImagesFormat` 추가
- SyncImpl 모듈에 `FirebaseStorage` + `Data` 의존성 추가 (Storage SDK + `ImageFileHandler` 재활용)

## 테스트 방법
- `tuist generate --no-open`
- `xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` — 전체 빌드 성공
- 사전: Firebase Storage Security Rules에 `match /users/{userId}/{allPaths=**} { allow read, write: if request.auth.uid == userId }` 게시 필요
- 수동(시뮬레이터):
  - 익명 상태에서 메모 + 이미지 첨부 → 기존 Core Data + 파일시스템 동작 그대로
  - Apple 로그인 → 익명 이미지들이 Firebase Console `users/{uid}/memos/{memoID}/images/...` (메타) + Storage `users/{uid}/memos/{memoID}/{id}.<ext>` (바이너리)에 자동 import
  - Console에서 이미지 메타 수정 → 앱 다음 진입 시 반영 (listener 미사용이라 실시간 X)
  - 앱에서 이미지 생성/삭제/순서 변경 → Console/Storage 즉시 반영
  - 저장 중 오버레이에 "이미지 N/M 업로드 중" 카운트 표시, 추가/삭제 둘 다 있으면 두 줄, 둘 다 없는 수정엔 spinner만
  - 로그아웃 → 익명 Core Data로 복귀
  - 재로그인 → 마이그레이션 재실행 안 함

## 리뷰 노트
- 본 PR로 카테고리·메모·이미지 세 Repository 모두 Firestore 직접 처리로 전환됨. 후속 정리 가능: `AnonymousToUserMigrator`·`UserScopedDataLayer` per-user 분기, `FirestoreSyncService`(직접 sync 엔진) 제거.
- 이미지는 메모/카테고리와 달리 listener 미사용 (실시간 cross-device 동기화 안 됨). 후속에서 listener 추가 가능 — 다만 메모 sub-collection 단위라 `collectionGroup` 쿼리 등 추가 설계 필요.
- 로컬 캐시 LRU evict 없음 — 다운로드 누적 가능. 캐시 한도 정책은 후속.
- 원본 리사이즈·압축 정책 미적용 — 현재 사진 라이브러리 원본 그대로 업로드. 사용자 옵션으로 제공할지 결정 필요.
- `MemoViewController.textFieldDidEndEditing`의 "모든 에러를 duplicate name으로 표시" UI 버그는 본 PR 범위 밖.