### PR TITLE
feat(account-deletion): 실제 데이터 정리 + cross-device 즉시 signOut + 홈 자동 전환

### DIFF
--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -24,6 +24,8 @@ struct AppEnvironment {
     let imageRepository: ImageRepository
     let analytics: Analytics
     let authService: AuthService
+    let accountSentinelService: AccountSentinelService
+    let accountDeletionService: AccountDeletionService
 
     let coreDataStack: CoreDataStack
 
@@ -64,11 +66,21 @@ struct AppEnvironment {
             anonymousMemoRepository: memoRepositoryCoreData
         )
         self.imageRepository = imageRepository
-        self.memoRepository = SyncBootstrap.makeMemoRepository(
+        let memoRepository = SyncBootstrap.makeMemoRepository(
             authService: authService,
             anonymousImpl: memoRepositoryCoreData,
             categoryResolver: categoryRepository,
             imageResolver: imageRepository
+        )
+        self.memoRepository = memoRepository
+        let accountSentinelService = SyncBootstrap.makeAccountSentinelService(authService: authService)
+        self.accountSentinelService = accountSentinelService
+        self.accountDeletionService = SyncBootstrap.makeAccountDeletionService(
+            authService: authService,
+            accountSentinelService: accountSentinelService,
+            memoRepository: memoRepository,
+            categoryRepository: categoryRepository,
+            imageRepository: imageRepository
         )
     }
 

--- a/NoteCard/Global/Application/SceneDelegate.swift
+++ b/NoteCard/Global/Application/SceneDelegate.swift
@@ -5,6 +5,7 @@
 //  Created by 김민성 on 2023/11/02.
 //
 
+import Combine
 import UIKit
 import Data
 import Domain
@@ -15,6 +16,7 @@ import Shared
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    private var cancellables = Set<AnyCancellable>()
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
@@ -42,6 +44,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         } else {
             self.window?.rootViewController = makeMainTabBarController(environment: appDelegate.environment)
         }
+
+        observeForceSignOut(environment: appDelegate.environment)
+    }
+
+    /// sign-out 이벤트 (user → nil) 가 발생하면 modal · navigation 상태를 초기화한 채 홈 탭에서
+    /// 시작하도록 rootViewController 를 통째로 교체.
+    /// dropFirst 로 구독 시점의 현재 값은 건너뛰고, filter 로 sign-in 이벤트는 무시 (LoginVC 가 처리).
+    private func observeForceSignOut(environment: AppEnvironment) {
+        environment.authService.authStatePublisher
+            .dropFirst()
+            .filter { $0 == nil }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.transitionToMainTabBar(environment: environment)
+            }
+            .store(in: &cancellables)
     }
 
     // MARK: - Root view construction

--- a/NoteCard/Presentation/TabBar/MainTabBarController.swift
+++ b/NoteCard/Presentation/TabBar/MainTabBarController.swift
@@ -102,6 +102,7 @@ class MainTabBarController: UITabBarController {
             categoryRepository: environment.categoryRepository,
             analytics: environment.analytics,
             authService: environment.authService,
+            accountDeletionService: environment.accountDeletionService,
             makeTrashViewController: { [environment] in
                 MemoViewController(memoVCType: .trash, environment: environment)
             }

--- a/Project.swift
+++ b/Project.swift
@@ -66,6 +66,7 @@ let appDependencies: [TargetDependency] = [
     .project(target: "SyncImpl", path: .relativeToRoot("Projects/Core/SyncImpl")),
     .project(target: "SettingsFeature", path: .relativeToRoot("Projects/Feature/SettingsFeature")),
     .project(target: "LoginFeature", path: .relativeToRoot("Projects/Feature/LoginFeature")),
+    .project(target: "AccountDeletionFeature", path: .relativeToRoot("Projects/Feature/AccountDeletionFeature")),
 ]
 
 let project = Project(

--- a/Projects/Core/Shared/Resources/Localizable.xcstrings
+++ b/Projects/Core/Shared/Resources/Localizable.xcstrings
@@ -1820,6 +1820,91 @@
         }
       }
     },
