### PR TITLE
feat(sync): 메모 영구 삭제 시 cloud sub-collection + 로컬 파일 정리 + dismiss-first

### DIFF
--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -517,16 +517,19 @@ extension PopupCardViewController {
         let cancelAction = UIAlertAction(title: L10n.Common.cancel, style: .cancel)
         let deleteAction = UIAlertAction(title: L10n.Common.delete, style: .destructive) { [weak self] action in
             guard let self else { return }
+            let memo = self.memo
+            let env = self.environment
+            let isInTrash = memo.isInTrash
+            self.dismiss(animated: true)
             Task {
                 do {
-                    if self.memo.isInTrash {
-                        try await self.environment.memoRepository.deleteMemo(self.memo)
-                        self.environment.analytics.log(.memoDeleted(count: 1))
+                    if isInTrash {
+                        try await env.memoRepository.deleteMemo(memo)
+                        env.analytics.log(.memoDeleted(count: 1))
                     } else {
-                        try await self.environment.memoRepository.moveToTrash(self.memo)
-                        self.environment.analytics.log(.memoMovedToTrash(count: 1))
+                        try await env.memoRepository.moveToTrash(memo)
+                        env.analytics.log(.memoMovedToTrash(count: 1))
                     }
-                    self.dismiss(animated: true)
                 } catch {
                     print(error.localizedDescription)
                 }

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
@@ -173,18 +173,36 @@ public final class ImageRepositoryFirestoreImpl: ImageRepository, @unchecked Sen
     }
 
     private func emitImageChanges(_ snapshot: QuerySnapshot, memoID: UUID) {
-        var hasAdds = false, hasMods = false, hasRems = false
+        var hasAddedImages = false
+        var hasModifiedImages = false
+        var hasRemovedImages = false
         for change in snapshot.documentChanges {
             switch change.type {
-            case .added: hasAdds = true
-            case .modified: hasMods = true
-            case .removed: hasRems = true
+            case .added:
+                hasAddedImages = true
+            case .modified:
+                hasModifiedImages = true
+            case .removed:
+                hasRemovedImages = true
+                if let dto = try? change.document.data(as: FirestoreMemoImage.self),
+                   let info = dto.toDomain() {
+                    deleteLocalImageFiles(for: info)
+                }
             }
         }
         // UI는 종류 무관하게 재조회하므로 변경 종류별로 한 번씩 coarse emit.
-        if hasAdds { imageUpdatedSubject.send(.create(memoID: memoID)) }
-        if hasMods { imageUpdatedSubject.send(.update(memoID: memoID)) }
-        if hasRems { imageUpdatedSubject.send(.delete(memoID: memoID)) }
+        if hasAddedImages { imageUpdatedSubject.send(.create(memoID: memoID)) }
+        if hasModifiedImages { imageUpdatedSubject.send(.update(memoID: memoID)) }
+        if hasRemovedImages { imageUpdatedSubject.send(.delete(memoID: memoID)) }
+    }
+
+    private func deleteLocalImageFiles(for info: MemoImageInfo) {
+        if let originalURL = try? ImageFileHandler.getFileURL(for: info, thumbnail: false) {
+            try? ImageFileHandler.delete(at: originalURL)
+        }
+        if let thumbnailURL = try? ImageFileHandler.getFileURL(for: info, thumbnail: true) {
+            try? ImageFileHandler.delete(at: thumbnailURL)
+        }
     }
 
     // MARK: - Update

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
@@ -4,6 +4,7 @@
 //
 
 import Combine
+import Data
 import Domain
 import FirebaseFirestore
 import Foundation
@@ -129,6 +130,9 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
             case .removed:
                 snapshotDTOByID.removeValue(forKey: id)
                 deletedIDs.append(id)
+                if let url = try? ImageFileHandler.getDirectory(for: id) {
+                    try? FileManager.default.removeItem(at: url)
+                }
             }
         }
         snapshotLock.unlock()
@@ -270,16 +274,34 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
     // MARK: - Hard delete
 
     public func deleteMemo(_ memo: Memo) async throws {
+        try await deleteImages(of: memo)
         try await collection.document(memo.memoID.uuidString).delete()
-        // NOTE: 로컬 이미지 파일 정리는 본 PR 범위 밖 (이미지 Repository가 Firebase Storage로 옮길 때 함께).
     }
 
     public func deleteMemos(_ memos: [Memo]) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for memo in memos {
+                group.addTask { try await self.deleteImages(of: memo) }
+            }
+            try await group.waitForAll()
+        }
         let batch = firestore.batch()
         for memo in memos {
             batch.deleteDocument(collection.document(memo.memoID.uuidString))
         }
         try await batch.commit()
