### PR TITLE
fix: 메모 삭제 시 PopupCard notFound 크래시 해결

### DIFF
--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -105,13 +105,16 @@ class PopupCardViewController: UIViewController {
                     do {
                         self.imageUIModels = try await self.makeImageUIModels()
                         self.rootView.imageCollectionView.reloadData()
+                    } catch RepositoryError.notFound {
+                        // 디바운스 중 메모가 삭제되면 더 이상 표시할 게 없으므로 닫기.
+                        self.dismiss(animated: true)
                     } catch {
-                        assertionFailure("변경된 메모의 이미지 데이터를 업데이트 하던 도중 오류 발생")
+                        print("PopupCard 이미지 업데이트 실패: \(error)")
                     }
                 }
             }
             .store(in: &cancellables)
-        
+
         environment.memoRepository.memoUpdatedPublisher
             .filter({ [weak self] updateType in
                 guard let self else { return false }
@@ -126,13 +129,14 @@ class PopupCardViewController: UIViewController {
                         let updatedMemo = try await self.environment.memoRepository.getMemo(id: self.memo.memoID)
                         self.memo = updatedMemo
                         self.categories = try await self.fetchCategories()
-                        
+
                         self.rootView.categoryCollectionView.reloadData()
                         self.rootView.titleTextField.text = updatedMemo.memoTitle
                         self.rootView.memoTextView.text = updatedMemo.memoText
-                        print("popupCard의 콘텐츠 업데이트됨")
+                    } catch RepositoryError.notFound {
+                        self.dismiss(animated: true)
                     } catch {
-                        assertionFailure("변경된 메모 데이터를 업데이트 하는 도중 에러 발생")
+                        print("PopupCard 메모 업데이트 실패: \(error)")
                     }
                 }
             }

--- a/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
@@ -82,8 +82,12 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
                 snapshotByID[domain.id] = domain
                 createdIDs.append(domain.id)
             case .modified:
+                let previous = snapshotByID[domain.id]
                 snapshotByID[domain.id] = domain
-                modifiedIDs.append(domain.id)
+                if previous != domain {
+                    // Firestore listener는 로컬 write에 캐시·서버 두 번 발화 — 동일 페이로드면 emit 안 함.
+                    modifiedIDs.append(domain.id)
+                }
             case .removed:
                 snapshotByID.removeValue(forKey: domain.id)
                 deletedIDs.append(domain.id)
