### PR TITLE
fix(popup-card): notFound 크래시 해결 + 원격 변경 반응성 확장

### DIFF
--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -105,13 +105,16 @@ class PopupCardViewController: UIViewController {
                     do {
                         self.imageUIModels = try await self.makeImageUIModels()
                         self.rootView.imageCollectionView.reloadData()
+                    } catch RepositoryError.notFound {
+                        // 디바운스 중 메모가 삭제되면 더 이상 표시할 게 없으므로 닫기.
+                        self.dismiss(animated: true)
                     } catch {
-                        assertionFailure("변경된 메모의 이미지 데이터를 업데이트 하던 도중 오류 발생")
+                        print("PopupCard 이미지 업데이트 실패: \(error)")
                     }
                 }
             }
             .store(in: &cancellables)
-        
+
         environment.memoRepository.memoUpdatedPublisher
             .filter({ [weak self] updateType in
                 guard let self else { return false }
@@ -126,13 +129,14 @@ class PopupCardViewController: UIViewController {
                         let updatedMemo = try await self.environment.memoRepository.getMemo(id: self.memo.memoID)
                         self.memo = updatedMemo
                         self.categories = try await self.fetchCategories()
-                        
+
                         self.rootView.categoryCollectionView.reloadData()
                         self.rootView.titleTextField.text = updatedMemo.memoTitle
                         self.rootView.memoTextView.text = updatedMemo.memoText
-                        print("popupCard의 콘텐츠 업데이트됨")
+                    } catch RepositoryError.notFound {
+                        self.dismiss(animated: true)
                     } catch {
-                        assertionFailure("변경된 메모 데이터를 업데이트 하는 도중 에러 발생")
+                        print("PopupCard 메모 업데이트 실패: \(error)")
                     }
                 }
             }

--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -147,6 +147,26 @@ class PopupCardViewController: UIViewController {
                 }
             }
             .store(in: &cancellables)
+
+        environment.categoryRepository.categoryUpdatedPublisher
+            .filter { [weak self] updateType in
+                guard let self else { return false }
+                let memoCategoryIDs = Set(self.memo.categories.map(\.id))
+                return updateType.categoryIDs.contains(where: memoCategoryIDs.contains)
+            }
+            .debounce(for: 0.3, scheduler: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                Task {
+                    do {
+                        self.categories = try await self.fetchCategories()
+                        self.rootView.categoryCollectionView.reloadData()
+                    } catch {
+                        print("PopupCard 카테고리 갱신 실패: \(error)")
+                    }
+                }
+            }
+            .store(in: &cancellables)
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -115,11 +115,11 @@ class PopupCardViewController: UIViewController {
             }
             .store(in: &cancellables)
 
