### PR TITLE
feat(sync): 첫 사인인 후 익명 데이터 정리 + 마이그레이션 완료까지 spinner 유지

### DIFF
--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -27,6 +27,7 @@ struct AppEnvironment {
     let accountSentinelService: AccountSentinelService
     let accountDeletionService: AccountDeletionService
     let syncStatusService: SyncStatusService
+    let migrationCleanupCoordinator: AnonymousMigrationCleanupCoordinator
 
     let coreDataStack: CoreDataStack
 
@@ -56,22 +57,27 @@ struct AppEnvironment {
         let memoRepositoryCoreData = MemoRepositoryImpl(stack: coreDataStack)
         let categoryRepositoryCoreData = CategoryRepositoryImpl(stack: coreDataStack)
         let imageRepositoryCoreData = ImageRepositoryImpl(stack: coreDataStack, memoRepository: memoRepositoryCoreData)
+        let migrationCleanupCoordinator = AnonymousMigrationCleanupCoordinator(coreDataStack: coreDataStack)
+        self.migrationCleanupCoordinator = migrationCleanupCoordinator
         let categoryRepository = SyncBootstrap.makeCategoryRepository(
             authService: authService,
-            anonymousImpl: categoryRepositoryCoreData
+            anonymousImpl: categoryRepositoryCoreData,
+            cleanupCoordinator: migrationCleanupCoordinator
         )
         self.categoryRepository = categoryRepository
         let imageRepository = SyncBootstrap.makeImageRepository(
             authService: authService,
             anonymousImpl: imageRepositoryCoreData,
-            anonymousMemoRepository: memoRepositoryCoreData
+            anonymousMemoRepository: memoRepositoryCoreData,
+            cleanupCoordinator: migrationCleanupCoordinator
         )
         self.imageRepository = imageRepository
         let memoRepository = SyncBootstrap.makeMemoRepository(
             authService: authService,
             anonymousImpl: memoRepositoryCoreData,
             categoryResolver: categoryRepository,
-            imageResolver: imageRepository
+            imageResolver: imageRepository,
+            cleanupCoordinator: migrationCleanupCoordinator
         )
         self.memoRepository = memoRepository
         let accountSentinelService = SyncBootstrap.makeAccountSentinelService(authService: authService)

--- a/NoteCard/Global/Application/SceneDelegate.swift
+++ b/NoteCard/Global/Application/SceneDelegate.swift
@@ -45,19 +45,23 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             self.window?.rootViewController = makeMainTabBarController(environment: appDelegate.environment)
         }
 
-        observeForceSignOut(environment: appDelegate.environment)
+        observeAuthStateChanges(environment: appDelegate.environment)
     }
 
