### PR TITLE
feat(image): PopupCard용 per-memo image listener 추가

### DIFF
--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -88,6 +88,11 @@ class PopupCardViewController: UIViewController {
             memoTextViewTapGesture.isEnabled = false
         }
         
+        // PopupCard 표시 중에만 해당 메모의 image sub-collection listener attach.
+        // cancellables 라이프사이클에 묶여 dismiss 시 자동 detach.
+        environment.imageRepository.observeImageChanges(for: memo.memoID)
+            .store(in: &cancellables)
+
         environment.imageRepository.imageUpdatedPublisher
             .filter { [weak self] updateType in
                 guard let self else { return false }

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
@@ -155,6 +155,38 @@ public final class ImageRepositoryFirestoreImpl: ImageRepository, @unchecked Sen
         }.compactMap { $0.toDomain() }
     }
 
+    // MARK: - Listener (per-memo)
+
+    public func observeImageChanges(for memoID: UUID) -> AnyCancellable {
+        let registration = imageCollection(for: memoID).addSnapshotListener { [weak self] snapshot, error in
+            guard let self else { return }
+            if let error {
+                print("[ImageRepoFirestore] listener error for memo \(memoID): \(error)")
+                return
+            }
+            guard let snapshot else { return }
+            self.emitImageChanges(snapshot, memoID: memoID)
+        }
+        return AnyCancellable {
+            registration.remove()
+        }
+    }
+
+    private func emitImageChanges(_ snapshot: QuerySnapshot, memoID: UUID) {
+        var hasAdds = false, hasMods = false, hasRems = false
+        for change in snapshot.documentChanges {
+            switch change.type {
+            case .added: hasAdds = true
+            case .modified: hasMods = true
+            case .removed: hasRems = true
+            }
+        }
+        // UI는 종류 무관하게 재조회하므로 변경 종류별로 한 번씩 coarse emit.
+        if hasAdds { imageUpdatedSubject.send(.create(memoID: memoID)) }
+        if hasMods { imageUpdatedSubject.send(.update(memoID: memoID)) }
+        if hasRems { imageUpdatedSubject.send(.delete(memoID: memoID)) }
+    }
+
     // MARK: - Update
 
     public func updateImageIndex(_ image: MemoImageInfo, newIndex: Int) async throws {

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
@@ -158,4 +158,8 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
     public func deleteImage(_ imageInfo: MemoImageInfo) async throws {
         try await current.deleteImage(imageInfo)
     }
+
+    public func observeImageChanges(for memoID: UUID) -> AnyCancellable {
+        current.observeImageChanges(for: memoID)
+    }
 }

--- a/Projects/Data/Sources/Repositories/ImageRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/ImageRepositoryImpl.swift
@@ -145,6 +145,12 @@ public final class ImageRepositoryImpl: ImageRepository, @unchecked Sendable {
         imageUpdatedSubject.send(.update(memoID: image.memoID))
     }
     
+    // 익명(Core Data) 모드는 cross-device 동기화 대상이 아니라 외부 변경 push 자체가 없음.
+    // 로컬 write는 기존 메서드들이 즉시 publisher emit하므로 추가 listener 없이 no-op cancellable 반환.
+    public func observeImageChanges(for memoID: UUID) -> AnyCancellable {
+        AnyCancellable {}
+    }
+
     // 이미지를 영구적으로 삭제.
     // 모든 이미지 데이터를 안전하게 삭제하기 위해서 FileManager 에 있는 이미지 및 썸네일 파일을 먼저 지우고,
     // 그 다음에 CoreData의 DB에서 ImageEntity 삭제

--- a/Projects/Domain/Sources/Repositories/ImageRepository.swift
+++ b/Projects/Domain/Sources/Repositories/ImageRepository.swift
@@ -29,4 +29,8 @@ public protocol ImageRepository: Sendable {
     func getAllImageInfo(for memo: Memo) async throws -> [MemoImageInfo]
     func updateImageIndex(_ image: MemoImageInfo, newIndex: Int) async throws
     func deleteImage(_ imageInfo: MemoImageInfo) async throws
+
+    /// 메모의 이미지 변경을 구독. 반환된 cancellable의 cancel 시점에 listener detach.
+    /// 활성 구간 동안 발생한 이벤트는 `imageUpdatedPublisher` 로 emit.
+    func observeImageChanges(for memoID: UUID) -> AnyCancellable
 }


### PR DESCRIPTION
## 배경
- PopupCard가 열려 있는 동안 다른 기기가 같은 메모의 이미지를 추가 / 삭제 / 순서 변경해도 반영되지 않던 문제 해결.
- 원인: `ImageRepositoryFirestoreImpl` 가 Firestore listener를 attach하지 않아, `imageUpdatedPublisher` 가 로컬 write에서만 emit. cross-device 변경은 push 자체를 받지 못함.

## 변경사항
- `ImageRepository` 프로토콜에 `observeImageChanges(for memoID:) -> AnyCancellable` 추가.
- `ImageRepositoryFirestoreImpl`:
  - 호출 시 메모의 image sub-collection (`users/<uid>/memos/<memoID>/images/`) 에 listener attach.
  - 반환 cancellable cancel 시 listener detach.
  - listener 발화 시 `documentChanges` 종류별로 (`.added` / `.modified` / `.removed`) coarse emit.
- `ImageRepositoryImpl` (Core Data anonymous): no-op cancellable 반환. 익명 모드는 cross-device 대상이 아니라 외부 push 없음.
- `ImageRepositoryRouter`: 활성 impl 로 위임.
- `PopupCardViewController.viewDidLoad`: `observeImageChanges(for: memo.memoID)` 호출, 반환 cancellable을 `cancellables` 에 store. VC dismiss 시 자동 detach.

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` 통과 확인.
- `tuist test` 통과 확인.
- 사인인 + 시뮬레이터 두 대로 수동 확인.
  - 한쪽에서 PopupCard 연 상태에서 다른 쪽이 같은 메모에 이미지 추가 → PopupCard 에 즉시 반영.
  - 한쪽에서 PopupCard 연 상태에서 다른 쪽이 같은 메모의 이미지 삭제 → PopupCard 에서 즉시 사라짐.
  - 한쪽에서 PopupCard 연 상태에서 다른 쪽이 이미지 순서 변경 → PopupCard 에서 새 순서로 갱신.

## 리뷰 노트
- listener 라이프사이클은 cancellable 기반. PopupCard 외 다른 호출자가 같은 `memoID` 로 동시에 observe 하면 listener 두 개 attach 됨 (현재는 PopupCard 한 곳뿐이라 무문제). 향후 다중 호출 패턴 등장 시 ref counting 검토.
- 첫 attach 시 기존 이미지 docs가 `.added` 로 들어와 `.create` emit 한 번 발생. PopupCard 의 0.5초 debounce + makeImageUIModels 가 흡수하므로 cosmetic. 필요 시 후속 PR 에서 initial-snapshot 억제 가능.
- 같은 페이로드 두 번 발화(캐시 / 서버 confirm) 가드는 현재 미적용. Memo / Category 와 달리 image 는 snapshot DTO 캐시가 없어 동일 가드 적용에 약간의 작업 필요. PopupCard 측 debounce 가 실효적으로 흡수하므로 보류.
- **알려진 후속 작업**: cross-device 로 새 이미지가 추가될 때 Storage 다운로드 동안 빈 상태로 보이는 latency. placeholder cell 표시는 별도 PR 로 분리 예정.
- 본 PR 머지로 known issue "PopupCard 이미지 갯수 cross-device 미갱신" 종결.