+        let initialIsInTrash = memo.isInTrash
         environment.memoRepository.memoUpdatedPublisher
             .filter({ [weak self] updateType in
                 guard let self else { return false }
-                guard case .update(let updatedAttribute) = updateType else { return false }
-                return updatedAttribute.memoIDs.contains(self.memo.memoID)
+                return updateType.memoIDs.contains(self.memo.memoID)
             })
             .debounce(for: 0.5, scheduler: RunLoop.main)
             .sink { [weak self] _ in
@@ -127,6 +127,12 @@ class PopupCardViewController: UIViewController {
                 Task {
                     do {
                         let updatedMemo = try await self.environment.memoRepository.getMemo(id: self.memo.memoID)
+                        // 다른 기기에서 휴지통 → 복원으로 모드가 뒤집힌 경우. UI를 그 자리에서
+                        // 재구성하기 복잡해서 그냥 닫는다 (사용자는 해당 메모를 새 위치에서 다시 열 수 있음).
+                        guard updatedMemo.isInTrash == initialIsInTrash else {
+                            self.dismiss(animated: true)
+                            return
+                        }
                         self.memo = updatedMemo
                         self.categories = try await self.fetchCategories()
 

--- a/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
@@ -82,8 +82,12 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
                 snapshotByID[domain.id] = domain
                 createdIDs.append(domain.id)
             case .modified:
+                let previous = snapshotByID[domain.id]
                 snapshotByID[domain.id] = domain
-                modifiedIDs.append(domain.id)
+                if previous != domain {
+                    // Firestore listener는 로컬 write에 캐시·서버 두 번 발화 — 동일 페이로드면 emit 안 함.
+                    modifiedIDs.append(domain.id)
+                }
             case .removed:
                 snapshotByID.removeValue(forKey: domain.id)
                 deletedIDs.append(domain.id)
@@ -107,7 +111,7 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
 
     public func getCategory(id: UUID) async throws -> Domain.Category {
         if let cached = cachedCategory(id: id) { return cached }
-        throw FirestoreRepositoryError.notFound
+        throw RepositoryError.notFound
     }
 
     public func getAllCategories(
@@ -150,7 +154,7 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
         // 같은 이름 중복 방지 (Core Data 구현과 정책 맞춤).
         let existingNames = snapshotNames()
         guard !existingNames.contains(name) else {
-            throw FirestoreRepositoryError.duplicateName
+            throw RepositoryError.duplicateName
         }
         let now = Date()
         let category = Domain.Category(id: UUID(), name: name, creationDate: now, modificationDate: now)
@@ -163,7 +167,7 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
     public func changeCategoryName(_ category: Domain.Category, newName: String) async throws {
         let existingNames = snapshotNames()
         guard !existingNames.contains(newName) else {
-            throw FirestoreRepositoryError.duplicateName
+            throw RepositoryError.duplicateName
         }
         try await collection.document(category.id.uuidString).updateData([
             "name": newName,
@@ -239,8 +243,3 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
     }
 }
 
-/// 스파이크 전용 에러. 정식 채택 시 도메인 에러 모델과 통합.
-public enum FirestoreRepositoryError: Error {
-    case notFound
-    case duplicateName
-}

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
@@ -103,7 +103,8 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
                         trashedIDs.append(id)
                     } else if previous.isInTrash && !dto.isInTrash {
                         restoredIDs.append(id)
-                    } else {
+                    } else if previous != dto {
+                        // Firestore listener는 로컬 write에 캐시·서버 두 번 발화 — 동일 페이로드면 emit 안 함.
                         updatedIDs.append(id)
                     }
                 } else {
@@ -146,14 +147,14 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
 
     public func getMemo(id: UUID) async throws -> Memo {
         guard let dto = cachedDTO(id: id), !dto.isInTrash else {
-            throw FirestoreRepositoryError.notFound
+            throw RepositoryError.notFound
         }
         return try await resolve(dto)
     }
 
     public func getMemoIncludingTrash(id: UUID) async throws -> Memo {
         guard let dto = cachedDTO(id: id) else {
-            throw FirestoreRepositoryError.notFound
+            throw RepositoryError.notFound
         }
         return try await resolve(dto)
     }
@@ -420,7 +421,7 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
     private func resolve(_ dto: FirestoreMemo) async throws -> Memo {
         let categories = await resolveCategories(for: dto)
         guard var memo = dto.toDomain(categories: categories) else {
-            throw FirestoreRepositoryError.notFound
+            throw RepositoryError.notFound
         }
         if let images = try? await imageResolver.getAllImageInfo(for: memo) {
             memo.images = Set(images)

--- a/Projects/Domain/Sources/Errors/RepositoryError.swift
+++ b/Projects/Domain/Sources/Errors/RepositoryError.swift
@@ -1,0 +1,21 @@
+//
+//  RepositoryError.swift
+//  NoteCard
+//
+
+import Foundation
+import Shared
+
+public enum RepositoryError: NoteCardError {
+    case notFound
+    case duplicateName
+
+    public var displayingMessage: String {
+        switch self {
+        case .notFound:
+            return "요청한 데이터를 찾을 수 없습니다."
+        case .duplicateName:
+            return "같은 이름이 이미 존재합니다."
+        }
+    }
+}


### PR DESCRIPTION
## 배경
- PR #66에서 다루던 PopupCard `notFound` 크래시 + 후속 reactivity 확장을 같은 PR로 재구성. (이전 PR은 close, 새 브랜치로 cherry-pick 후 추가 작업 누적.)
- 메모 / 카테고리의 원격 변경이 PopupCard에 거의 반영되지 않던 문제도 함께 해결.

## 변경사항
- `RepositoryError`를 Domain으로 끌어올림.
  - 기존 `FirestoreRepositoryError` 정의를 `Projects/Domain/Sources/Errors/RepositoryError.swift`로 이동.
  - 코드의 `정식 채택 시 도메인 에러 모델과 통합` 의도 실현.
- `handleSnapshot`의 `.modified` 분기에 동일 페이로드 가드 추가.
  - 캐시 fire / 서버 confirm 두 번 발화 중, 두 번째 spurious `.update` 차단.
  - `MemoRepositoryFirestoreImpl`, `CategoryRepositoryFirestoreImpl` 양쪽 적용.
- PopupCard 메모 핸들러 확장.
  - 필터를 `.update` 한정에서 `event.memoIDs` 기반으로 변경 — cross-device `.trash` / `.delete` / `.restore` 도 통과.
  - 초기 `isInTrash` 와 갱신 후 `isInTrash` 가 다르면(모드 플립) `dismiss`.
  - catch에서 `RepositoryError.notFound` 는 `dismiss(animated:)`, 그 외는 print.
- PopupCard 이미지 핸들러 catch도 같은 패턴(`notFound` → dismiss, 그 외 → print)으로 통일.
- PopupCard에 `categoryUpdatedPublisher` 구독 추가.
  - 이벤트의 `categoryIDs` 와 메모의 카테고리 ID 집합 교집합 있을 때만 통과.
  - 0.3초 debounce 후 `fetchCategories` + `categoryCollectionView.reloadData`.

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` 통과 확인.
- `tuist test` 통과 확인.
- 사인인 + 시뮬레이터 두 대로 수동 확인.
  - 한쪽에서 PopupCard 연 상태에서 다른 쪽이 같은 메모 휴지통 이동 → 크래시 없이 dismiss.
  - 한쪽에서 PopupCard 연 상태에서 다른 쪽이 영구 삭제 → dismiss.
  - 한쪽에서 휴지통 메모 PopupCard 연 상태에서 다른 쪽이 복원 → dismiss (모드 플립).
  - 한쪽에서 PopupCard 연 상태에서 다른 쪽이 메모의 카테고리 이름 변경 → chip 자동 갱신.

## 리뷰 노트
- `previous != dto` 비교는 `FirestoreMemo` / `FirestoreCategory` DTO가 `Equatable` 이고 `serverUpdatedAt` 같은 listener 메타가 DTO 스키마에 포함되지 않아 캐시 / 서버 confirm 두 발화의 DTO가 동일하다는 점에 기반.
- 이미지 publisher는 본 PR 범위 밖. `ImageRepository` 가 listener 미사용이라 cross-device 이미지 변경은 후속 (`collectionGroup` listener 도입 PR).
- 이전 PR #66 을 close 하고 동일 작업 + 추가 작업을 본 PR로 재구성.
