### PR TITLE
fix(sync): Firestore 메모 정렬이 사용자 설정 반영하도록 수정

### DIFF
--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
@@ -44,6 +44,14 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
     private var snapshotDTOByID: [UUID: FirestoreMemo] = [:]
     private var listenerRegistration: ListenerRegistration?
 
+    /// 사용자가 설정 화면에서 고른 정렬 기준. Core Data impl 과 동일한 UserDefaults 키를 공유해
+    /// 두 backend 동작이 일치하도록 함.
+    @UserDefault<String>(key: .orderCriterion, defaultValue: OrderCriterion.modificationDate.rawValue)
+    private var orderCriterion: String
+
+    @UserDefault<Bool>(key: .isOrderAscending, defaultValue: false)
+    private var isOrderAscending: Bool
+
     public init(
         userID: String,
         categoryResolver: CategoryRepository,
@@ -170,7 +178,7 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
     public func getAllMemos() async throws -> [Memo] {
         let dtos = allSnapshotDTOs().filter { !$0.isInTrash }
         let memos = try await resolveAll(dtos)
-        return Self.sortByModificationDateDesc(memos)
+        return sortByPreference(memos)
     }
 
     public func getAllMemos(inCategory category: Domain.Category?) async throws -> [Memo] {
@@ -183,13 +191,13 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
             }
         }
         let memos = try await resolveAll(dtos)
-        return Self.sortByModificationDateDesc(memos)
+        return sortByPreference(memos)
     }
 
     public func getAllMemosInTrash() async throws -> [Memo] {
         let dtos = allSnapshotDTOs().filter { $0.isInTrash }
         let memos = try await resolveAll(dtos)
-        return Self.sortByModificationDateDesc(memos)
+        return sortByPreference(memos)
     }
 
     public func searchMemo(searchText: String, inCategory category: Domain.Category?) async throws -> [Memo] {
@@ -203,13 +211,13 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
             return hit
         }
         let memos = try await resolveAll(dtos)
-        return Self.sortByModificationDateDesc(memos)
+        return sortByPreference(memos)
     }
 
     public func getFavoriteMemos() async throws -> [Memo] {
         let dtos = allSnapshotDTOs().filter { $0.isFavorite && !$0.isInTrash }
         let memos = try await resolveAll(dtos)
-        return Self.sortByModificationDateDesc(memos)
+        return sortByPreference(memos)
     }
 
     // MARK: - Create
@@ -466,7 +474,20 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
         return categories
     }
 
-    private static func sortByModificationDateDesc(_ memos: [Memo]) -> [Memo] {
-        memos.sorted { $0.modificationDate > $1.modificationDate }
+    /// 사용자 설정 (UserDefaults) 의 orderCriterion / isOrderAscending 을 반영해 정렬.
+    /// Core Data impl 의 NSSortDescriptor(key:ascending:) 와 동일한 결과를 내도록 맞춤.
+    private func sortByPreference(_ memos: [Memo]) -> [Memo] {
+        let criterion = OrderCriterion(rawValue: orderCriterion) ?? .modificationDate
+        let ascending = isOrderAscending
+        switch criterion {
+        case .modificationDate:
+            return memos.sorted {
+                ascending ? $0.modificationDate < $1.modificationDate : $0.modificationDate > $1.modificationDate
+            }
+        case .creationDate:
+            return memos.sorted {
+                ascending ? $0.creationDate < $1.creationDate : $0.creationDate > $1.creationDate
+            }
+        }
     }
 }


### PR DESCRIPTION
## 배경
- 로그인 상태 (Firestore backend) 에서 설정 화면의 정렬 기준 설정이 무시되고 항상 `modificationDate desc` 로 표시되던 버그.
- Core Data backend (익명 모드) 는 `@UserDefault` 로 `orderCriterion` / `isOrderAscending` 을 직접 읽어 적용 — Firestore impl 만 누락.
- `MemoRepository` protocol 의 `getAllMemos` / `getAllMemos(inCategory:)` / `getAllMemosInTrash` 등이 order 파라미터를 받지 않는 설계라 각 impl 이 UserDefaults 를 직접 읽어야 일관됨.

## 변경사항
- `MemoRepositoryFirestoreImpl` 에 `@UserDefault` 두 개 추가 — `orderCriterion` (String), `isOrderAscending` (Bool). Core Data impl 과 동일 키 공유.
- 하드코딩된 `sortByModificationDateDesc(_:)` 제거, `sortByPreference(_:)` instance method 로 교체.
  - `OrderCriterion` (`.modificationDate` / `.creationDate`) 분기 + 오름차 / 내림차 분기.
- 5곳 호출처 (`getAllMemos` / `getAllMemos(inCategory:)` / `getAllMemosInTrash` / `searchMemo` / `getFavoriteMemos`) 모두 새 메서드 사용.

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` 통과 확인.
- `tuist test` 통과 확인.
- 사인인 상태 시뮬레이터 수동 확인 (사용자 검증 완료):
  - 설정 → 표시 순서 → 수정일 / 내림차순 → 홈에서 최신 수정 메모가 맨 위.
  - 오름차순으로 토글 → 오래된 수정 메모가 맨 위.
  - 정렬 기준 생성일로 변경 → 생성 순으로 정렬.
  - 휴지통 / 즐겨찾기 / 카테고리별 / 검색 결과 모두 동일하게 적용.

## 리뷰 노트
- `MemoRepository` protocol 시그니처를 손대지 않아 다른 모듈 영향 0.
- in-memory snapshot 정렬이라 어느 기준이든 비용 동일.
- Category 는 protocol 이 이미 order 파라미터를 받아서 양쪽 impl 이 같이 정상 동작 중 — 본 PR 범위 밖.