-    /// sign-out 이벤트 (user → nil) 가 발생하면 modal · navigation 상태를 초기화한 채 홈 탭에서
-    /// 시작하도록 rootViewController 를 통째로 교체.
-    /// dropFirst 로 구독 시점의 현재 값은 건너뛰고, filter 로 sign-in 이벤트는 무시 (LoginVC 가 처리).
-    private func observeForceSignOut(environment: AppEnvironment) {
+    /// auth 상태 전이 시 rootViewController 를 새 MainTabBar 로 교체해 modal · navigation 상태 reset.
+    /// 사인인은 LoginVC 가 자체 transition 하므로 rootVC 가 LoginVC 가 아닌 경로만 처리.
+    /// 사인아웃은 force signOut (sentinel / token 만료 등) 까지 커버.
+    private func observeAuthStateChanges(environment: AppEnvironment) {
         environment.authService.authStatePublisher
             .dropFirst()
-            .filter { $0 == nil }
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                self?.transitionToMainTabBar(environment: environment)
+            .sink { [weak self] user in
+                guard let self else { return }
+                if user == nil {
+                    self.transitionToMainTabBar(environment: environment)
+                } else if !(self.window?.rootViewController is LoginViewController) {
+                    self.transitionToMainTabBar(environment: environment)
+                }
             }
             .store(in: &cancellables)
     }

--- a/NoteCard/Presentation/HomeView/HomeViewController.swift
+++ b/NoteCard/Presentation/HomeView/HomeViewController.swift
@@ -54,6 +54,7 @@ class HomeViewController: UIViewController {
     private var diffableDataSource: DiffableDataSource!
 
     private var initialLoadCompleted = false
+    private var awaitingMigrationCleanup = false
     private var cancellables: Set<AnyCancellable> = []
 
     private let environment: AppEnvironment
@@ -97,11 +98,30 @@ class HomeViewController: UIViewController {
 
         setupNaviBar()
         setupDiffableDataSource()
-        if environment.authService.currentUser != nil {
+        if let userID = environment.authService.currentUser?.id {
+            let cleanupMarker = "sync.anonymousMigrationCleanup.\(userID)"
+            awaitingMigrationCleanup = !UserDefaults.standard.bool(forKey: cleanupMarker)
             homeView.loadingIndicator.startAnimating()
-            Task { [weak self] in
-                try? await Task.sleep(nanoseconds: 3_000_000_000)
-                self?.completeInitialLoad()
+
+            if awaitingMigrationCleanup {
+                environment.migrationCleanupCoordinator.cleanupCompletedPublisher
+                    .filter { $0 == userID }
+                    .receive(on: DispatchQueue.main)
+                    .sink { [weak self] _ in
+                        self?.awaitingMigrationCleanup = false
+                        self?.completeInitialLoad()
+                    }
+                    .store(in: &cancellables)
+                // 첫 마이그레이션은 이미지 다수 업로드 등으로 분 단위 가능. 안전망 60초.
+                Task { [weak self] in
+                    try? await Task.sleep(nanoseconds: 60_000_000_000)
+                    self?.completeInitialLoad()
+                }
+            } else {
+                Task { [weak self] in
+                    try? await Task.sleep(nanoseconds: 3_000_000_000)
+                    self?.completeInitialLoad()
+                }
             }
         } else {
             initialLoadCompleted = true
@@ -303,6 +323,8 @@ class HomeViewController: UIViewController {
 
     private func completeInitialLoadIfDataArrived() {
         guard !initialLoadCompleted else { return }
+        // 첫 사인인 진행 중엔 cleanup 신호로만 종료. 데이터 일부 도착으로 조기 중단 X.
+        guard !awaitingMigrationCleanup else { return }
         let hasData = !allMemos.isEmpty || !categories.isEmpty || !favoriteMemos.isEmpty
         if hasData {
             completeInitialLoad()

--- a/Projects/Core/SyncImpl/Sources/AnonymousMigrationCleanupCoordinator.swift
+++ b/Projects/Core/SyncImpl/Sources/AnonymousMigrationCleanupCoordinator.swift
@@ -1,0 +1,89 @@
+//
+//  AnonymousMigrationCleanupCoordinator.swift
+//  NoteCard
+//
+
+import Combine
+import CoreData
+import Data
+import Foundation
+
+/// Memo / Category / Image Router 의 첫 로그인 마이그레이션이 모두 완료되면 익명 Core Data 의 모든 entity 를
+/// 일괄 삭제. Documents 의 이미지 파일은 캐시로 유지 — 사인인 후 같은 UUID 로 Firestore impl 의 이미지 로드
+/// 캐시 hit 을 제공.
+public final class AnonymousMigrationCleanupCoordinator: @unchecked Sendable {
+
+    private let coreDataStack: CoreDataStack
+    private let lock = NSLock()
+    private var cleanupInProgress: Set<String> = []
+
+    private let cleanupCompletedSubject = PassthroughSubject<String, Never>()
+    /// cleanup 이 완료된 (혹은 이미 완료돼있던) 사용자의 userID 를 emit. UI 가 spinner 종료 트리거로 사용.
+    public var cleanupCompletedPublisher: AnyPublisher<String, Never> {
+        cleanupCompletedSubject.eraseToAnyPublisher()
+    }
+
+    public init(coreDataStack: CoreDataStack) {
+        self.coreDataStack = coreDataStack
+    }
+
+    public func reportMigrationCompleted(userID: String) async {
+        guard allMigrationsCompleted(for: userID) else { return }
+        let cleanupMarker = Self.cleanupMarkerKey(for: userID)
+
+        enum Decision { case skipAlreadyDone, skipAlreadyRunning, proceed }
+        let decision: Decision = lock.withLock {
+            if UserDefaults.standard.bool(forKey: cleanupMarker) {
+                return .skipAlreadyDone
+            }
+            if cleanupInProgress.contains(userID) {
+                return .skipAlreadyRunning
+            }
+            cleanupInProgress.insert(userID)
+            return .proceed
+        }
+
+        switch decision {
+        case .skipAlreadyDone:
+            cleanupCompletedSubject.send(userID)
+            return
+        case .skipAlreadyRunning:
+            return
+        case .proceed:
+            break
+        }
+
+        await performCleanup()
+        UserDefaults.standard.set(true, forKey: cleanupMarker)
+        lock.withLock { _ = cleanupInProgress.remove(userID) }
+        cleanupCompletedSubject.send(userID)
+    }
+
+    private func allMigrationsCompleted(for userID: String) -> Bool {
+        ["Memo", "Category", "Image"].allSatisfy { domain in
+            UserDefaults.standard.bool(forKey: "sync.anonymousToFirestore\(domain)Migration.\(userID)")
+        }
+    }
+
+    private static func cleanupMarkerKey(for userID: String) -> String {
+        "sync.anonymousMigrationCleanup.\(userID)"
+    }
+
+    /// Core Data 의 Memo / Category / Image entity 를 일괄 삭제.
+    /// Documents 폴더의 이미지 파일은 의도적으로 보존 — 사인인 후 Firestore impl 의 캐시로 활용.
+    /// NSBatchDeleteRequest 가 many-to-many 의 join table 정리 / Nullify rule 실행을 못 해서 fetch + context.delete 사용.
+    private func performCleanup() async {
+        let context = coreDataStack.backgroundContext
+        await context.perform {
+            for entityName in ["ImageEntity", "MemoEntity", "CategoryEntity"] {
+                let request = NSFetchRequest<NSManagedObject>(entityName: entityName)
+                if let objects = try? context.fetch(request) {
+                    for object in objects {
+                        context.delete(object)
+                    }
+                }
+            }
+            try? context.save()
+        }
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/CategoryRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/CategoryRepositoryRouter.swift
@@ -27,6 +27,7 @@ public final class CategoryRepositoryRouter: CategoryRepository, @unchecked Send
     private let authService: AuthService
     private let anonymousImpl: CategoryRepository
     private let firestore: Firestore
+    private let cleanupCoordinator: AnonymousMigrationCleanupCoordinator
 
     private let lock = NSLock()
     private var _activeImpl: CategoryRepository
@@ -43,10 +44,12 @@ public final class CategoryRepositoryRouter: CategoryRepository, @unchecked Send
     public init(
         authService: AuthService,
         anonymousImpl: CategoryRepository,
+        cleanupCoordinator: AnonymousMigrationCleanupCoordinator,
         firestore: Firestore = .firestore()
     ) {
         self.authService = authService
         self.anonymousImpl = anonymousImpl
+        self.cleanupCoordinator = cleanupCoordinator
         self.firestore = firestore
         self._activeImpl = anonymousImpl
         attachForwarding(from: anonymousImpl)
@@ -106,7 +109,11 @@ public final class CategoryRepositoryRouter: CategoryRepository, @unchecked Send
     /// (재호출 시 stale 로컬이 newer Firestore를 덮어쓰는 데이터 손실 방지)
     private func triggerMigrationIfNeeded(to firestoreImpl: CategoryRepositoryFirestoreImpl, userID: String) {
         let markerKey = "sync.anonymousToFirestoreCategoryMigration.\(userID)"
-        guard !UserDefaults.standard.bool(forKey: markerKey) else { return }
+        let coordinator = cleanupCoordinator
+        if UserDefaults.standard.bool(forKey: markerKey) {
+            Task { await coordinator.reportMigrationCompleted(userID: userID) }
+            return
+        }
         let source = anonymousImpl
         Task { [weak firestoreImpl] in
             guard let firestoreImpl else { return }
@@ -116,6 +123,7 @@ public final class CategoryRepositoryRouter: CategoryRepository, @unchecked Send
                     try await firestoreImpl.importCategories(anonymous)
                 }
                 UserDefaults.standard.set(true, forKey: markerKey)
+                await coordinator.reportMigrationCompleted(userID: userID)
             } catch {
                 // 스파이크에선 로그만. 정식 채택 시 status로 surface.
                 print("[CategoryRepositoryRouter] migration error: \(error)")

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
@@ -27,6 +27,7 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
     private let anonymousMemoRepository: MemoRepository
     private let firestore: Firestore
     private let storage: Storage
+    private let cleanupCoordinator: AnonymousMigrationCleanupCoordinator
 
     private let lock = NSLock()
     private var _activeImpl: ImageRepository
@@ -43,12 +44,14 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
         authService: AuthService,
         anonymousImpl: ImageRepository,
         anonymousMemoRepository: MemoRepository,
+        cleanupCoordinator: AnonymousMigrationCleanupCoordinator,
         firestore: Firestore = .firestore(),
         storage: Storage = .storage()
     ) {
         self.authService = authService
         self.anonymousImpl = anonymousImpl
         self.anonymousMemoRepository = anonymousMemoRepository
+        self.cleanupCoordinator = cleanupCoordinator
         self.firestore = firestore
         self.storage = storage
         self._activeImpl = anonymousImpl
@@ -79,7 +82,11 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
     /// 익명 이미지를 새 Firestore impl로 이관. UserDefaults 마커로 기기+사용자별 1회.
     private func triggerMigrationIfNeeded(to firestoreImpl: ImageRepositoryFirestoreImpl, userID: String) {
         let markerKey = "sync.anonymousToFirestoreImageMigration.\(userID)"
-        guard !UserDefaults.standard.bool(forKey: markerKey) else { return }
+        let coordinator = cleanupCoordinator
+        if UserDefaults.standard.bool(forKey: markerKey) {
+            Task { await coordinator.reportMigrationCompleted(userID: userID) }
+            return
+        }
         let memoRepo = anonymousMemoRepository
         let imageRepo = anonymousImpl
         Task { [weak firestoreImpl] in
@@ -97,6 +104,7 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
                     try await firestoreImpl.importImages(collected)
                 }
                 UserDefaults.standard.set(true, forKey: markerKey)
+                await coordinator.reportMigrationCompleted(userID: userID)
             } catch {
                 print("[ImageRepositoryRouter] migration error: \(error)")
             }

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryRouter.swift
@@ -23,6 +23,7 @@ public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
     private let categoryResolver: CategoryRepository
     private let imageResolver: ImageRepository
     private let firestore: Firestore
+    private let cleanupCoordinator: AnonymousMigrationCleanupCoordinator
 
     private let lock = NSLock()
     private var _activeImpl: MemoRepository
@@ -41,12 +42,14 @@ public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
         anonymousImpl: MemoRepository,
         categoryResolver: CategoryRepository,
         imageResolver: ImageRepository,
+        cleanupCoordinator: AnonymousMigrationCleanupCoordinator,
         firestore: Firestore = .firestore()
     ) {
         self.authService = authService
         self.anonymousImpl = anonymousImpl
         self.categoryResolver = categoryResolver
         self.imageResolver = imageResolver
+        self.cleanupCoordinator = cleanupCoordinator
         self.firestore = firestore
         self._activeImpl = anonymousImpl
         attachForwarding(from: anonymousImpl)
@@ -105,7 +108,11 @@ public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
     /// 익명 메모(휴지통 포함)를 새 Firestore impl로 이관. UserDefaults 마커로 기기+사용자별 1회.
     private func triggerMigrationIfNeeded(to firestoreImpl: MemoRepositoryFirestoreImpl, userID: String) {
         let markerKey = "sync.anonymousToFirestoreMemoMigration.\(userID)"
-        guard !UserDefaults.standard.bool(forKey: markerKey) else { return }
+        let coordinator = cleanupCoordinator
+        if UserDefaults.standard.bool(forKey: markerKey) {
+            Task { await coordinator.reportMigrationCompleted(userID: userID) }
+            return
+        }
         let source = anonymousImpl
         Task { [weak firestoreImpl] in
             guard let firestoreImpl else { return }
@@ -117,6 +124,7 @@ public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
                     try await firestoreImpl.importMemos(all)
                 }
                 UserDefaults.standard.set(true, forKey: markerKey)
+                await coordinator.reportMigrationCompleted(userID: userID)
             } catch {
                 print("[MemoRepositoryRouter] migration error: \(error)")
             }

--- a/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
+++ b/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
@@ -32,12 +32,17 @@ public enum SyncBootstrap {
     /// 아니면 익명 impl을 그대로 반환. (Firebase 미설정 환경에서 `.firestore()` fatalError 회피)
     public static func makeCategoryRepository(
         authService: AuthService,
-        anonymousImpl: CategoryRepository
+        anonymousImpl: CategoryRepository,
+        cleanupCoordinator: AnonymousMigrationCleanupCoordinator
     ) -> CategoryRepository {
         guard FirebaseApp.app() != nil else {
             return anonymousImpl
         }
-        return CategoryRepositoryRouter(authService: authService, anonymousImpl: anonymousImpl)
+        return CategoryRepositoryRouter(
+            authService: authService,
+            anonymousImpl: anonymousImpl,
+            cleanupCoordinator: cleanupCoordinator
+        )
     }
 
     /// 메모용 동일 패턴. `categoryResolver`·`imageResolver`는 보통 각각 `makeCategoryRepository` /
@@ -46,7 +51,8 @@ public enum SyncBootstrap {
         authService: AuthService,
         anonymousImpl: MemoRepository,
         categoryResolver: CategoryRepository,
-        imageResolver: ImageRepository
+        imageResolver: ImageRepository,
+        cleanupCoordinator: AnonymousMigrationCleanupCoordinator
     ) -> MemoRepository {
         guard FirebaseApp.app() != nil else {
             return anonymousImpl
@@ -55,7 +61,8 @@ public enum SyncBootstrap {
             authService: authService,
             anonymousImpl: anonymousImpl,
             categoryResolver: categoryResolver,
-            imageResolver: imageResolver
+            imageResolver: imageResolver,
+            cleanupCoordinator: cleanupCoordinator
         )
     }
 
@@ -64,7 +71,8 @@ public enum SyncBootstrap {
     public static func makeImageRepository(
         authService: AuthService,
         anonymousImpl: ImageRepository,
-        anonymousMemoRepository: MemoRepository
+        anonymousMemoRepository: MemoRepository,
+        cleanupCoordinator: AnonymousMigrationCleanupCoordinator
     ) -> ImageRepository {
         guard FirebaseApp.app() != nil else {
             return anonymousImpl
@@ -72,7 +80,8 @@ public enum SyncBootstrap {
         return ImageRepositoryRouter(
             authService: authService,
             anonymousImpl: anonymousImpl,
-            anonymousMemoRepository: anonymousMemoRepository
+            anonymousMemoRepository: anonymousMemoRepository,
+            cleanupCoordinator: cleanupCoordinator
         )
     }
 


### PR DESCRIPTION
## 배경
- 익명 사용자가 처음 사인인하면 메모 / 카테고리 / 이미지 가 Firestore 로 이관되지만 익명 Core Data row 는 그대로 남아있어, 사인아웃 후 익명 모드에서 옛 데이터가 다시 보이는 일관성 문제.
- 사용자 요구: 첫 사인인 시 마이그레이션 + 정리가 모두 끝날 때까지 spinner 유지 (안전성 우선).

## 변경사항
- `AnonymousMigrationCleanupCoordinator` 신설.
  - 3개 Router (Memo / Category / Image) 의 마이그레이션 마커가 모두 set 되면 익명 Core Data row 를 일괄 삭제.
  - Documents 폴더의 이미지 파일은 캐시로 보존 — UUID 동일하므로 Firestore impl 의 이미지 로드가 캐시 hit.
  - `cleanupCompletedPublisher` 노출 — UI 가 spinner 종료 트리거로 사용.
  - 마이그레이션 이미 완료된 사용자 재로그인 시 Router 의 early-return 경로에서도 coordinator 호출 → 마커 set 인데 cleanup 미실행 엣지 케이스 회복.
  - `NSLock.withLock` 으로 critical section 보호 — async 컨텍스트 안전.
- 3개 Router 가 마이그레이션 Task 성공 후 (또는 이미 완료 상태에서 진입 시) `coordinator.reportMigrationCompleted` 호출. `SyncBootstrap` factory 가 coordinator 주입 받음.
- `AppEnvironment` 가 `migrationCleanupCoordinator` 노출.
- `HomeViewController`:
  - cleanup 마커 미존재 시 (첫 사인인) `cleanupCompletedPublisher` 구독해 spinner 유지. 60초 fallback timeout.
  - 진행 중에 데이터 일부 도착해도 spinner 종료 안 함.
  - 이미 마이그레이션 완료된 사용자는 기존 3초 fallback.
- `SceneDelegate.observeAuthStateChanges` (이전 `observeForceSignOut`): 사인아웃 / 사인인 양쪽에서 rootVC 교체. `LoginViewController` 가 rootVC 인 경로는 LoginVC 의 자체 transition 에 맡김 (이중 발화 방지).
  - 결과: AccountDetail 에서 사인인해도 새 HomeVC 가 마이그레이션 spinner 정상 표시.

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` 통과 확인.
- `tuist test` 통과 확인.
- 시뮬레이터 수동 확인 (사용자 검증 완료):
  - 시뮬레이터 → 앱 삭제 → 재설치 → 익명 + 메모 / 카테고리 / 이미지 생성 → 사인인.
    - 마이그레이션 완료까지 spinner 유지.
    - spinner 종료 후 사인아웃 → 익명 모드 메모 / 카테고리 / 이미지 모두 비어있음.
  - AccountDetail 에서 사인인 → rootVC 가 새 HomeVC 로 자동 전환되며 spinner 표시.
  - 익명 모드 / 이미 마이그레이션 완료한 사용자 → 기존 동작 그대로 (spinner 표시 안 됨 / 짧은 fallback).

## 리뷰 노트
- **NSBatchDeleteRequest 대신 fetch + context.delete 사용 이유**: Memo ↔ Category 가 many-to-many. NSBatchDeleteRequest 는 SQL 직접 조작이라 join table 정리 및 Nullify rule 실행을 안 함 → CategoryEntity 삭제가 SQLite 제약으로 실패하던 버그. Core Data 의 정식 매커니즘은 관계 / 룰 모두 평가.
- **Documents 폴더 보존**: UUID 가 마이그레이션 후에도 동일하므로 캐시로 활용. 사인인 후 첫 이미지 열람 시 Storage 다운로드 없이 즉시 표시.
- **사인인 시 rootVC 교체**: AccountDetail 에서 사인인했을 때 기존 HomeVC 가 미리 익명 상태로 viewDidLoad 실행했기 때문에 마이그레이션 spinner 가 표시되지 않던 비대칭 해결. LoginVC 가드로 첫 사인인 경로의 이중 transition 방지.
- 본 PR 머지 후 익명 → 사인인 사용자 경험이 개선됨. 기존 사인인 사용자는 영향 없음 (이미 마커 set 이라 새 path 비활성).
