### PR TITLE
fix(sync): CategoryRepositoryFirestoreImpl memoCount 실제 집계로 교체

### DIFF
--- a/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
@@ -150,9 +150,11 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
     }
 
     public func memoCount(of category: Domain.Category) async throws -> Int {
-        // Memo Repository가 Firestore로 가면 그때 count_query/denormalized count 결정.
-        // 스파이크에선 0 반환 (UI는 표시만 0으로 뜸).
-        0
+        let memos = firestore.collection("users").document(userID).collection("memos")
+        let snapshot = try await memos
+            .whereField("categoryIDs", arrayContains: category.id.uuidString)
+            .getDocuments(source: .cache)
+        return snapshot.count
     }
 
     // MARK: - Write


### PR DESCRIPTION
## 배경
- 로그인 상태에서 카테고리 목록의 각 카테고리별 메모 수가 모두 0으로 표시되는 문제.
- `CategoryRepositoryFirestoreImpl.memoCount(of:)` 가 Firestore 스파이크 시절 `return 0` 하드코딩 상태로 남아있던 게 원인.

## 변경사항
- `CategoryRepositoryFirestoreImpl.memoCount(of:)` 를 실제 집계로 교체
  - `users/<uid>/memos` collection 에 `categoryIDs arrayContains <category.id.uuidString>` 쿼리
  - 휴지통 이동 시 `MemoRepositoryFirestoreImpl.trashPayload` 가 `categoryIDs` 를 빈 배열로 덮어쓰므로 `isInTrash` 필터 불필요
  - `source: .cache` 사용 — `MemoRepositoryFirestoreImpl` 의 listener 가 채운 SDK 캐시 재사용해 네트워크 호출 0회

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` — BUILD SUCCEEDED
- 시뮬레이터 수동 확인: 로그인 상태에서 카테고리 목록 진입 시 각 카테고리별 실제 메모 수 표시 확인

## 리뷰 노트
- `.cache` source 선택 이유: `MemoRepositoryFirestoreImpl` 가 init 시점부터 listener 로 SDK 캐시를 유지하므로, 카테고리 목록 렌더 시점엔 캐시가 준비돼있음. 서버 호출 / aggregation read 비용 없이 즉시 응답
- 휴지통 메모 제외는 schema invariant (`trashPayload` 의 `"categoryIDs": []`) 에 의존 — 향후 trash 정책 변경 시 이 메서드도 같이 점검 필요