### PR TITLE
fix(l10n): 메모 저장 progress 문구 "업로드 중" → "저장 중"

### DIFF
--- a/NoteCard/Presentation/MemoDetailView/MemoDetailViewController.swift
+++ b/NoteCard/Presentation/MemoDetailView/MemoDetailViewController.swift
@@ -93,7 +93,7 @@ class MemoDetailViewController: UIViewController {
     private func refreshSavingProgressLabel() {
         var lines: [String] = []
         if savingTotalAdds > 0 {
-            lines.append(String(format: L10n.MemoDetail.uploadingImagesFormat, savingCompletedAdds, savingTotalAdds))
+            lines.append(String(format: L10n.MemoDetail.savingImagesFormat, savingCompletedAdds, savingTotalAdds))
         }
         if savingTotalDeletes > 0 {
             lines.append(String(format: L10n.MemoDetail.deletingImagesFormat, savingCompletedDeletes, savingTotalDeletes))

--- a/Projects/Core/Shared/Resources/Localizable.xcstrings
+++ b/Projects/Core/Shared/Resources/Localizable.xcstrings
@@ -817,19 +817,19 @@
         }
       }
     },
-    "memoDetail.uploadingImagesFormat": {
+    "memoDetail.savingImagesFormat": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Uploading %1$d of %2$d images"
+            "value": "Saving %1$d of %2$d images"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "이미지 %1$d / %2$d 업로드 중"
+            "value": "이미지 %1$d / %2$d 저장 중"
           }
         }
       }

--- a/Projects/Core/Shared/Sources/Localization/L10n.swift
+++ b/Projects/Core/Shared/Sources/Localization/L10n.swift
@@ -92,7 +92,7 @@ public enum L10n {
         public static let addMemo = "memoDetail.addMemo".localized()
         public static let imageLimitExceeded = "memoDetail.imageLimitExceeded".localized()
         public static let imageLimitMessage = "memoDetail.imageLimitMessage".localized()
-        public static let uploadingImagesFormat = "memoDetail.uploadingImagesFormat".localized()
+        public static let savingImagesFormat = "memoDetail.savingImagesFormat".localized()
         public static let deletingImagesFormat = "memoDetail.deletingImagesFormat".localized()
     }
 


### PR DESCRIPTION
## 배경
- 익명 모드에선 클라우드 업로드가 일어나지 않음에도 메모 저장 시 "이미지 N / M 업로드 중" 문구가 노출돼 사용자 혼선 유발.
- 사인인 모드 / 익명 모드 양쪽에서 통용되는 표현으로 통일 필요.

## 변경사항
- 메모 저장 progress 문구 단어 변경
  - ko: "이미지 %1$d / %2$d 업로드 중" → "이미지 %1$d / %2$d 저장 중"
  - en: "Uploading %1$d of %2$d images" → "Saving %1$d of %2$d images"
- N / M 카운트(저장 진행 상황) 는 유지
- L10n key / xcstrings key 도 의미 일치 위해 `uploadingImagesFormat` → `savingImagesFormat` 으로 rename
- 호출부(`MemoDetailViewController.refreshSavingProgressLabel`) 반영

## 테스트 방법
- `tuist generate --no-open && xcodebuild build -workspace NoteCard.xcworkspace -scheme NoteCard -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` — BUILD SUCCEEDED
- 시뮬레이터 수동 확인
  - 익명 / 사인인 양 모드에서 이미지 포함 메모 저장 시 "이미지 N / M 저장 중" 표시 확인
  - 이미지 삭제 progress("삭제 중") 는 변동 없음

## 리뷰 노트
- 삭제 progress(`deletingImagesFormat`) 는 어휘 변경 없음 — 삭제는 두 모드 모두 의미 동일