+    "sync.auth.requiresRecentLogin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "For security, please sign in again to delete your account."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보안을 위해 계정 삭제 전에 다시 로그인이 필요해요."
+          }
+        }
+      }
+    },
+    "sync.accountDeletion.inProgress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deleting your account and data…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "계정과 데이터를 삭제하는 중이에요…"
+          }
+        }
+      }
+    },
+    "sync.accountDeletion.dataCleanupFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't fully delete your data. Please check your connection and try again."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "데이터를 전부 삭제하지 못했어요. 네트워크 상태를 확인하고 다시 시도해주세요."
+          }
+        }
+      }
+    },
+    "sync.accountDeletion.reauthRequired": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please sign in again to confirm account deletion."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "계정 삭제를 확인하려면 다시 로그인해주세요."
+          }
+        }
+      }
+    },
+    "sync.accountDeletion.invalidatedRemotely": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your account is no longer available. You have been signed out."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 계정에 더 이상 접근할 수 없어요. 로그아웃되었어요."
+          }
+        }
+      }
+    },
     "sync.error.network": {
       "extractionState": "manual",
       "localizations": {

--- a/Projects/Core/Shared/Sources/Localization/L10n.swift
+++ b/Projects/Core/Shared/Sources/Localization/L10n.swift
@@ -134,6 +134,14 @@ public enum L10n {
             public static let invalidCredential = "sync.auth.invalidCredential".localized()
             public static let unavailable = "sync.auth.unavailable".localized()
             public static let unknown = "sync.auth.unknown".localized()
+            public static let requiresRecentLogin = "sync.auth.requiresRecentLogin".localized()
+        }
+
+        public enum AccountDeletion {
+            public static let inProgress = "sync.accountDeletion.inProgress".localized()
+            public static let dataCleanupFailed = "sync.accountDeletion.dataCleanupFailed".localized()
+            public static let reauthRequired = "sync.accountDeletion.reauthRequired".localized()
+            public static let invalidatedRemotely = "sync.accountDeletion.invalidatedRemotely".localized()
         }
 
         public enum Error {

--- a/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
@@ -31,6 +31,13 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
         categoryUpdatedSubject.eraseToAnyPublisher()
     }
 
+    /// listener 발화 시 도착한 에러를 그대로 emit. Router 가 받아 permission denied 등 세션 무효화
+    /// 신호를 처리하는 데 사용.
+    private let listenerErrorSubject = PassthroughSubject<Error, Never>()
+    public var listenerErrorPublisher: AnyPublisher<Error, Never> {
+        listenerErrorSubject.eraseToAnyPublisher()
+    }
+
     /// listener가 채우는 in-memory 스냅샷. 읽기/쓰기 모두 `snapshotLock`으로 보호.
     private let snapshotLock = NSLock()
     private var snapshotByID: [UUID: Domain.Category] = [:]
@@ -56,8 +63,8 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
         listenerRegistration = collection.addSnapshotListener { [weak self] snapshot, error in
             guard let self else { return }
             if let error {
-                // 스파이크에선 디버그 로그로만. 정식 채택 시 status로 surface.
                 print("[CategoryRepoFirestore] listener error: \(error)")
+                self.listenerErrorSubject.send(error)
                 return
             }
             guard let snapshot else { return }

--- a/Projects/Core/SyncImpl/Sources/CategoryRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/CategoryRepositoryRouter.swift
@@ -33,6 +33,7 @@ public final class CategoryRepositoryRouter: CategoryRepository, @unchecked Send
     private var _firestoreImpl: CategoryRepositoryFirestoreImpl?
     private var _authCancellable: AnyCancellable?
     private var _publisherCancellable: AnyCancellable?
+    private var _listenerErrorCancellable: AnyCancellable?
 
     private let updatedSubject = PassthroughSubject<CategoryUpdateType, Never>()
     public var categoryUpdatedPublisher: AnyPublisher<CategoryUpdateType, Never> {
@@ -64,6 +65,7 @@ public final class CategoryRepositoryRouter: CategoryRepository, @unchecked Send
             _activeImpl = impl
             lock.unlock()
             attachForwarding(from: impl)
+            attachListenerErrorHandling(from: impl)
             // 익명 → Firestore 1회 마이그레이션 (백그라운드)
             triggerMigrationIfNeeded(to: impl, userID: userID)
         } else {
@@ -71,12 +73,33 @@ public final class CategoryRepositoryRouter: CategoryRepository, @unchecked Send
             lock.lock()
             _firestoreImpl = nil
             _activeImpl = anonymousImpl
+            _listenerErrorCancellable?.cancel()
+            _listenerErrorCancellable = nil
             lock.unlock()
             attachForwarding(from: anonymousImpl)
         }
         // 백엔드가 바뀌었음을 UI에 알려 재조회 유도.
         // (Core Data impl은 자발적 emit이 없고, Firestore listener도 첫 스냅샷 도착이 비동기라 둘 다 보조)
         updatedSubject.send(.update(content: .name(categoryIDs: [])))
+    }
+
+    /// Firestore listener 가 permission denied 등으로 발화하면 — 다른 기기에서 본 계정이 삭제됐다는
+    /// 신호일 가능성 — 강제 signOut 으로 익명 모드 복귀.
+    private func attachListenerErrorHandling(from impl: CategoryRepositoryFirestoreImpl) {
+        let newCancellable = impl.listenerErrorPublisher.sink { [weak self] error in
+            guard let self else { return }
+            let nsError = error as NSError
+            guard nsError.domain == FirestoreErrorDomain,
+                  nsError.code == FirestoreErrorCode.permissionDenied.rawValue
+            else { return }
+            Task { [authService = self.authService] in
+                try? await authService.signOut()
+            }
+        }
+        lock.lock()
+        _listenerErrorCancellable?.cancel()
+        _listenerErrorCancellable = newCancellable
+        lock.unlock()
     }
 
     /// 익명 카테고리를 새 Firestore impl로 이관한다. UserDefaults 마커로 기기+사용자별 1회만 수행.

--- a/Projects/Core/SyncImpl/Sources/FirebaseAccountDeletionService.swift
+++ b/Projects/Core/SyncImpl/Sources/FirebaseAccountDeletionService.swift
@@ -1,0 +1,77 @@
+//
+//  FirebaseAccountDeletionService.swift
+//  NoteCard
+//
+
+import Domain
+import Foundation
+import SyncInterface
+
+/// Repository 추상화를 통해 데이터 정리를 수행하는 `AccountDeletionService` 구현.
+///
+/// 순서: reauth → 데이터 삭제 → Auth user 삭제. reauth 를 가장 먼저 두는 이유는
+/// (1) 사용자가 Apple 시트를 취소했을 때 아무것도 지워지지 않은 깨끗한 상태로 종료되고
+/// (2) reauth 후 token 이 신선하므로 마지막 `user.delete()` 가 `requiresRecentLogin` 없이 통과하기 때문.
+///
+/// 데이터 삭제는 기존 Repository 메서드를 그대로 사용 — 호출 시점 활성 impl (보통 Firestore)
+/// 의 `deleteMemo` / `deleteImage` / `deleteCategory` 가 각각의 클라우드 / Storage 부수효과를 책임진다.
+public final class FirebaseAccountDeletionService: AccountDeletionService, @unchecked Sendable {
+
+    private let authService: AuthService
+    private let accountSentinelService: AccountSentinelService
+    private let memoRepository: MemoRepository
+    private let categoryRepository: CategoryRepository
+    private let imageRepository: ImageRepository
+
+    public init(
+        authService: AuthService,
+        accountSentinelService: AccountSentinelService,
+        memoRepository: MemoRepository,
+        categoryRepository: CategoryRepository,
+        imageRepository: ImageRepository
+    ) {
+        self.authService = authService
+        self.accountSentinelService = accountSentinelService
+        self.memoRepository = memoRepository
+        self.categoryRepository = categoryRepository
+        self.imageRepository = imageRepository
+    }
+
+    public func deleteAccountAndAllData() async throws {
+        // 1. 파괴적 작업 전에 reauth 먼저 — Apple sign-in 시트가 즉시 뜸. 사용자가 여기서 취소하면
+        //    `AuthError.cancelled` 가 던져지고 데이터·계정 모두 그대로 보존.
+        _ = try await authService.signInWithApple()
+
+        // 2. sentinel doc 삭제 — 다른 기기의 listener 가 .removed 받자마자 signOut.
+        //    본 기기 listener 는 service 내부에서 detach 되어 self-trigger 방지됨.
+        try await accountSentinelService.deleteSentinel()
+
+        // 3. 데이터 삭제. token 신선해서 Firestore 접근 정상.
+        try await deleteAllUserData()
+
+        // 4. Auth user 삭제. 방금 reauth 했으므로 requiresRecentLogin 발생하지 않음.
+        try await authService.deleteAccount()
+    }
+
+    /// 메모 / 이미지 / 카테고리를 enumerate 해 모두 삭제. 개별 실패는 다음 항목 진행을 막지 않음 —
+    /// 결과적으로 클라우드에 남은 게 있더라도 호출자가 다시 시도하면 됨.
+    private func deleteAllUserData() async throws {
+        let activeMemos = (try? await memoRepository.getAllMemos()) ?? []
+        let trashedMemos = (try? await memoRepository.getAllMemosInTrash()) ?? []
+
+        for memo in activeMemos + trashedMemos {
+            let images = (try? await imageRepository.getAllImageInfo(for: memo)) ?? []
+            for image in images {
+                try? await imageRepository.deleteImage(image)
+            }
+            try? await memoRepository.deleteMemo(memo)
+        }
+
+        let allCategories = (try? await categoryRepository.getAllCategories(
+            inOrderOf: .modificationDate, isAscending: false
+        )) ?? []
+        for category in allCategories {
+            try? await categoryRepository.deleteCategory(category)
+        }
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/FirebaseAccountSentinelService.swift
+++ b/Projects/Core/SyncImpl/Sources/FirebaseAccountSentinelService.swift
@@ -1,0 +1,136 @@
+//
+//  FirebaseAccountSentinelService.swift
+//  NoteCard
+//
+
+import Combine
+import FirebaseFirestore
+import Foundation
+import SyncInterface
+
+/// Firestore 기반 `AccountSentinelService` 구현.
+///
+/// 동작:
+/// - `authStatePublisher` 구독: 사인인 → `ensureSentinel` 후 listener attach. 사인아웃 → detach.
+/// - listener: sentinel 이 "존재 → 비존재" 로 전이하면 강제 `signOut()`. 초기 부재 (`ensureSentinel`
+///   완료 전) 는 무시.
+/// - `deleteSentinel()`: 본 기기 listener 를 먼저 detach 하고 `isLocalDeletionInProgress` 플래그를 켜서
+///   self-trigger 를 막은 뒤 doc 삭제.
+public final class FirebaseAccountSentinelService: AccountSentinelService, @unchecked Sendable {
+
+    private let firestore: Firestore
+    private let authService: AuthService
+
+    private let lock = NSLock()
+    private var listenerRegistration: ListenerRegistration?
+    private var hasSeenSentinelExist = false
+    private var isLocalDeletionInProgress = false
+    private var authCancellable: AnyCancellable?
+
+    public init(authService: AuthService, firestore: Firestore = .firestore()) {
+        self.authService = authService
+        self.firestore = firestore
+        authCancellable = authService.authStatePublisher.sink { [weak self] user in
+            self?.handleAuthChange(user: user)
+        }
+    }
+
+    deinit {
+        listenerRegistration?.remove()
+    }
+
+    // MARK: - Path
+
+    private func sentinelDoc(for userID: String) -> DocumentReference {
+        firestore.collection("users").document(userID).collection("_meta").document("active")
+    }
+
+    // MARK: - Auth state
+
+    private func handleAuthChange(user: AuthUser?) {
+        if let user {
+            Task { [weak self] in
+                guard let self else { return }
+                // ensureSentinel 이 끝난 뒤 listener 를 붙여, 초기 fire 가 exists=true 가 되도록 한다.
+                // 그래야 그 다음 .removed (다른 기기 삭제 신호) 를 정확히 감지 가능.
+                try? await self.ensureSentinel(for: user.id)
+                self.startListening(userID: user.id)
+            }
+        } else {
+            stopListening()
+        }
+    }
+
+    private func ensureSentinel(for userID: String) async throws {
+        try await sentinelDoc(for: userID).setData([
+            "createdAt": FieldValue.serverTimestamp()
+        ], merge: true)
+    }
+
+    // MARK: - Listener
+
+    private func startListening(userID: String) {
+        let registration = sentinelDoc(for: userID).addSnapshotListener { [weak self] snapshot, error in
+            guard let self else { return }
+            if let error {
+                print("[AccountSentinel] listener error: \(error)")
+                return
+            }
+            guard let snapshot else { return }
+            self.handleSnapshot(snapshot)
+        }
+        lock.lock()
+        listenerRegistration?.remove()
+        listenerRegistration = registration
+        hasSeenSentinelExist = false
+        lock.unlock()
+    }
+
+    private func stopListening() {
+        lock.lock()
+        listenerRegistration?.remove()
+        listenerRegistration = nil
+        hasSeenSentinelExist = false
+        lock.unlock()
+    }
+
+    private func handleSnapshot(_ snapshot: DocumentSnapshot) {
+        lock.lock()
+        let suppressed = isLocalDeletionInProgress
+        let wasExisting = hasSeenSentinelExist
+        if snapshot.exists {
+            hasSeenSentinelExist = true
+        } else if wasExisting {
+            hasSeenSentinelExist = false
+        }
+        lock.unlock()
+
+        guard !suppressed else { return }
+        guard !snapshot.exists, wasExisting else { return }
+
+        // sentinel 이 살아있던 상태에서 사라짐 → 다른 기기에서 계정 삭제됐다는 신호.
+        Task { [weak self] in
+            try? await self?.authService.signOut()
+        }
+    }
+
+    // MARK: - Public API
+
+    public func deleteSentinel() async throws {
+        guard let userID = authService.currentUser?.id else { return }
+
+        lock.lock()
+        isLocalDeletionInProgress = true
+        listenerRegistration?.remove()
+        listenerRegistration = nil
+        lock.unlock()
+
+        defer {
+            lock.lock()
+            isLocalDeletionInProgress = false
+            lock.unlock()
+        }
+
+        try await sentinelDoc(for: userID).delete()
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/FirebaseAuthService.swift
+++ b/Projects/Core/SyncImpl/Sources/FirebaseAuthService.swift
@@ -73,7 +73,13 @@ public final class FirebaseAuthService: NSObject, AuthService, @unchecked Sendab
         guard let user = Auth.auth().currentUser else {
             throw AuthError.invalidCredential
         }
-        try await user.delete()
+        do {
+            try await user.delete()
+        } catch let error as NSError where error.code == AuthErrorCode.requiresRecentLogin.rawValue {
+            throw AuthError.requiresRecentLogin
+        } catch {
+            throw AuthError.unknown(error)
+        }
     }
 
     // MARK: - Private

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
@@ -32,6 +32,13 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
         memoUpdatedSubject.eraseToAnyPublisher()
     }
 
+    /// listener 발화 시 도착한 에러를 그대로 emit. Router 가 받아 permission denied 등 세션 무효화
+    /// 신호를 처리하는 데 사용.
+    private let listenerErrorSubject = PassthroughSubject<Error, Never>()
+    public var listenerErrorPublisher: AnyPublisher<Error, Never> {
+        listenerErrorSubject.eraseToAnyPublisher()
+    }
+
     /// listener가 채우는 in-memory DTO 스냅샷. 카테고리는 read 시점에 해석.
     private let snapshotLock = NSLock()
     private var snapshotDTOByID: [UUID: FirestoreMemo] = [:]
@@ -65,6 +72,7 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
             guard let self else { return }
             if let error {
                 print("[MemoRepoFirestore] listener error: \(error)")
+                self.listenerErrorSubject.send(error)
                 return
             }
             guard let snapshot else { return }

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryRouter.swift
@@ -29,6 +29,7 @@ public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
     private var _firestoreImpl: MemoRepositoryFirestoreImpl?
     private var _authCancellable: AnyCancellable?
     private var _publisherCancellable: AnyCancellable?
+    private var _listenerErrorCancellable: AnyCancellable?
 
     private let updatedSubject = PassthroughSubject<MemoUpdateType, Never>()
     public var memoUpdatedPublisher: AnyPublisher<MemoUpdateType, Never> {
@@ -67,16 +68,38 @@ public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
             _activeImpl = impl
             lock.unlock()
             attachForwarding(from: impl)
+            attachListenerErrorHandling(from: impl)
             triggerMigrationIfNeeded(to: impl, userID: userID)
         } else {
             lock.lock()
             _firestoreImpl = nil
             _activeImpl = anonymousImpl
+            _listenerErrorCancellable?.cancel()
+            _listenerErrorCancellable = nil
             lock.unlock()
             attachForwarding(from: anonymousImpl)
         }
         // 백엔드 전환을 UI에 알려 재조회 유도.
         updatedSubject.send(.update(content: .titleText(memoIDs: [])))
+    }
+
+    /// Firestore listener 가 permission denied 등으로 발화하면 — 보통 다른 기기에서 본 계정이
+    /// 삭제됐다는 신호 — 강제 로그아웃해서 익명 모드로 전환.
+    private func attachListenerErrorHandling(from impl: MemoRepositoryFirestoreImpl) {
+        let newCancellable = impl.listenerErrorPublisher.sink { [weak self] error in
+            guard let self else { return }
+            let nsError = error as NSError
+            guard nsError.domain == FirestoreErrorDomain,
+                  nsError.code == FirestoreErrorCode.permissionDenied.rawValue
+            else { return }
+            Task { [authService = self.authService] in
+                try? await authService.signOut()
+            }
+        }
+        lock.lock()
+        _listenerErrorCancellable?.cancel()
+        _listenerErrorCancellable = newCancellable
+        lock.unlock()
     }
 
     /// 익명 메모(휴지통 포함)를 새 Firestore impl로 이관. UserDefaults 마커로 기기+사용자별 1회.

--- a/Projects/Core/SyncImpl/Sources/NoOpAccountDeletionService.swift
+++ b/Projects/Core/SyncImpl/Sources/NoOpAccountDeletionService.swift
@@ -1,0 +1,16 @@
+//
+//  NoOpAccountDeletionService.swift
+//  NoteCard
+//
+
+import Foundation
+import SyncInterface
+
+/// Firebase 미설정 환경에서 사용. 호출 시 `missingFirebase` 던짐.
+public final class NoOpAccountDeletionService: AccountDeletionService, @unchecked Sendable {
+    public init() {}
+
+    public func deleteAccountAndAllData() async throws {
+        throw AuthError.missingFirebase
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/NoOpAccountSentinelService.swift
+++ b/Projects/Core/SyncImpl/Sources/NoOpAccountSentinelService.swift
@@ -1,0 +1,13 @@
+//
+//  NoOpAccountSentinelService.swift
+//  NoteCard
+//
+
+import Foundation
+import SyncInterface
+
+/// Firebase 미설정 환경에서 사용. 모든 메서드는 no-op.
+public final class NoOpAccountSentinelService: AccountSentinelService, @unchecked Sendable {
+    public init() {}
+    public func deleteSentinel() async throws {}
+}

--- a/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
+++ b/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
@@ -75,4 +75,36 @@ public enum SyncBootstrap {
             anonymousMemoRepository: anonymousMemoRepository
         )
     }
+
+    /// FirebaseApp 설정이 완료돼 있으면 데이터 정리 + Auth user 삭제를 함께 수행하는 서비스를,
+    /// 아니면 호출 시 missingFirebase 를 던지는 No-op 을 반환.
+    public static func makeAccountDeletionService(
+        authService: AuthService,
+        accountSentinelService: AccountSentinelService,
+        memoRepository: MemoRepository,
+        categoryRepository: CategoryRepository,
+        imageRepository: ImageRepository
+    ) -> AccountDeletionService {
+        guard FirebaseApp.app() != nil else {
+            return NoOpAccountDeletionService()
+        }
+        return FirebaseAccountDeletionService(
+            authService: authService,
+            accountSentinelService: accountSentinelService,
+            memoRepository: memoRepository,
+            categoryRepository: categoryRepository,
+            imageRepository: imageRepository
+        )
+    }
+
+    /// 계정의 sentinel doc 을 관리하는 서비스. 사인인 시 자동 생성·감시, cross-device 계정 삭제를
+    /// .removed 이벤트로 즉시 감지해 강제 signOut.
+    public static func makeAccountSentinelService(
+        authService: AuthService
+    ) -> AccountSentinelService {
+        guard FirebaseApp.app() != nil else {
+            return NoOpAccountSentinelService()
+        }
+        return FirebaseAccountSentinelService(authService: authService)
+    }
 }

--- a/Projects/Core/SyncInterface/Sources/AccountDeletionService.swift
+++ b/Projects/Core/SyncInterface/Sources/AccountDeletionService.swift
@@ -1,0 +1,18 @@
+//
+//  AccountDeletionService.swift
+//  NoteCard
+//
+
+import Foundation
+
+/// 사용자가 계정 삭제를 요청했을 때 클라우드 데이터 정리와 Auth user 삭제를 함께 수행하는 오케스트레이터.
+///
+/// `AuthService.deleteAccount` 는 Firebase Auth user 만 삭제 — Firestore 문서 / Storage 파일은 남는다.
+/// 본 서비스는 호출 시점 사용자의 모든 데이터 (메모 / 카테고리 / 이미지 + 바이너리) 를 먼저 삭제한 뒤
+/// Auth user 를 삭제한다. `requiresRecentLogin` 이 발생하면 Apple sign-in 으로 reauthenticate 후 재시도.
+public protocol AccountDeletionService: AnyObject, Sendable {
+
+    /// 모든 클라우드 데이터 + Auth user 삭제. 실패 시 부분 삭제 상태일 수 있으므로 호출자는
+    /// 다시 시도하도록 안내. reauth 가 필요하면 내부에서 Apple sign-in 시트를 띄움.
+    func deleteAccountAndAllData() async throws
+}

--- a/Projects/Core/SyncInterface/Sources/AccountSentinelService.swift
+++ b/Projects/Core/SyncInterface/Sources/AccountSentinelService.swift
@@ -1,0 +1,21 @@
+//
+//  AccountSentinelService.swift
+//  NoteCard
+//
+
+import Foundation
+
+/// 사용자 계정이 살아있음을 나타내는 sentinel 문서 (`users/<uid>/_meta/active`) 의 생성·감시·삭제를 담당.
+///
+/// 동작:
+/// - 사인인 시 sentinel 을 멱등 생성 + listener attach.
+/// - listener 가 .removed 를 감지하면 (= 다른 기기에서 계정 삭제) 강제 signOut → 익명 모드 전환.
+/// - 사인아웃 시 listener detach.
+/// - 본 기기에서 계정 삭제 진행 시 `deleteSentinel()` 을 사용. 호출 측 (예: AccountDeletionService) 이
+///   다른 데이터 삭제보다 먼저 호출하면 다른 기기들이 즉시 signOut 됨.
+public protocol AccountSentinelService: AnyObject, Sendable {
+
+    /// 현재 사용자의 sentinel 문서를 삭제. 호출 직전에 본 기기의 listener 가 자동 detach 되어
+    /// self-trigger (자기 listener 가 자기가 지운 sentinel 을 감지해 signOut 하는 사고) 를 방지.
+    func deleteSentinel() async throws
+}

--- a/Projects/Core/SyncInterface/Sources/AuthService.swift
+++ b/Projects/Core/SyncInterface/Sources/AuthService.swift
@@ -48,14 +48,16 @@ public enum AuthError: LocalizedError {
     case cancelled
     case invalidCredential
     case missingFirebase
+    case requiresRecentLogin
     case unknown(Error)
 
     public var errorDescription: String? {
         switch self {
-        case .cancelled:         return L10n.Sync.Auth.cancelled
-        case .invalidCredential: return L10n.Sync.Auth.invalidCredential
-        case .missingFirebase:   return L10n.Sync.Auth.unavailable
-        case .unknown:           return L10n.Sync.Auth.unknown
+        case .cancelled:           return L10n.Sync.Auth.cancelled
+        case .invalidCredential:   return L10n.Sync.Auth.invalidCredential
+        case .missingFirebase:     return L10n.Sync.Auth.unavailable
+        case .requiresRecentLogin: return L10n.Sync.Auth.requiresRecentLogin
+        case .unknown:             return L10n.Sync.Auth.unknown
         }
     }
 }

--- a/Projects/Feature/AccountDeletionFeature/Project.swift
+++ b/Projects/Feature/AccountDeletionFeature/Project.swift
@@ -2,10 +2,8 @@ import ProjectDescription
 import ProjectDescriptionHelpers
 
 let project = Project.feature(
-    .settingsFeature,
-    resources: ["Resources/**"],
+    .accountDeletionFeature,
     additionalDependencies: [
         .module(.syncInterface),
-        .module(.accountDeletionFeature),
     ]
 )

--- a/Projects/Feature/AccountDeletionFeature/Sources/AccountDeletionViewController.swift
+++ b/Projects/Feature/AccountDeletionFeature/Sources/AccountDeletionViewController.swift
@@ -1,0 +1,151 @@
+//
+//  AccountDeletionViewController.swift
+//  NoteCard
+//
+
+import Shared
+import SyncInterface
+import UIKit
+
+/// 계정 삭제 흐름을 담당하는 진입 VC.
+///
+/// 호출 측 (예: 계정 상세 화면) 은 본 VC 를 present 하기만 하면 됨:
+/// - 확인 alert 표시 → 사용자가 진행하면 `AccountDeletionService` 호출
+/// - 진행 중 ActivityIndicator 표시
+/// - 성공 시 dismiss (이후 `authStatePublisher` 가 nil emit → 호출 측 UI 자동 전환)
+/// - 실패 시 사용자 친화적 메시지로 alert + 재시도 가능 상태 유지
+///
+/// 추후 폴리시 여지: 진행률 화면, 데이터 항목 별 진행 단계, reauth 안내 화면 등을 본 VC 안에서 확장.
+public final class AccountDeletionViewController: UIViewController {
+
+    private let accountDeletionService: AccountDeletionService
+
+    private let dimmingView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .large)
+        indicator.color = .white
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+
+    private let progressLabel: UILabel = {
+        let label = UILabel()
+        label.text = L10n.Sync.AccountDeletion.inProgress
+        label.textColor = .white
+        label.font = .preferredFont(forTextStyle: .body)
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.isHidden = true
+        return label
+    }()
+
+    public init(accountDeletionService: AccountDeletionService) {
+        self.accountDeletionService = accountDeletionService
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .overFullScreen
+        modalTransitionStyle = .crossDissolve
+    }
+
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) { fatalError("init(coder:) is unavailable") }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+        setupLayout()
+    }
+
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        presentConfirmation()
+    }
+
+    // MARK: - Layout
+
+    private func setupLayout() {
+        view.addSubview(dimmingView)
+        view.addSubview(activityIndicator)
+        view.addSubview(progressLabel)
+
+        NSLayoutConstraint.activate([
+            dimmingView.topAnchor.constraint(equalTo: view.topAnchor),
+            dimmingView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            dimmingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            dimmingView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
+            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+
+            progressLabel.topAnchor.constraint(equalTo: activityIndicator.bottomAnchor, constant: 16),
+            progressLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 32),
+            progressLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -32)
+        ])
+    }
+
+    // MARK: - Flow
+
+    private func presentConfirmation() {
+        let alert = UIAlertController(
+            title: L10n.Account.deleteAccountConfirmTitle,
+            message: L10n.Account.deleteAccountConfirmMessage,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: L10n.Common.cancel, style: .cancel) { [weak self] _ in
+            self?.dismiss(animated: true)
+        })
+        alert.addAction(UIAlertAction(title: L10n.Account.deleteAccountProceed, style: .destructive) { [weak self] _ in
+            self?.startDeletion()
+        })
+        present(alert, animated: true)
+    }
+
+    private func startDeletion() {
+        setProgress(true)
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.accountDeletionService.deleteAccountAndAllData()
+                await MainActor.run { self.dismiss(animated: true) }
+            } catch AuthError.cancelled {
+                // reauth 단계에서 사용자가 Apple 시트 취소 — 흐름 종료, alert 없이 dismiss.
+                await MainActor.run { self.dismiss(animated: true) }
+            } catch let error as AuthError {
+                await MainActor.run {
+                    self.setProgress(false)
+                    self.presentError(message: error.errorDescription ?? L10n.Sync.Auth.unknown)
+                }
+            } catch {
+                await MainActor.run {
+                    self.setProgress(false)
+                    self.presentError(message: L10n.Sync.AccountDeletion.dataCleanupFailed)
+                }
+            }
+        }
+    }
+
+    private func setProgress(_ active: Bool) {
+        if active {
+            activityIndicator.startAnimating()
+            progressLabel.isHidden = false
+        } else {
+            activityIndicator.stopAnimating()
+            progressLabel.isHidden = true
+        }
+    }
+
+    private func presentError(message: String) {
+        let alert = UIAlertController(title: message, message: nil, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: L10n.Common.ok, style: .default) { [weak self] _ in
+            self?.dismiss(animated: true)
+        })
+        present(alert, animated: true)
+    }
+}

