### PR TITLE
chore(l10n): 인증 흐름 안내 문구 톤 개선 + AuthError 정리

### DIFF
--- a/Projects/Core/Shared/Resources/Localizable.xcstrings
+++ b/Projects/Core/Shared/Resources/Localizable.xcstrings
@@ -1820,23 +1820,6 @@
         }
       }
     },
-    "sync.auth.requiresRecentLogin": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "For security, please sign in again to delete your account."
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "보안을 위해 계정 삭제 전에 다시 로그인이 필요해요."
-          }
-        }
-      }
-    },
     "sync.accountDeletion.inProgress": {
       "extractionState": "manual",
       "localizations": {
@@ -2353,13 +2336,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sign in with Apple to sync your memos across your devices. You can start from Settings → Account."
+            "value": "Sign in with your Apple ID to view your memos on other devices.\nYou can start from Settings → Account."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apple로 로그인하면 메모를 다른 기기와 동기화할 수 있어요. 설정 → 계정에서 시작하세요."
+            "value": "Apple ID로 로그인하면 이 기기의 메모를 다른 기기에서도 볼 수 있어요.\n'설정' 탭의 계정 페이지에서 시작할 수 있어요."
           }
         }
       }
@@ -2391,8 +2374,8 @@
     "account.signInPrompt": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Sign in with Apple to sync your memos across your devices." } },
-        "ko": { "stringUnit": { "state": "translated", "value": "Apple로 로그인하면 메모를 다른 기기와 동기화할 수 있어요." } }
+        "en": { "stringUnit": { "state": "translated", "value": "Sign in with your Apple ID to view your memos on other devices.\nInitial setup may take a moment." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "Apple ID로 로그인하면 이 기기의 메모를 다른 기기에서도 볼 수 있어요.\n처음에는 초기 설정에 시간이 조금 걸릴 수도 있어요." } }
       }
     },
     "account.syncStatusLabel": {
@@ -2461,8 +2444,8 @@
     "account.signOutConfirmMessage": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "This device stops syncing. Your memos remain safe in your account." } },
-        "ko": { "stringUnit": { "state": "translated", "value": "이 기기에서 동기화가 멈춰요. 계정의 메모는 계속 안전하게 보관돼요." } }
+        "en": { "stringUnit": { "state": "translated", "value": "Signing out switches to local mode, showing only memos that aren't synced.\nSign back in to see your synced memos again." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "로그아웃하면 동기화되지 않은 메모만 보이는 '로컬 모드'로 전환돼요.\n다시 로그인하면 동기화된 메모들을 볼 수 있어요." } }
       }
     },
     "account.deleteAccount": {
@@ -2482,8 +2465,8 @@
     "account.deleteAccountConfirmMessage": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "This cannot be undone. Your account and all synced data will be permanently deleted." } },