@@ -107,7 +111,7 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
 
     public func getCategory(id: UUID) async throws -> Domain.Category {
         if let cached = cachedCategory(id: id) { return cached }
-        throw FirestoreRepositoryError.notFound
+        throw RepositoryError.notFound
     }
 
     public func getAllCategories(
@@ -150,7 +154,7 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
         // 같은 이름 중복 방지 (Core Data 구현과 정책 맞춤).
         let existingNames = snapshotNames()
         guard !existingNames.contains(name) else {
-            throw FirestoreRepositoryError.duplicateName
+            throw RepositoryError.duplicateName
         }
         let now = Date()
         let category = Domain.Category(id: UUID(), name: name, creationDate: now, modificationDate: now)
@@ -163,7 +167,7 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
     public func changeCategoryName(_ category: Domain.Category, newName: String) async throws {
         let existingNames = snapshotNames()
         guard !existingNames.contains(newName) else {
-            throw FirestoreRepositoryError.duplicateName
+            throw RepositoryError.duplicateName
         }
         try await collection.document(category.id.uuidString).updateData([
             "name": newName,
@@ -239,8 +243,3 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
     }
 }
 
-/// 스파이크 전용 에러. 정식 채택 시 도메인 에러 모델과 통합.
-public enum FirestoreRepositoryError: Error {
-    case notFound
-    case duplicateName
-}

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
@@ -103,7 +103,8 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
                         trashedIDs.append(id)
                     } else if previous.isInTrash && !dto.isInTrash {
                         restoredIDs.append(id)
-                    } else {
+                    } else if previous != dto {
+                        // Firestore listener는 로컬 write에 캐시·서버 두 번 발화 — 동일 페이로드면 emit 안 함.
                         updatedIDs.append(id)
                     }
                 } else {
@@ -146,14 +147,14 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
 
     public func getMemo(id: UUID) async throws -> Memo {
         guard let dto = cachedDTO(id: id), !dto.isInTrash else {
-            throw FirestoreRepositoryError.notFound
+            throw RepositoryError.notFound
         }
         return try await resolve(dto)
     }
 
     public func getMemoIncludingTrash(id: UUID) async throws -> Memo {
         guard let dto = cachedDTO(id: id) else {
-            throw FirestoreRepositoryError.notFound
+            throw RepositoryError.notFound
         }
         return try await resolve(dto)
     }
@@ -420,7 +421,7 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
     private func resolve(_ dto: FirestoreMemo) async throws -> Memo {
         let categories = await resolveCategories(for: dto)
         guard var memo = dto.toDomain(categories: categories) else {
-            throw FirestoreRepositoryError.notFound
+            throw RepositoryError.notFound
         }
         if let images = try? await imageResolver.getAllImageInfo(for: memo) {
             memo.images = Set(images)

--- a/Projects/Domain/Sources/Errors/RepositoryError.swift
+++ b/Projects/Domain/Sources/Errors/RepositoryError.swift
@@ -1,0 +1,21 @@
+//
+//  RepositoryError.swift
+//  NoteCard
+//
+
+import Foundation
+import Shared
+
+public enum RepositoryError: NoteCardError {
+    case notFound
+    case duplicateName
+
+    public var displayingMessage: String {
+        switch self {
+        case .notFound:
+            return "요청한 데이터를 찾을 수 없습니다."
+        case .duplicateName:
+            return "같은 이름이 이미 존재합니다."
+        }
+    }
+}


### PR DESCRIPTION
## 배경
- 메모 카드를 휴지통으로 이동하거나, 휴지통에서 영구 삭제할 때 PopupCard에서 `notFound: SyncImpl.FirestoreRepositoryError`로 크래시 발생.
- 원인은 두 가지가 겹친 race:
  1. Firestore listener가 로컬 write에 대해 캐시 / 서버 confirm 두 번 발화하고, 두 번째 발화에서 페이로드 변화가 없는데도 `.update`를 emit하는 점.
  2. PopupCard 핸들러가 닫히는 동안 도달한 `.update`를 받고 이미 사라진 메모를 다시 조회해 `notFound`로 떨어지는데, catch가 `assertionFailure`라 Debug 빌드에서 즉시 trap된 점.

## 변경사항
- 도메인 에러로 `RepositoryError` 신설.
  - 기존 `FirestoreRepositoryError` 정의를 `Projects/Domain/Sources/Errors/RepositoryError.swift`로 이동.
  - 코드에 남아있던 `정식 채택 시 도메인 에러 모델과 통합` 의도 반영.
- `handleSnapshot`의 `.modified` 분기에 동일 페이로드 가드 추가.
  - 직전 캐시값과 이번 DTO가 `==`면 emit 건너뜀.
  - `MemoRepositoryFirestoreImpl`, `CategoryRepositoryFirestoreImpl` 두 곳에 적용.
  - 페이로드는 같지만 trash transition(`previous.isInTrash != dto.isInTrash`)이 살아있으면 기존대로 `.trash` / `.restore`로 분기 emit.
- PopupCard 핸들러의 catch 분기 처리.
  - `RepositoryError.notFound`는 `dismiss(animated:)`로 그레이스풀하게 닫음.
  - 그 외 에러는 `print` 후 진행. 더 이상 `assertionFailure`로 trap하지 않음.
  - 메모 / 이미지 핸들러 두 곳에 동일 패턴 적용.

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`
- `tuist test`로 `SyncImplTests`, `NoteCardTests` 통과 확인.
- 사인인 + 시뮬레이터 두 대 사용:
  - 메모를 PopupCard로 연 상태에서 다른 기기에서 같은 메모를 삭제 → PopupCard가 크래시 없이 닫힘.
  - PopupCard에서 휴지통으로 이동 → 정상 dismiss.
  - PopupCard에서 영구 삭제 → 정상 dismiss.

## 리뷰 노트
- 기존 `FirestoreRepositoryError`를 import한 외부 코드는 없어 단순 rename으로 충분 (PopupCard는 Domain만 import).
- `previous != dto` 비교는 `FirestoreMemo` / `FirestoreCategory` DTO가 모두 `Equatable`이고 `serverUpdatedAt` 같은 listener 메타가 DTO 스키마에 포함되지 않아 캐시/서버 confirm 두 발화의 DTO가 동일하다는 점에 기반.
- 이미지 갯수 미갱신(별도 보고된 Bug 1)은 본 PR 범위 밖. `ImageRepository`가 아직 listener 미사용이라 후속 PR(`collectionGroup` listener 도입)에서 다룸.
