### PR TITLE
feat(home): 진입 시 로딩 인디케이터 + FirebaseAuthService.currentUser 동기 노출

### DIFF
--- a/NoteCard/Presentation/HomeView/HomeView.swift
+++ b/NoteCard/Presentation/HomeView/HomeView.swift
@@ -90,7 +90,14 @@ final class HomeView: UIView {
     }
     
     let homeCollectionView: WispableCollectionView
-    
+
+    let loadingIndicator: UIActivityIndicatorView = {
+        let view = UIActivityIndicatorView(style: .medium)
+        view.hidesWhenStopped = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
     init() {
         let sectionProvider: UICollectionViewCompositionalLayoutSectionProvider = { sectionIndex, env in
             switch sectionIndex {
@@ -135,14 +142,18 @@ final class HomeView: UIView {
     
     private func setupViewHierarchy() {
         self.addSubview(homeCollectionView)
+        self.addSubview(loadingIndicator)
     }
-    
+
     private func setupLayoutConstraints() {
         NSLayoutConstraint.activate([
             homeCollectionView.topAnchor.constraint(equalTo: self.topAnchor, constant: 0),
             homeCollectionView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 0),
             homeCollectionView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 0),
             homeCollectionView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: 0),
+
+            loadingIndicator.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            loadingIndicator.centerYAnchor.constraint(equalTo: self.centerYAnchor),
         ])
     }
     

--- a/NoteCard/Presentation/HomeView/HomeViewController.swift
+++ b/NoteCard/Presentation/HomeView/HomeViewController.swift
@@ -52,7 +52,8 @@ class HomeViewController: UIViewController {
     private var favoriteMemos: [Memo] = []
     private var allMemos: [Memo] = []
     private var diffableDataSource: DiffableDataSource!
-    
+
+    private var initialLoadCompleted = false
     private var cancellables: Set<AnyCancellable> = []
 
     private let environment: AppEnvironment
@@ -96,9 +97,20 @@ class HomeViewController: UIViewController {
 
         setupNaviBar()
         setupDiffableDataSource()
+        if environment.authService.currentUser != nil {
+            homeView.loadingIndicator.startAnimating()
+            Task { [weak self] in
+                try? await Task.sleep(nanoseconds: 3_000_000_000)
+                self?.completeInitialLoad()
+            }
+        } else {
+            initialLoadCompleted = true
+        }
+
         Task {
             try await fetchData()
             applySnapshot()
+            completeInitialLoadIfDataArrived()
         }
         setupDelegates()
         bind()
@@ -283,9 +295,24 @@ class HomeViewController: UIViewController {
                 Task {
                     try await self.fetchData()
                     self.applySnapshot()
+                    self.completeInitialLoadIfDataArrived()
                 }
             }
             .store(in: &cancellables)
+    }
+
+    private func completeInitialLoadIfDataArrived() {
+        guard !initialLoadCompleted else { return }
+        let hasData = !allMemos.isEmpty || !categories.isEmpty || !favoriteMemos.isEmpty
+        if hasData {
+            completeInitialLoad()
+        }
+    }
+
+    private func completeInitialLoad() {
+        guard !initialLoadCompleted else { return }
+        initialLoadCompleted = true
+        homeView.loadingIndicator.stopAnimating()
     }
     
     @objc private func onHeaderButtonTapped(_ sender: UIButton) {

--- a/Projects/Core/SyncImpl/Sources/FirebaseAuthService.swift
+++ b/Projects/Core/SyncImpl/Sources/FirebaseAuthService.swift
@@ -29,6 +29,10 @@ public final class FirebaseAuthService: NSObject, AuthService, @unchecked Sendab
 
     public override init() {
         super.init()
+        // Firebase listener 첫 fire 가 비동기라 init 직후 currentUser 가 nil. 캐시 사용자를 미리 시드.
+        if let user = Auth.auth().currentUser {
+            authStateSubject.send(Self.toAuthUser(user))
+        }
         attachAuthStateListener()
     }
 
@@ -87,7 +91,9 @@ public final class FirebaseAuthService: NSObject, AuthService, @unchecked Sendab
     private func attachAuthStateListener() {
         stateHandle = Auth.auth().addStateDidChangeListener { [weak self] _, user in
             guard let self else { return }
-            self.authStateSubject.send(user.map(Self.toAuthUser))
+            let newValue = user.map(Self.toAuthUser)
+            guard self.authStateSubject.value != newValue else { return }
+            self.authStateSubject.send(newValue)
         }
     }
 


### PR DESCRIPTION
## 배경
- 사인인 상태에서 앱 첫 진입 시 홈 화면이 0.5~1초 빈 상태로 노출되어 broken UI 인상을 줌. 그 구간에 spinner 표시.
- 구현 과정에서 `FirebaseAuthService.currentUser` 가 init 직후 잠깐 nil 로 노출되던 추상화 레이어 문제도 함께 해결 — Firebase Auth 의 첫 listener fire 가 비동기인데 우리 subject 가 그걸 기다리느라 spinner 트리거 조건이 통과 안 되던 게 원인.

## 변경사항
- `FirebaseAuthService` 초기화 시점 보강.
  - `Auth.auth().currentUser` 동기 읽기 → `authStateSubject` 즉시 시드. init 직후 어디서든 `currentUser` 가 캐시 사용자 반환.
  - `addStateDidChangeListener` 가 동일 값으로 fire 하면 emit skip — Router 가 Firestore impl 중복 생성 안 함.
- `HomeView` 에 가운데 `UIActivityIndicatorView` 추가.
- `HomeViewController` 가 진입 시 spinner 토글.
  - 사인인 상태에서만 spinner 시작 (익명 모드는 Core Data 즉시 반환이라 불필요).
  - `fetchData` 또는 debounce sink 가 데이터 반영 시 stop.
  - 3초 안전망 timeout — 빈 사용자 / 네트워크 이슈로도 무한 회전 방지.

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` 통과 확인.
- `tuist test` 통과 확인.
- 시뮬레이터 수동 확인:
  - 사인인 상태에서 앱 강제 종료 후 재실행 → 홈 진입 시 spinner 가운데 회전 → 데이터 도착 시 사라짐.
  - 익명 모드: spinner 안 보임.
  - 사인인 + 메모 0개 사용자: 3초 후 spinner 멈춤.

## 리뷰 노트
- `FirebaseAuthService` 변경은 spinner 외에도 부수 효과 있음 — Router 들이 "초기 익명 setup → 즉시 Firestore 로 swap" 이중 작업 사라짐. 사인인 상태 첫 부팅이 약간 더 깔끔.
- `HomeViewController` 의 fetchData 가 `try await` 인데 에러 시 처리 안 함 (기존 동작 유지). 에러 시엔 spinner 가 3초 fallback 으로 멈춤.
- spinner 가 도는 동안 collection view 가 비어 보이는 이유 — `applySnapshot` 이 아직 호출 전이라 섹션 / 셀 0개 + collection view 배경 투명. 의도된 동작.