-        "ko": { "stringUnit": { "state": "translated", "value": "이 작업은 되돌릴 수 없어요. 계정과 모든 동기화 데이터가 영구 삭제돼요." } }
+        "en": { "stringUnit": { "state": "translated", "value": "This cannot be undone. Your account and all synced data will be permanently deleted.\nYou'll be asked to sign in with Apple again for security." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이 작업은 되돌릴 수 없어요. 계정과 모든 동기화 데이터가 영구 삭제돼요.\n보안을 위해 Apple ID로 다시 로그인을 요청해요." } }
       }
     },
     "account.deleteAccountProceed": {

--- a/Projects/Core/Shared/Sources/Localization/L10n.swift
+++ b/Projects/Core/Shared/Sources/Localization/L10n.swift
@@ -134,7 +134,6 @@ public enum L10n {
             public static let invalidCredential = "sync.auth.invalidCredential".localized()
             public static let unavailable = "sync.auth.unavailable".localized()
             public static let unknown = "sync.auth.unknown".localized()
-            public static let requiresRecentLogin = "sync.auth.requiresRecentLogin".localized()
         }
 
         public enum AccountDeletion {

--- a/Projects/Core/SyncImpl/Sources/FirebaseAccountDeletionService.swift
+++ b/Projects/Core/SyncImpl/Sources/FirebaseAccountDeletionService.swift
@@ -9,9 +9,9 @@ import SyncInterface
 
 /// Repository 추상화를 통해 데이터 정리를 수행하는 `AccountDeletionService` 구현.
 ///
-/// 순서: reauth → 데이터 삭제 → Auth user 삭제. reauth 를 가장 먼저 두는 이유는
-/// (1) 사용자가 Apple 시트를 취소했을 때 아무것도 지워지지 않은 깨끗한 상태로 종료되고
-/// (2) reauth 후 token 이 신선하므로 마지막 `user.delete()` 가 `requiresRecentLogin` 없이 통과하기 때문.
+/// 순서: reauth → 데이터 삭제 → Auth user 삭제. reauth 를 가장 먼저 두는 이유는 사용자가
+/// Apple 시트를 취소했을 때 아무것도 지워지지 않은 깨끗한 상태로 종료되고, reauth 후 token 이
+/// 신선해 마지막 `user.delete()` 가 안전하게 통과하기 때문.
 ///
 /// 데이터 삭제는 기존 Repository 메서드를 그대로 사용 — 호출 시점 활성 impl (보통 Firestore)
 /// 의 `deleteMemo` / `deleteImage` / `deleteCategory` 가 각각의 클라우드 / Storage 부수효과를 책임진다.

--- a/Projects/Core/SyncImpl/Sources/FirebaseAuthService.swift
+++ b/Projects/Core/SyncImpl/Sources/FirebaseAuthService.swift
@@ -79,8 +79,6 @@ public final class FirebaseAuthService: NSObject, AuthService, @unchecked Sendab
         }
         do {
             try await user.delete()
-        } catch let error as NSError where error.code == AuthErrorCode.requiresRecentLogin.rawValue {
-            throw AuthError.requiresRecentLogin
         } catch {
             throw AuthError.unknown(error)
         }

--- a/Projects/Core/SyncInterface/Sources/AccountDeletionService.swift
+++ b/Projects/Core/SyncInterface/Sources/AccountDeletionService.swift
@@ -8,11 +8,12 @@ import Foundation
 /// 사용자가 계정 삭제를 요청했을 때 클라우드 데이터 정리와 Auth user 삭제를 함께 수행하는 오케스트레이터.
 ///
 /// `AuthService.deleteAccount` 는 Firebase Auth user 만 삭제 — Firestore 문서 / Storage 파일은 남는다.
-/// 본 서비스는 호출 시점 사용자의 모든 데이터 (메모 / 카테고리 / 이미지 + 바이너리) 를 먼저 삭제한 뒤
-/// Auth user 를 삭제한다. `requiresRecentLogin` 이 발생하면 Apple sign-in 으로 reauthenticate 후 재시도.
+/// 본 서비스는 reauth 로 token 을 갱신한 뒤 사용자의 모든 데이터 (메모 / 카테고리 / 이미지 + 바이너리) 를
+/// 삭제하고 마지막에 Auth user 를 삭제한다.
 public protocol AccountDeletionService: AnyObject, Sendable {
 
-    /// 모든 클라우드 데이터 + Auth user 삭제. 실패 시 부분 삭제 상태일 수 있으므로 호출자는
-    /// 다시 시도하도록 안내. reauth 가 필요하면 내부에서 Apple sign-in 시트를 띄움.
+    /// 모든 클라우드 데이터 + Auth user 삭제. 호출 시 Apple sign-in 시트로 reauth 가 먼저 진행되며,
+    /// 사용자가 시트를 취소하면 아무것도 삭제되지 않은 채 종료. 데이터 삭제 도중 실패 시엔 부분
+    /// 삭제 상태일 수 있어 호출자는 다시 시도하도록 안내.
     func deleteAccountAndAllData() async throws
 }

--- a/Projects/Core/SyncInterface/Sources/AuthService.swift
+++ b/Projects/Core/SyncInterface/Sources/AuthService.swift
@@ -48,16 +48,14 @@ public enum AuthError: LocalizedError {
     case cancelled
     case invalidCredential
     case missingFirebase
-    case requiresRecentLogin
     case unknown(Error)
 
     public var errorDescription: String? {
         switch self {
-        case .cancelled:           return L10n.Sync.Auth.cancelled
-        case .invalidCredential:   return L10n.Sync.Auth.invalidCredential
-        case .missingFirebase:     return L10n.Sync.Auth.unavailable
-        case .requiresRecentLogin: return L10n.Sync.Auth.requiresRecentLogin
-        case .unknown:             return L10n.Sync.Auth.unknown
+        case .cancelled:         return L10n.Sync.Auth.cancelled
+        case .invalidCredential: return L10n.Sync.Auth.invalidCredential
+        case .missingFirebase:   return L10n.Sync.Auth.unavailable
+        case .unknown:           return L10n.Sync.Auth.unknown
         }
     }
 }

--- a/Projects/Feature/LoginFeature/Sources/LoginViewController.swift
+++ b/Projects/Feature/LoginFeature/Sources/LoginViewController.swift
@@ -100,9 +100,6 @@ public final class LoginViewController: UIViewController {
             rootView.errorLabel.text = L10n.Sync.Auth.unavailable
         case .invalidCredential:
             rootView.errorLabel.text = L10n.Sync.Auth.invalidCredential
-        case .requiresRecentLogin:
-            // 로그인 진입점에서는 발생하지 않는 케이스 (delete 흐름 전용). 방어적으로 unknown 메시지.
-            rootView.errorLabel.text = L10n.Sync.Auth.unknown
         case .unknown:
             rootView.errorLabel.text = L10n.Sync.Auth.unknown
         }

--- a/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
+++ b/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
@@ -201,9 +201,6 @@ public final class AccountDetailViewController: UIViewController {
             showAlert(title: L10n.Sync.Auth.unavailable)
         case .invalidCredential:
             showAlert(title: L10n.Sync.Auth.invalidCredential)
-        case .requiresRecentLogin:
-            // 로그인 진입점에선 발생하지 않는 케이스 (delete 흐름 전용). 방어적으로 unknown 메시지.
-            showAlert(title: L10n.Sync.Auth.unknown)
         case .unknown:
             showAlert(title: L10n.Sync.Auth.unknown)
         }

--- a/Projects/Feature/SettingsFeature/Sources/DarkModeSettingView/DarkModeSettingView.swift
+++ b/Projects/Feature/SettingsFeature/Sources/DarkModeSettingView/DarkModeSettingView.swift
@@ -33,8 +33,7 @@ final class DarkModeSettingView: UIView {
     }
     
     private func setupUI() {
-        self.backgroundColor = .systemBackground
-        
+        self.backgroundColor = .systemGray6
         self.addSubview(darkModeSettingTableView)
     }
     


### PR DESCRIPTION
## 배경
- 로그인 / 로그아웃 / 계정 삭제 등 인증 흐름의 사용자 가시 문구를 톤·정확도 기준으로 정비.
- 사전 안내로 흡수 가능해진 `AuthError.requiresRecentLogin` 케이스가 reauth-first 패턴 도입 이후 unreachable 이 됨 — dead code 정리.
- 다크 모드 설정 화면 배경색 보정 (별개의 작은 시각 정리).

## 변경사항
- `account.signInPrompt`: 기기 간 보기 + 초기 설정 시간 안내, 두 문장 줄바꿈.
- `account.signOutConfirmMessage`: '로컬 모드' 개념 도입 + 재로그인 안내. '서버' 표현 회피. alert 가독성 위해 축약 + 줄바꿈.
- `sync.introduction.body`: signInPrompt 와 톤 통일.
- `account.deleteAccountConfirmMessage`: 보안 reauth 사전 안내 추가.
- `AuthError.requiresRecentLogin` 관련 코드 / 문자열 / 호출자 switch case 일괄 제거.
  - reauth 가 항상 먼저 일어나므로 unreachable.
  - 호출 가능한 흐름이 다시 생기면 그때 재도입.
- `DarkModeSettingView` 배경색 `.systemBackground` → `.systemGray6` — 다른 설정 하위 화면들의 grouped 배경 톤과 통일.

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` 통과 확인.
- `tuist test` 통과 확인.
- 시뮬레이터 수동 확인 (사용자 검증 완료):
  - 계정 페이지 (로그아웃 상태) — signInPrompt 두 줄로 보임.
  - Sync introduction 모달 (UserDefaults 키 초기화 시) — 두 줄로 보임.
  - 로그아웃 confirm alert — '로컬 모드' 표현 + 재로그인 안내 보임.
  - 계정 삭제 confirm alert — 보안 reauth 사전 안내 줄 보임.
  - 다크 모드 설정 화면 — 배경색 grouped 톤.

## 리뷰 노트
- `requiresRecentLogin` 제거는 현재 reauth-first 구조 (`FirebaseAccountDeletionService.deleteAccountAndAllData` 가 `signInWithApple` 을 가장 먼저 호출) 에 의존. 미래에 lazy reauth 흐름이 다시 채택되면 케이스 재도입 필요.
- `requiresRecentLogin` 의 NSError 매핑이 빠지면서 해당 error 도 `AuthError.unknown` 으로 흡수됨. 만일 token 만료 race 가 극히 드물게 발생하면 사용자에게 generic 메시지가 표시됨.
- 안내 문구 변경이라 UI 스크린샷은 생략 — 시뮬레이터에서 직접 확인하는 게 빠름.