+    }
+
+    /// Firestore parent doc 삭제는 sub-collection 을 자동 정리하지 않으므로 명시 순회.
+    private func deleteImages(of memo: Memo) async throws {
+        let images = (try? await imageResolver.getAllImageInfo(for: memo)) ?? []
+        guard !images.isEmpty else { return }
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for image in images {
+                group.addTask { try? await self.imageResolver.deleteImage(image) }
+            }
+            try await group.waitForAll()
+        }
     }
 
     // MARK: - Restore


### PR DESCRIPTION
## 배경
- Firestore parent doc 을 삭제해도 sub-collection 의 doc 들은 자동으로 안 지워지는 잘 알려진 quirk 때문에, `deleteMemo` 가 memo doc 만 삭제하던 동안 `users/<uid>/memos/<memoID>/images/<imageID>` 와 Storage 의 이미지 / 썸네일 바이너리, 그리고 `Documents/<memoID>/` 의 로컬 파일이 orphan 으로 누적.
- PopupCard 의 영구 삭제 흐름은 deleteMemo 가 완료된 후에야 dismiss — 이미지 listener 가 활성이라 그 사이 이미지가 하나씩 사라지는 시각적 깜빡임 발생.

## 변경사항
- `MemoRepositoryFirestoreImpl.deleteMemo` / `deleteMemos` 확장.
  - `imageResolver.deleteImage` 를 통해 메모의 모든 이미지 (Storage 바이너리 + Firestore image doc + 로컬 파일) 를 먼저 정리한 뒤 memo doc 삭제.
  - 한 메모의 이미지들 / 여러 메모의 이미지들 모두 `TaskGroup` 으로 병렬 처리.
- `MemoRepositoryFirestoreImpl.handleSnapshot` 의 `.removed` 분기에서 `Documents/<memoID>/` 디렉터리 삭제.
  - 본 기기 / 다른 기기의 영구 삭제 모두 listener fire 를 통해 로컬 정리 수행.
- `ImageRepositoryFirestoreImpl.emitImageChanges` 의 `.removed` 분기에서 단일 이미지 로컬 파일 삭제.
  - PopupCard 활성 시 cross-device 이미지 단일 삭제도 즉시 로컬 반영.
  - `hasAdds` / `hasMods` / `hasRems` → `hasAddedImages` / `hasModifiedImages` / `hasRemovedImages` 로 풀어쓰고 각자 라인 분리.
- `PopupCardViewController.askDeleting` 의 deleteAction.
  - 사용자 확인 직후 `dismiss(animated: true)` 부터 호출, 삭제는 백그라운드 `Task` 에서 수행.
  - VC 캡처 제거 — memo / env / isInTrash 를 로컬 캡처해 VC 가 해제돼도 작업 계속.

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` 통과 확인.
- `tuist test` 통과 확인.
- 사인인 상태 시뮬레이터 수동 확인 (사용자 검증 완료):
  - 휴지통 메모 PopupCard 열고 우상단 메뉴 → 삭제 → 즉시 dismiss → 휴지통 목록에서 메모 사라짐.
  - Firebase Console 의 Firestore 에서 해당 memo doc + images sub-collection 모두 삭제됐는지 확인.
  - Firebase Console 의 Storage 에서 해당 메모 폴더의 이미지 / 썸네일 모두 삭제됐는지 확인.
  - 시뮬레이터 sandbox 의 `Documents/<memoID>/` 디렉터리 사라졌는지 확인.
  - 휴지통에서 다중 선택 영구 삭제 시 동일 동작.
  - 다른 기기에서 메모 영구 삭제 시 본 기기의 로컬 디렉터리 사라짐.

## 리뷰 노트
- 이번 변경으로 `deleteMemo` 가 외부 통신 (Storage / Firestore) 을 N+1 회 (N=이미지 수) 호출. 본 기기는 dismiss-first 라 사용자 체감 없음. 자동 휴지통 청소 (SceneDelegate 의 14일 룰) 도 백그라운드라 영향 없음.
- 본 PR 의 cloud 정리 효과로 [#69 (계정 삭제)](https://github.com/nolanMinsung/NoteCard/pull/69) 의 `FirebaseAccountDeletionService` 가 memo 별 이미지 순회를 별도로 안 해도 되는 단순화 여지가 생겼지만, 정확성에 영향 없는 리팩토링이라 본 PR 범위 밖.
- 다중 영구 삭제 시 로딩 modal 은 본 PR 에 포함하지 않음 — 백그라운드 처리 + 목록 자동 갱신만으로 v1 충분. generic 한 progress modal 컴포넌트는 추후 별도 작업 (`DesignSystem` 도입 예정).
- 사용자 명명 규칙 피드백 반영 — 약어 (`hasRems` 등) 풀어쓰기.