--- a/Projects/Feature/LoginFeature/Sources/LoginViewController.swift
+++ b/Projects/Feature/LoginFeature/Sources/LoginViewController.swift
@@ -100,6 +100,9 @@ public final class LoginViewController: UIViewController {
             rootView.errorLabel.text = L10n.Sync.Auth.unavailable
         case .invalidCredential:
             rootView.errorLabel.text = L10n.Sync.Auth.invalidCredential
+        case .requiresRecentLogin:
+            // 로그인 진입점에서는 발생하지 않는 케이스 (delete 흐름 전용). 방어적으로 unknown 메시지.
+            rootView.errorLabel.text = L10n.Sync.Auth.unknown
         case .unknown:
             rootView.errorLabel.text = L10n.Sync.Auth.unknown
         }

--- a/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
+++ b/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
@@ -3,6 +3,7 @@
 //  NoteCard
 //
 
+import AccountDeletionFeature
 import Combine
 import Shared
 import SyncInterface
@@ -13,12 +14,14 @@ import UIKit
 public final class AccountDetailViewController: UIViewController {
 
     private let authService: AuthService
+    private let accountDeletionService: AccountDeletionService
     private var cancellable: AnyCancellable?
 
     private lazy var rootView = self.view as! AccountDetailView
 
-    public init(authService: AuthService) {
+    public init(authService: AuthService, accountDeletionService: AccountDeletionService) {
         self.authService = authService
+        self.accountDeletionService = accountDeletionService
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -93,16 +96,8 @@ public final class AccountDetailViewController: UIViewController {
     }
 
     @objc private func deleteAccountTapped() {
-        let alert = UIAlertController(
-            title: L10n.Account.deleteAccountConfirmTitle,
-            message: L10n.Account.deleteAccountConfirmMessage,
-            preferredStyle: .alert
-        )
-        alert.addAction(UIAlertAction(title: L10n.Common.cancel, style: .cancel))
-        alert.addAction(UIAlertAction(title: L10n.Account.deleteAccountProceed, style: .destructive) { [weak self] _ in
-            self?.performDeleteAccount()
-        })
-        present(alert, animated: true)
+        let deletionVC = AccountDeletionViewController(accountDeletionService: accountDeletionService)
+        present(deletionVC, animated: true)
     }
 
     private func performSignOut() {
@@ -113,22 +108,6 @@ public final class AccountDetailViewController: UIViewController {
             do {
                 try await self.authService.signOut()
                 // authStatePublisher가 nil emit → 미로그인 상태로 자동 전환
-            } catch {
-                await MainActor.run { self.showAlert(title: L10n.Sync.Auth.unknown) }
-            }
-        }
-    }
-
-    private func performDeleteAccount() {
-        setLoading(true)
-        Task { [weak self] in
-            guard let self else { return }
-            defer { Task { @MainActor in self.setLoading(false) } }
-            do {
-                try await self.authService.deleteAccount()
-                // authStatePublisher가 nil emit → 미로그인 상태로 자동 전환
-            } catch let error as AuthError {
-                await MainActor.run { self.showAlert(title: error.errorDescription ?? L10n.Sync.Auth.unknown) }
             } catch {
                 await MainActor.run { self.showAlert(title: L10n.Sync.Auth.unknown) }
             }
@@ -152,6 +131,9 @@ public final class AccountDetailViewController: UIViewController {
             showAlert(title: L10n.Sync.Auth.unavailable)
         case .invalidCredential:
             showAlert(title: L10n.Sync.Auth.invalidCredential)
+        case .requiresRecentLogin:
+            // 로그인 진입점에선 발생하지 않는 케이스 (delete 흐름 전용). 방어적으로 unknown 메시지.
+            showAlert(title: L10n.Sync.Auth.unknown)
         case .unknown:
             showAlert(title: L10n.Sync.Auth.unknown)
         }

--- a/Projects/Feature/SettingsFeature/Sources/SettingsViewController.swift
+++ b/Projects/Feature/SettingsFeature/Sources/SettingsViewController.swift
@@ -19,6 +19,7 @@ public final class SettingsViewController: UITableViewController {
     private let categoryRepository: CategoryRepository
     private let analytics: Analytics
     private let authService: AuthService
+    private let accountDeletionService: AccountDeletionService
     private let makeTrashViewController: () -> UIViewController
 
     public init(
@@ -26,12 +27,14 @@ public final class SettingsViewController: UITableViewController {
         categoryRepository: CategoryRepository,
         analytics: Analytics,
         authService: AuthService,
+        accountDeletionService: AccountDeletionService,
         makeTrashViewController: @escaping () -> UIViewController
     ) {
         self.memoRepository = memoRepository
         self.categoryRepository = categoryRepository
         self.analytics = analytics
         self.authService = authService
+        self.accountDeletionService = accountDeletionService
         self.makeTrashViewController = makeTrashViewController
         super.init(nibName: nil, bundle: nil)
     }
@@ -389,7 +392,10 @@ extension SettingsViewController {
         
         switch indexPath {
         case IndexPath(row: 0, section: 0):
-            targetVC = AccountDetailViewController(authService: authService)
+            targetVC = AccountDetailViewController(
+                authService: authService,
+                accountDeletionService: accountDeletionService
+            )
         case IndexPath(row: 0, section: 1):
             targetVC = ThemeColorPickingViewController()
         case IndexPath(row: 1, section: 1):

--- a/Tuist/ProjectDescriptionHelpers/ModulePaths.swift
+++ b/Tuist/ProjectDescriptionHelpers/ModulePaths.swift
@@ -23,10 +23,11 @@ public enum Module: String {
     case analyticsImpl      = "AnalyticsImpl"
     case syncInterface      = "SyncInterface"
     case syncImpl           = "SyncImpl"
-    case homeFeature        = "HomeFeature"
-    case memoFeature        = "MemoFeature"
-    case settingsFeature    = "SettingsFeature"
-    case loginFeature       = "LoginFeature"
+    case homeFeature             = "HomeFeature"
+    case memoFeature             = "MemoFeature"
+    case settingsFeature         = "SettingsFeature"
+    case loginFeature            = "LoginFeature"
+    case accountDeletionFeature  = "AccountDeletionFeature"
 
     public var layer: Layer {
         switch self {
@@ -34,7 +35,7 @@ public enum Module: String {
         case .data:   return .data
         case .designSystem, .shared, .analyticsInterface, .analyticsImpl, .syncInterface, .syncImpl:
             return .core
-        case .homeFeature, .memoFeature, .settingsFeature, .loginFeature:
+        case .homeFeature, .memoFeature, .settingsFeature, .loginFeature, .accountDeletionFeature:
             return .feature
         }
     }


### PR DESCRIPTION
## 배경
- 기존 `AuthService.deleteAccount` 가 Firebase Auth user 만 삭제 — Firestore 문서 / Storage 파일이 클라우드에 남음. 한국 개인정보보호법 (PIPA) / App Store 정책 (2022년 6월부터 계정 삭제 기능 필수) 모두 미충족.
- 한쪽 기기에서 계정을 삭제해도 다른 기기는 token 만료 (~1시간) 까지 로그인 상태로 남아 stale UI 노출.
- 배포 직전 critical 이슈로 한 PR 에서 (1) 실제 데이터 정리 (2) cross-device 즉시 logout (3) UI 흐름 통합 마무리.

## 변경사항
- `AuthError.requiresRecentLogin` 케이스 추가.
  - `FirebaseAuthService.deleteAccount` 가 NSError(requiresRecentLogin) 를 typed error 로 매핑.
  - LoginViewController switch 에 새 케이스 처리.
- `AccountSentinelService` 신설 — `users/<uid>/_meta/active` sentinel doc 관리.
  - 사인인 시 멱등 생성 + listener attach.
  - listener 가 .removed 감지 시 강제 signOut → 익명 모드 전환.
  - self-trigger 방지: 본 기기에서 sentinel 삭제 직전 listener detach + isLocalDeletionInProgress 플래그.
- `AccountDeletionService` 신설 — reauth → sentinel 삭제 → 데이터 삭제 → Auth user 삭제 순.
  - reauth 가 가장 먼저라 사용자가 Apple 시트 취소 시 아무것도 지워지지 않음.
  - sentinel 을 데이터보다 먼저 삭제해 다른 기기들이 즉시 signOut.
  - 데이터 삭제는 기존 Repository 메서드 활용 (memos · images · categories 순회).
- Firestore Memo · Category Router 가 listener PERMISSION_DENIED 감지 시 강제 signOut.
  - sentinel 기반 즉시 감지가 우선 경로. 본 변경은 token 만료 등 fallback.
- `AccountDeletionFeature` 모듈 신설 — LoginFeature 와 대칭적 위치.
  - `AccountDeletionViewController`: overFullScreen modal. 확인 alert → progress 표시 → 성공 dismiss / 실패 alert.
- `SettingsFeature` 가 AccountDeletionFeature 의존성 추가.
  - AccountDetailViewController 의 deleteAccountTapped 가 inline 로직 대신 새 VC 를 present.
- `SceneDelegate` 가 authStatePublisher 구독 — sign-out 이벤트 발생 시 rootViewController 를 새 MainTabBar 로 crossfade 교체.
  - dropFirst 로 구독 시점 상태는 skip, filter(nil) 로 sign-in 이벤트는 무시.
  - 다른 기기 계정 삭제 → sentinel listener → signOut 체인이 발생했을 때 modal · navigation 상태 잃고 홈에서 깨끗하게 시작.
- `AppEnvironment` / `MainTabBarController` / `SyncBootstrap` 결선.
- `L10n.Sync.AccountDeletion.*` + `L10n.Sync.Auth.requiresRecentLogin` 한·영 5개 키 추가.

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` 통과 확인.
- `tuist test` 통과 확인.
- 시뮬레이터 두 대로 수동 확인 (사용자 검증 완료):
  - 한쪽에서 계정 삭제 → Apple 시트 → 데이터 정리 → 완료 dismiss → 홈 자동 전환.
  - 다른 기기: sentinel listener `.removed` 즉시 받아 signOut → 홈 화면 자동 전환.
  - 한쪽에서 reauth 취소 → 데이터 · 계정 모두 보존된 상태로 흐름 종료.
  - 사용자 본인 signOut (AccountDetail 의 Sign Out 버튼) → 홈 자동 전환.

## 리뷰 노트
- **Firestore Security Rules**: 기존 `match /users/{userID}/{document=**}` 와일드카드가 `_meta/active` 도 자동 커버. 추가 룰 변경 불필요.
- **PIPA / App Store 대응**: 본 PR 머지 후 `user.delete()` 만 호출하던 옛 흐름이 완전히 대체됨.
- **self-trigger 방지**: 본 기기는 sentinel 삭제 진행 시 자기 listener 를 먼저 detach. 만약 그 사이에 race 가 발생해도 isLocalDeletionInProgress 플래그가 listener 콜백을 suppress.
- **알려진 후속 작업**:
  - 사인인 이관 후 익명 데이터 / Documents 폴더 캐시 정리 (별도 PR).
  - 원격 삭제 시 로컬 이미지 파일 정리 (별도 PR).
  - 홈 진입 시 로딩 인디케이터 (별도 PR).
- **무관한 commit 없음**: 6개 commit 모두 계정 삭제 / cross-device propagation / 홈 자동 전환의 동일 스토리.
