### PR TITLE
feat(sync): 첫 sign-in 시 데이터 준비 완료까지 home 진입 차단 (readiness gate)

### DIFF
--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -98,7 +98,8 @@ struct AppEnvironment {
         self.firstSignInReadinessCoordinator = SyncBootstrap.makeFirstSignInReadinessCoordinator(
             cleanupCoordinator: migrationCleanupCoordinator,
             memoRepository: memoRepository,
-            categoryRepository: categoryRepository
+            categoryRepository: categoryRepository,
+            imageRepository: imageRepository
         )
     }
 

--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -28,6 +28,7 @@ struct AppEnvironment {
     let accountDeletionService: AccountDeletionService
     let syncStatusService: SyncStatusService
     let migrationCleanupCoordinator: AnonymousMigrationCleanupCoordinator
+    let firstSignInReadinessCoordinator: FirstSignInReadinessCoordinator
 
     let coreDataStack: CoreDataStack
 
@@ -91,6 +92,11 @@ struct AppEnvironment {
         )
         self.syncStatusService = SyncBootstrap.makeSyncStatusService(
             authService: authService,
+            memoRepository: memoRepository,
+            categoryRepository: categoryRepository
+        )
+        self.firstSignInReadinessCoordinator = SyncBootstrap.makeFirstSignInReadinessCoordinator(
+            cleanupCoordinator: migrationCleanupCoordinator,
             memoRepository: memoRepository,
             categoryRepository: categoryRepository
         )

--- a/NoteCard/Global/Application/SceneDelegate.swift
+++ b/NoteCard/Global/Application/SceneDelegate.swift
@@ -78,7 +78,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     private func makeLoginViewController(environment: AppEnvironment) -> LoginViewController {
-        LoginViewController(authService: environment.authService) { [weak self] outcome in
+        LoginViewController(
+            authService: environment.authService,
+            readinessCoordinator: environment.firstSignInReadinessCoordinator
+        ) { [weak self] outcome in
             UserDefaults.standard.set(true, forKey: UserDefaultsKey.didShowSyncIntroduction.rawValue)
             switch outcome {
             case .signedIn, .skipped:

--- a/NoteCard/Global/Application/SceneDelegate.swift
+++ b/NoteCard/Global/Application/SceneDelegate.swift
@@ -103,6 +103,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     /// auth 상태 전이 시 rootViewController 를 새 MainTabBar 로 교체해 modal · navigation 상태 reset.
     /// 사인인은 LoginVC 가 자체 transition 하므로 rootVC 가 LoginVC 가 아닌 경로만 처리.
     /// 사인아웃은 force signOut (sentinel / token 만료 등) 까지 커버.
+    /// AccountDetail 에서의 sign-in 처럼 LoginVC 가 아닌 경로는 readiness gate 완료까지 transition 을 지연.
+    /// 그래야 overlay 가 phase 라벨을 갱신하는 동안 UIView.transition 의 window snapshot 이 시각을 덮어쓰지 않음.
     private func observeAuthStateChanges(environment: AppEnvironment) {
         environment.authService.authStatePublisher
             .dropFirst()
@@ -112,10 +114,23 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 if user == nil {
                     self.transitionToMainTabBar(environment: environment)
                 } else if !(self.window?.rootViewController is LoginViewController) {
-                    self.transitionToMainTabBar(environment: environment)
+                    self.transitionAfterReadiness(environment: environment)
                 }
             }
             .store(in: &cancellables)
+    }
+
+    /// phase 가 .ready 또는 .idle 이 될 때까지 기다린 뒤 transition. 현재 phase 가 이미 .ready / .idle 이면 즉시.
+    /// readiness gate 가 동작 중인 동안은 overlay 가 살아남아 단계별 라벨 갱신을 사용자에게 보여줄 수 있음.
+    private func transitionAfterReadiness(environment: AppEnvironment) {
+        var cancellable: AnyCancellable?
+        cancellable = environment.firstSignInReadinessCoordinator.phasePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] phase in
+                guard phase == .ready || phase == .idle else { return }
+                cancellable?.cancel()
+                self?.transitionToMainTabBar(environment: environment)
+            }
     }
 
     // MARK: - Root view construction

--- a/NoteCard/Global/Application/SceneDelegate.swift
+++ b/NoteCard/Global/Application/SceneDelegate.swift
@@ -63,7 +63,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     private func handle(phase: SignInPhase) {
-        print("[DEBUG-Overlay] main received phase=\(phase) @ \(String(format: "%.3f", CFAbsoluteTimeGetCurrent()))")
         switch phase {
         case .idle, .ready:
             hideSignInProgressOverlay()

--- a/NoteCard/Global/Application/SceneDelegate.swift
+++ b/NoteCard/Global/Application/SceneDelegate.swift
@@ -12,11 +12,13 @@ import Domain
 import DesignSystem
 import LoginFeature
 import Shared
+import SyncInterface
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
     private var cancellables = Set<AnyCancellable>()
+    private var signInProgressOverlay: SignInProgressOverlay?
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
@@ -46,6 +48,55 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
 
         observeAuthStateChanges(environment: appDelegate.environment)
+        observeReadinessPhase(environment: appDelegate.environment)
+    }
+
+    /// readiness gate phase 에 따라 window 위에 SignInProgressOverlay 를 show / hide.
+    /// rootVC 교체와 무관하게 살아남아 sign-in 흐름 전체 동안 터치 차단 + 단계 표시.
+    private func observeReadinessPhase(environment: AppEnvironment) {
+        environment.firstSignInReadinessCoordinator.phasePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] phase in
+                self?.handle(phase: phase)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func handle(phase: SignInPhase) {
+        switch phase {
+        case .idle, .ready:
+            hideSignInProgressOverlay()
+        case .signingIn, .uploading, .downloading:
+            showSignInProgressOverlay(phase: phase)
+        }
+    }
+
+    private func showSignInProgressOverlay(phase: SignInPhase) {
+        guard let window = self.window else { return }
+        let overlay = signInProgressOverlay ?? SignInProgressOverlay()
+        if overlay.superview == nil {
+            overlay.alpha = 0
+            window.addSubview(overlay)
+            NSLayoutConstraint.activate([
+                overlay.topAnchor.constraint(equalTo: window.topAnchor),
+                overlay.leadingAnchor.constraint(equalTo: window.leadingAnchor),
+                overlay.trailingAnchor.constraint(equalTo: window.trailingAnchor),
+                overlay.bottomAnchor.constraint(equalTo: window.bottomAnchor)
+            ])
+            signInProgressOverlay = overlay
+            UIView.animate(withDuration: 0.2) { overlay.alpha = 1 }
+        }
+        overlay.update(phase: phase)
+    }
+
+    private func hideSignInProgressOverlay() {
+        guard let overlay = signInProgressOverlay, overlay.superview != nil else { return }
+        UIView.animate(withDuration: 0.2, animations: {
+            overlay.alpha = 0
+        }, completion: { [weak self] _ in
+            overlay.removeFromSuperview()
+            self?.signInProgressOverlay = nil
+        })
     }
 
     /// auth 상태 전이 시 rootViewController 를 새 MainTabBar 로 교체해 modal · navigation 상태 reset.

--- a/NoteCard/Global/Application/SceneDelegate.swift
+++ b/NoteCard/Global/Application/SceneDelegate.swift
@@ -63,6 +63,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     private func handle(phase: SignInPhase) {
+        print("[DEBUG-Overlay] main received phase=\(phase) @ \(String(format: "%.3f", CFAbsoluteTimeGetCurrent()))")
         switch phase {
         case .idle, .ready:
             hideSignInProgressOverlay()

--- a/NoteCard/Global/Application/SignInProgressOverlay.swift
+++ b/NoteCard/Global/Application/SignInProgressOverlay.swift
@@ -1,0 +1,83 @@
+//
+//  SignInProgressOverlay.swift
+//  NoteCard
+//
+
+import Shared
+import SyncInterface
+import UIKit
+
+/// Window 레벨에서 전체 화면 터치를 가로채고 현재 sign-in phase 를 안내하는 overlay.
+/// rootViewController 교체 (LoginVC → MainTabBar / AccountDetail → MainTabBar) 와 무관하게
+/// window 에 직접 add 되어 sign-in 전체 흐름 동안 살아남음.
+final class SignInProgressOverlay: UIView {
+
+    private let backgroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.systemBackground.withAlphaComponent(0.85)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let activityIndicator: UIActivityIndicatorView = {
+        let view = UIActivityIndicatorView(style: .large)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let phaseLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 15, weight: .medium)
+        label.textColor = .label
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) is unavailable") }
+
+    private func setupUI() {
+        backgroundColor = .clear
+        translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(backgroundView)
+        addSubview(activityIndicator)
+        addSubview(phaseLabel)
+
+        NSLayoutConstraint.activate([
+            backgroundView.topAnchor.constraint(equalTo: topAnchor),
+            backgroundView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            backgroundView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            backgroundView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor, constant: -12),
+
+            phaseLabel.topAnchor.constraint(equalTo: activityIndicator.bottomAnchor, constant: 16),
+            phaseLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 32),
+            phaseLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -32)
+        ])
+
+        activityIndicator.startAnimating()
+    }
+
+    func update(phase: SignInPhase) {
+        switch phase {
+        case .signingIn:
+            phaseLabel.text = L10n.Login.phaseSigningIn
+        case .uploading:
+            phaseLabel.text = L10n.Login.phaseUploading
+        case .downloading:
+            phaseLabel.text = L10n.Login.phaseDownloading
+        case .idle, .ready:
+            phaseLabel.text = nil
+        }
+    }
+}

--- a/NoteCard/Global/Application/SignInProgressOverlay.swift
+++ b/NoteCard/Global/Application/SignInProgressOverlay.swift
@@ -69,7 +69,6 @@ final class SignInProgressOverlay: UIView {
     }
 
     func update(phase: SignInPhase) {
-        let oldText = phaseLabel.text ?? "nil"
         switch phase {
         case .signingIn:
             phaseLabel.text = L10n.Login.phaseSigningIn
@@ -80,6 +79,5 @@ final class SignInProgressOverlay: UIView {
         case .idle, .ready:
             phaseLabel.text = nil
         }
-        print("[DEBUG-Overlay] update label '\(oldText)' → '\(phaseLabel.text ?? "nil")' @ \(String(format: "%.3f", CFAbsoluteTimeGetCurrent()))")
     }
 }

--- a/NoteCard/Global/Application/SignInProgressOverlay.swift
+++ b/NoteCard/Global/Application/SignInProgressOverlay.swift
@@ -69,6 +69,7 @@ final class SignInProgressOverlay: UIView {
     }
 
     func update(phase: SignInPhase) {
+        let oldText = phaseLabel.text ?? "nil"
         switch phase {
         case .signingIn:
             phaseLabel.text = L10n.Login.phaseSigningIn
@@ -79,5 +80,6 @@ final class SignInProgressOverlay: UIView {
         case .idle, .ready:
             phaseLabel.text = nil
         }
+        print("[DEBUG-Overlay] update label '\(oldText)' → '\(phaseLabel.text ?? "nil")' @ \(String(format: "%.3f", CFAbsoluteTimeGetCurrent()))")
     }
 }

--- a/NoteCard/Presentation/HomeView/HomeView.swift
+++ b/NoteCard/Presentation/HomeView/HomeView.swift
@@ -91,13 +91,6 @@ final class HomeView: UIView {
     
     let homeCollectionView: WispableCollectionView
 
-    let loadingIndicator: UIActivityIndicatorView = {
-        let view = UIActivityIndicatorView(style: .medium)
-        view.hidesWhenStopped = true
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
-    }()
-
     init() {
         let sectionProvider: UICollectionViewCompositionalLayoutSectionProvider = { sectionIndex, env in
             switch sectionIndex {
@@ -142,7 +135,6 @@ final class HomeView: UIView {
     
     private func setupViewHierarchy() {
         self.addSubview(homeCollectionView)
-        self.addSubview(loadingIndicator)
     }
 
     private func setupLayoutConstraints() {
@@ -150,10 +142,7 @@ final class HomeView: UIView {
             homeCollectionView.topAnchor.constraint(equalTo: self.topAnchor, constant: 0),
             homeCollectionView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 0),
             homeCollectionView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 0),
-            homeCollectionView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: 0),
-
-            loadingIndicator.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-            loadingIndicator.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            homeCollectionView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: 0)
         ])
     }
     

--- a/NoteCard/Presentation/HomeView/HomeViewController.swift
+++ b/NoteCard/Presentation/HomeView/HomeViewController.swift
@@ -53,7 +53,6 @@ class HomeViewController: UIViewController {
     private var allMemos: [Memo] = []
     private var diffableDataSource: DiffableDataSource!
 
-    private var initialLoadCompleted = false
     private var cancellables: Set<AnyCancellable> = []
 
     private let environment: AppEnvironment
@@ -97,21 +96,9 @@ class HomeViewController: UIViewController {
 
         setupNaviBar()
         setupDiffableDataSource()
-        if environment.authService.currentUser != nil {
-            homeView.loadingIndicator.startAnimating()
-            // readiness gate 가 LoginVC 단계에서 이미 데이터 도착을 보장. 데이터 fetch 가 빠르므로 짧은 안전망만.
-            Task { [weak self] in
-                try? await Task.sleep(nanoseconds: 3_000_000_000)
-                self?.completeInitialLoad()
-            }
-        } else {
-            initialLoadCompleted = true
-        }
-
         Task {
             try await fetchData()
             applySnapshot()
-            completeInitialLoadIfDataArrived()
         }
         setupDelegates()
         bind()
@@ -296,24 +283,9 @@ class HomeViewController: UIViewController {
                 Task {
                     try await self.fetchData()
                     self.applySnapshot()
-                    self.completeInitialLoadIfDataArrived()
                 }
             }
             .store(in: &cancellables)
-    }
-
-    private func completeInitialLoadIfDataArrived() {
-        guard !initialLoadCompleted else { return }
-        let hasData = !allMemos.isEmpty || !categories.isEmpty || !favoriteMemos.isEmpty
-        if hasData {
-            completeInitialLoad()
-        }
-    }
-
-    private func completeInitialLoad() {
-        guard !initialLoadCompleted else { return }
-        initialLoadCompleted = true
-        homeView.loadingIndicator.stopAnimating()
     }
     
     @objc private func onHeaderButtonTapped(_ sender: UIButton) {

--- a/NoteCard/Presentation/HomeView/HomeViewController.swift
+++ b/NoteCard/Presentation/HomeView/HomeViewController.swift
@@ -54,7 +54,6 @@ class HomeViewController: UIViewController {
     private var diffableDataSource: DiffableDataSource!
 
     private var initialLoadCompleted = false
-    private var awaitingMigrationCleanup = false
     private var cancellables: Set<AnyCancellable> = []
 
     private let environment: AppEnvironment
@@ -98,30 +97,12 @@ class HomeViewController: UIViewController {
 
         setupNaviBar()
         setupDiffableDataSource()
-        if let userID = environment.authService.currentUser?.id {
-            let cleanupMarker = "sync.anonymousMigrationCleanup.\(userID)"
-            awaitingMigrationCleanup = !UserDefaults.standard.bool(forKey: cleanupMarker)
+        if environment.authService.currentUser != nil {
             homeView.loadingIndicator.startAnimating()
-
-            if awaitingMigrationCleanup {
-                environment.migrationCleanupCoordinator.cleanupCompletedPublisher
-                    .filter { $0 == userID }
-                    .receive(on: DispatchQueue.main)
-                    .sink { [weak self] _ in
-                        self?.awaitingMigrationCleanup = false
-                        self?.completeInitialLoad()
-                    }
-                    .store(in: &cancellables)
-                // 첫 마이그레이션은 이미지 다수 업로드 등으로 분 단위 가능. 안전망 60초.
-                Task { [weak self] in
-                    try? await Task.sleep(nanoseconds: 60_000_000_000)
-                    self?.completeInitialLoad()
-                }
-            } else {
-                Task { [weak self] in
-                    try? await Task.sleep(nanoseconds: 3_000_000_000)
-                    self?.completeInitialLoad()
-                }
+            // readiness gate 가 LoginVC 단계에서 이미 데이터 도착을 보장. 데이터 fetch 가 빠르므로 짧은 안전망만.
+            Task { [weak self] in
+                try? await Task.sleep(nanoseconds: 3_000_000_000)
+                self?.completeInitialLoad()
             }
         } else {
             initialLoadCompleted = true
@@ -323,8 +304,6 @@ class HomeViewController: UIViewController {
 
     private func completeInitialLoadIfDataArrived() {
         guard !initialLoadCompleted else { return }
-        // 첫 사인인 진행 중엔 cleanup 신호로만 종료. 데이터 일부 도착으로 조기 중단 X.
-        guard !awaitingMigrationCleanup else { return }
         let hasData = !allMemos.isEmpty || !categories.isEmpty || !favoriteMemos.isEmpty
         if hasData {
             completeInitialLoad()

--- a/NoteCard/Presentation/TabBar/MainTabBarController.swift
+++ b/NoteCard/Presentation/TabBar/MainTabBarController.swift
@@ -104,6 +104,7 @@ class MainTabBarController: UITabBarController {
             authService: environment.authService,
             accountDeletionService: environment.accountDeletionService,
             syncStatusService: environment.syncStatusService,
+            readinessCoordinator: environment.firstSignInReadinessCoordinator,
             makeTrashViewController: { [environment] in
                 MemoViewController(memoVCType: .trash, environment: environment)
             }

--- a/Projects/Core/Shared/Resources/Localizable.xcstrings
+++ b/Projects/Core/Shared/Resources/Localizable.xcstrings
@@ -2543,6 +2543,27 @@
         "en": { "stringUnit": { "state": "translated", "value": "Delete" } },
         "ko": { "stringUnit": { "state": "translated", "value": "삭제" } }
       }
+    },
+    "account.syncIncompleteMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Initial sync did not finish. You can retry it now." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "초기 동기화가 완료되지 않았습니다. 지금 다시 시도할 수 있어요." } }
+      }
+    },
+    "account.syncRetryButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Retry Sync" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "동기화 다시 시도" } }
+      }
+    },
+    "account.syncRetrySuccessMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Sync completed." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "동기화가 완료되었습니다." } }
+      }
     }
   },
   "version": "1.0"

--- a/Projects/Core/Shared/Resources/Localizable.xcstrings
+++ b/Projects/Core/Shared/Resources/Localizable.xcstrings
@@ -2313,6 +2313,74 @@
         }
       }
     },
+    "login.phaseSigningIn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signing in…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인 중…"
+          }
+        }
+      }
+    },
+    "login.phaseUploading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uploading your data…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "데이터를 올리는 중…"
+          }
+        }
+      }
+    },
+    "login.phaseDownloading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Syncing from server…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "데이터를 받아오는 중…"
+          }
+        }
+      }
+    },
+    "login.syncTimeoutError": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync is taking longer than expected. Please try again."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "동기화가 평소보다 오래 걸립니다. 다시 시도해 주세요."
+          }
+        }
+      }
+    },
     "sync.introduction.title": {
       "extractionState": "manual",
       "localizations": {

--- a/Projects/Core/Shared/Sources/Localization/L10n.swift
+++ b/Projects/Core/Shared/Sources/Localization/L10n.swift
@@ -187,6 +187,9 @@ public enum L10n {
         public static let deleteAccountConfirmTitle = "account.deleteAccountConfirmTitle".localized()
         public static let deleteAccountConfirmMessage = "account.deleteAccountConfirmMessage".localized()
         public static let deleteAccountProceed = "account.deleteAccountProceed".localized()
+        public static let syncIncompleteMessage = "account.syncIncompleteMessage".localized()
+        public static let syncRetryButton = "account.syncRetryButton".localized()
+        public static let syncRetrySuccessMessage = "account.syncRetrySuccessMessage".localized()
     }
 
     public enum ThemeColor {

--- a/Projects/Core/Shared/Sources/Localization/L10n.swift
+++ b/Projects/Core/Shared/Sources/Localization/L10n.swift
@@ -164,6 +164,10 @@ public enum L10n {
         public static let skipConfirmationTitle = "login.skipConfirmationTitle".localized()
         public static let skipConfirmationMessage = "login.skipConfirmationMessage".localized()
         public static let skipConfirmationProceed = "login.skipConfirmationProceed".localized()
+        public static let phaseSigningIn = "login.phaseSigningIn".localized()
+        public static let phaseUploading = "login.phaseUploading".localized()
+        public static let phaseDownloading = "login.phaseDownloading".localized()
+        public static let syncTimeoutError = "login.syncTimeoutError".localized()
     }
 
     public enum Account {

--- a/Projects/Core/SyncImpl/Sources/AnonymousMigrationCleanupCoordinator.swift
+++ b/Projects/Core/SyncImpl/Sources/AnonymousMigrationCleanupCoordinator.swift
@@ -60,9 +60,11 @@ public final class AnonymousMigrationCleanupCoordinator: @unchecked Sendable {
     }
 
     private func allMigrationsCompleted(for userID: String) -> Bool {
-        ["Memo", "Category", "Image"].allSatisfy { domain in
-            UserDefaults.standard.bool(forKey: "sync.anonymousToFirestore\(domain)Migration.\(userID)")
-        }
+        let memoDone = UserDefaults.standard.bool(forKey: "sync.anonymousToFirestoreMemoMigration.\(userID)")
+        let categoryDone = UserDefaults.standard.bool(forKey: "sync.anonymousToFirestoreCategoryMigration.\(userID)")
+        let imageDone = UserDefaults.standard.bool(forKey: "sync.anonymousToFirestoreImageMetadataMigration.\(userID)")
+            || UserDefaults.standard.bool(forKey: "sync.anonymousToFirestoreImageMigration.\(userID)")
+        return memoDone && categoryDone && imageDone
     }
 
     private static func cleanupMarkerKey(for userID: String) -> String {

--- a/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
@@ -38,6 +38,12 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
         listenerErrorSubject.eraseToAnyPublisher()
     }
 
+    /// listener 가 첫 비-캐시(server) snapshot 을 받으면 true 로 전이. readiness gate 신호.
+    private let initialServerSyncSubject = CurrentValueSubject<Bool, Never>(false)
+    public var initialServerSyncPublisher: AnyPublisher<Bool, Never> {
+        initialServerSyncSubject.eraseToAnyPublisher()
+    }
+
     /// listener가 채우는 in-memory 스냅샷. 읽기/쓰기 모두 `snapshotLock`으로 보호.
     private let snapshotLock = NSLock()
     private var snapshotByID: [UUID: Domain.Category] = [:]
@@ -68,6 +74,9 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
                 return
             }
             guard let snapshot else { return }
+            if !snapshot.metadata.isFromCache, !self.initialServerSyncSubject.value {
+                self.initialServerSyncSubject.send(true)
+            }
             self.handleSnapshot(snapshot)
         }
     }

--- a/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
@@ -66,15 +66,21 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
     // MARK: - Listener
 
     private func startListening() {
+        print("[DEBUG-CategoryListener] startListening for uid=\(userID)")
         listenerRegistration = collection.addSnapshotListener { [weak self] snapshot, error in
             guard let self else { return }
             if let error {
-                print("[CategoryRepoFirestore] listener error: \(error)")
+                print("[DEBUG-CategoryListener] error: \(error)")
                 self.listenerErrorSubject.send(error)
                 return
             }
-            guard let snapshot else { return }
+            guard let snapshot else {
+                print("[DEBUG-CategoryListener] nil snapshot")
+                return
+            }
+            print("[DEBUG-CategoryListener] snapshot received: docCount=\(snapshot.documents.count), isFromCache=\(snapshot.metadata.isFromCache), pendingWrites=\(snapshot.metadata.hasPendingWrites)")
             if !snapshot.metadata.isFromCache, !self.initialServerSyncSubject.value {
+                print("[DEBUG-CategoryListener] initialServerSync → true")
                 self.initialServerSyncSubject.send(true)
             }
             self.handleSnapshot(snapshot)

--- a/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
@@ -38,7 +38,9 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
         listenerErrorSubject.eraseToAnyPublisher()
     }
 
-    /// listener 가 첫 비-캐시(server) snapshot 을 받으면 true 로 전이. readiness gate 신호.
+    /// listener 가 첫 snapshot 을 받으면 true 로 전이. readiness gate 신호.
+    /// cache / server 어느 source 든 인정 — re-sign-in 직후엔 SDK 가 cache 만 발화하고 server fetch 를 생략하는 경우가 있음.
+    /// cache emission 인 경우 home 은 stale 데이터로 빠르게 진입하고, 후속 server snapshot 도착 시 categoryUpdatedPublisher 가 fire 돼 자동 refetch 됨.
     private let initialServerSyncSubject = CurrentValueSubject<Bool, Never>(false)
     public var initialServerSyncPublisher: AnyPublisher<Bool, Never> {
         initialServerSyncSubject.eraseToAnyPublisher()
@@ -79,8 +81,8 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
                 return
             }
             print("[DEBUG-CategoryListener] snapshot received: docCount=\(snapshot.documents.count), isFromCache=\(snapshot.metadata.isFromCache), pendingWrites=\(snapshot.metadata.hasPendingWrites)")
-            if !snapshot.metadata.isFromCache, !self.initialServerSyncSubject.value {
-                print("[DEBUG-CategoryListener] initialServerSync → true")
+            if !self.initialServerSyncSubject.value {
+                print("[DEBUG-CategoryListener] initialServerSync → true (isFromCache=\(snapshot.metadata.isFromCache))")
                 self.initialServerSyncSubject.send(true)
             }
             self.handleSnapshot(snapshot)

--- a/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/CategoryRepositoryFirestoreImpl.swift
@@ -68,21 +68,15 @@ public final class CategoryRepositoryFirestoreImpl: CategoryRepository, @uncheck
     // MARK: - Listener
 
     private func startListening() {
-        print("[DEBUG-CategoryListener] startListening for uid=\(userID)")
         listenerRegistration = collection.addSnapshotListener { [weak self] snapshot, error in
             guard let self else { return }
             if let error {
-                print("[DEBUG-CategoryListener] error: \(error)")
+                print("[CategoryRepoFirestore] listener error: \(error)")
                 self.listenerErrorSubject.send(error)
                 return
             }
-            guard let snapshot else {
-                print("[DEBUG-CategoryListener] nil snapshot")
-                return
-            }
-            print("[DEBUG-CategoryListener] snapshot received: docCount=\(snapshot.documents.count), isFromCache=\(snapshot.metadata.isFromCache), pendingWrites=\(snapshot.metadata.hasPendingWrites)")
+            guard let snapshot else { return }
             if !self.initialServerSyncSubject.value {
-                print("[DEBUG-CategoryListener] initialServerSync → true (isFromCache=\(snapshot.metadata.isFromCache))")
                 self.initialServerSyncSubject.send(true)
             }
             self.handleSnapshot(snapshot)

--- a/Projects/Core/SyncImpl/Sources/CategoryRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/CategoryRepositoryRouter.swift
@@ -35,10 +35,17 @@ public final class CategoryRepositoryRouter: CategoryRepository, @unchecked Send
     private var _authCancellable: AnyCancellable?
     private var _publisherCancellable: AnyCancellable?
     private var _listenerErrorCancellable: AnyCancellable?
+    private var _initialSyncCancellable: AnyCancellable?
 
     private let updatedSubject = PassthroughSubject<CategoryUpdateType, Never>()
     public var categoryUpdatedPublisher: AnyPublisher<CategoryUpdateType, Never> {
         updatedSubject.eraseToAnyPublisher()
+    }
+
+    private let initialServerSyncSubject = CurrentValueSubject<Bool, Never>(false)
+    /// 현재 활성 FirestoreImpl 의 초기 server snapshot 도착 여부. 사인아웃 시 false 로 리셋.
+    public var initialServerSyncPublisher: AnyPublisher<Bool, Never> {
+        initialServerSyncSubject.eraseToAnyPublisher()
     }
 
     public init(
@@ -69,6 +76,7 @@ public final class CategoryRepositoryRouter: CategoryRepository, @unchecked Send
             lock.unlock()
             attachForwarding(from: impl)
             attachListenerErrorHandling(from: impl)
+            attachInitialSyncForwarding(from: impl)
             // 익명 → Firestore 1회 마이그레이션 (백그라운드)
             triggerMigrationIfNeeded(to: impl, userID: userID)
         } else {
@@ -78,12 +86,25 @@ public final class CategoryRepositoryRouter: CategoryRepository, @unchecked Send
             _activeImpl = anonymousImpl
             _listenerErrorCancellable?.cancel()
             _listenerErrorCancellable = nil
+            _initialSyncCancellable?.cancel()
+            _initialSyncCancellable = nil
             lock.unlock()
             attachForwarding(from: anonymousImpl)
+            initialServerSyncSubject.send(false)
         }
         // 백엔드가 바뀌었음을 UI에 알려 재조회 유도.
         // (Core Data impl은 자발적 emit이 없고, Firestore listener도 첫 스냅샷 도착이 비동기라 둘 다 보조)
         updatedSubject.send(.update(content: .name(categoryIDs: [])))
+    }
+
+    private func attachInitialSyncForwarding(from impl: CategoryRepositoryFirestoreImpl) {
+        let newCancellable = impl.initialServerSyncPublisher.sink { [weak self] synced in
+            self?.initialServerSyncSubject.send(synced)
+        }
+        lock.lock()
+        _initialSyncCancellable?.cancel()
+        _initialSyncCancellable = newCancellable
+        lock.unlock()
     }
 
     /// Firestore listener 가 permission denied 등으로 발화하면 — 다른 기기에서 본 계정이 삭제됐다는

--- a/Projects/Core/SyncImpl/Sources/CategoryRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/CategoryRepositoryRouter.swift
@@ -98,9 +98,7 @@ public final class CategoryRepositoryRouter: CategoryRepository, @unchecked Send
     }
 
     private func attachInitialSyncForwarding(from impl: CategoryRepositoryFirestoreImpl) {
-        print("[DEBUG-CategoryRouter] attachInitialSyncForwarding")
         let newCancellable = impl.initialServerSyncPublisher.sink { [weak self] synced in
-            print("[DEBUG-CategoryRouter] forwarding initialSync=\(synced)")
             self?.initialServerSyncSubject.send(synced)
         }
         lock.lock()

--- a/Projects/Core/SyncImpl/Sources/CategoryRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/CategoryRepositoryRouter.swift
@@ -126,6 +126,16 @@ public final class CategoryRepositoryRouter: CategoryRepository, @unchecked Send
         lock.unlock()
     }
 
+    /// AccountDetail 재시도 버튼 등 외부에서 마이그레이션을 수동으로 다시 시작할 때 호출.
+    /// marker 이미 set 이면 short-circuit. 현재 활성 Firestore impl 이 없으면 no-op.
+    public func retryMigrationIfNeeded(userID: String) {
+        lock.lock()
+        let impl = _firestoreImpl
+        lock.unlock()
+        guard let impl else { return }
+        triggerMigrationIfNeeded(to: impl, userID: userID)
+    }
+
     /// 익명 카테고리를 새 Firestore impl로 이관한다. UserDefaults 마커로 기기+사용자별 1회만 수행.
     /// (재호출 시 stale 로컬이 newer Firestore를 덮어쓰는 데이터 손실 방지)
     private func triggerMigrationIfNeeded(to firestoreImpl: CategoryRepositoryFirestoreImpl, userID: String) {

--- a/Projects/Core/SyncImpl/Sources/CategoryRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/CategoryRepositoryRouter.swift
@@ -98,7 +98,9 @@ public final class CategoryRepositoryRouter: CategoryRepository, @unchecked Send
     }
 
     private func attachInitialSyncForwarding(from impl: CategoryRepositoryFirestoreImpl) {
+        print("[DEBUG-CategoryRouter] attachInitialSyncForwarding")
         let newCancellable = impl.initialServerSyncPublisher.sink { [weak self] synced in
+            print("[DEBUG-CategoryRouter] forwarding initialSync=\(synced)")
             self?.initialServerSyncSubject.send(synced)
         }
         lock.lock()

--- a/Projects/Core/SyncImpl/Sources/FirebaseFirstSignInReadinessCoordinator.swift
+++ b/Projects/Core/SyncImpl/Sources/FirebaseFirstSignInReadinessCoordinator.swift
@@ -40,23 +40,30 @@ public final class FirebaseFirstSignInReadinessCoordinator: FirstSignInReadiness
     }
 
     public func awaitReady(userID: String, timeout: TimeInterval) async throws {
+        let t0 = CFAbsoluteTimeGetCurrent()
+        print("[DEBUG-Readiness] awaitReady start")
         phaseSubject.send(.uploading)
+        print("[DEBUG-Readiness] sent .uploading @ \(String(format: "%.1f", (CFAbsoluteTimeGetCurrent() - t0) * 1000))ms")
         do {
             try await waitForCleanup(userID: userID, timeout: timeout)
         } catch {
             phaseSubject.send(.idle)
             throw error
         }
+        print("[DEBUG-Readiness] cleanup done @ \(String(format: "%.1f", (CFAbsoluteTimeGetCurrent() - t0) * 1000))ms")
 
         phaseSubject.send(.downloading)
+        print("[DEBUG-Readiness] sent .downloading @ \(String(format: "%.1f", (CFAbsoluteTimeGetCurrent() - t0) * 1000))ms")
         do {
             try await waitForInitialSync(timeout: timeout)
         } catch {
             phaseSubject.send(.idle)
             throw error
         }
+        print("[DEBUG-Readiness] initialSync done @ \(String(format: "%.1f", (CFAbsoluteTimeGetCurrent() - t0) * 1000))ms")
 
         phaseSubject.send(.ready)
+        print("[DEBUG-Readiness] sent .ready @ \(String(format: "%.1f", (CFAbsoluteTimeGetCurrent() - t0) * 1000))ms")
     }
 
     public func retryReady(userID: String, timeout: TimeInterval) async throws {

--- a/Projects/Core/SyncImpl/Sources/FirebaseFirstSignInReadinessCoordinator.swift
+++ b/Projects/Core/SyncImpl/Sources/FirebaseFirstSignInReadinessCoordinator.swift
@@ -12,6 +12,7 @@ public final class FirebaseFirstSignInReadinessCoordinator: FirstSignInReadiness
     private let cleanupCoordinator: AnonymousMigrationCleanupCoordinator
     private let memoRouter: MemoRepositoryRouter
     private let categoryRouter: CategoryRepositoryRouter
+    private let imageRouter: ImageRepositoryRouter
 
     private let phaseSubject = CurrentValueSubject<SignInPhase, Never>(.idle)
     public var phasePublisher: AnyPublisher<SignInPhase, Never> {
@@ -21,11 +22,13 @@ public final class FirebaseFirstSignInReadinessCoordinator: FirstSignInReadiness
     public init(
         cleanupCoordinator: AnonymousMigrationCleanupCoordinator,
         memoRouter: MemoRepositoryRouter,
-        categoryRouter: CategoryRepositoryRouter
+        categoryRouter: CategoryRepositoryRouter,
+        imageRouter: ImageRepositoryRouter
     ) {
         self.cleanupCoordinator = cleanupCoordinator
         self.memoRouter = memoRouter
         self.categoryRouter = categoryRouter
+        self.imageRouter = imageRouter
     }
 
     public func reportSigningIn() {
@@ -54,6 +57,13 @@ public final class FirebaseFirstSignInReadinessCoordinator: FirstSignInReadiness
         }
 
         phaseSubject.send(.ready)
+    }
+
+    public func retryReady(userID: String, timeout: TimeInterval) async throws {
+        memoRouter.retryMigrationIfNeeded(userID: userID)
+        categoryRouter.retryMigrationIfNeeded(userID: userID)
+        imageRouter.retryMigrationIfNeeded(userID: userID)
+        try await awaitReady(userID: userID, timeout: timeout)
     }
 
     private func waitForCleanup(userID: String, timeout: TimeInterval) async throws {

--- a/Projects/Core/SyncImpl/Sources/FirebaseFirstSignInReadinessCoordinator.swift
+++ b/Projects/Core/SyncImpl/Sources/FirebaseFirstSignInReadinessCoordinator.swift
@@ -1,0 +1,119 @@
+//
+//  FirebaseFirstSignInReadinessCoordinator.swift
+//  NoteCard
+//
+
+import Combine
+import Foundation
+import SyncInterface
+
+public final class FirebaseFirstSignInReadinessCoordinator: FirstSignInReadinessCoordinator, @unchecked Sendable {
+
+    private let cleanupCoordinator: AnonymousMigrationCleanupCoordinator
+    private let memoRouter: MemoRepositoryRouter
+    private let categoryRouter: CategoryRepositoryRouter
+
+    private let phaseSubject = CurrentValueSubject<SignInPhase, Never>(.idle)
+    public var phasePublisher: AnyPublisher<SignInPhase, Never> {
+        phaseSubject.eraseToAnyPublisher()
+    }
+
+    public init(
+        cleanupCoordinator: AnonymousMigrationCleanupCoordinator,
+        memoRouter: MemoRepositoryRouter,
+        categoryRouter: CategoryRepositoryRouter
+    ) {
+        self.cleanupCoordinator = cleanupCoordinator
+        self.memoRouter = memoRouter
+        self.categoryRouter = categoryRouter
+    }
+
+    public func reportSigningIn() {
+        phaseSubject.send(.signingIn)
+    }
+
+    public func reset() {
+        phaseSubject.send(.idle)
+    }
+
+    public func awaitReady(userID: String, timeout: TimeInterval) async throws {
+        phaseSubject.send(.uploading)
+        do {
+            try await waitForCleanup(userID: userID, timeout: timeout)
+        } catch {
+            phaseSubject.send(.idle)
+            throw error
+        }
+
+        phaseSubject.send(.downloading)
+        do {
+            try await waitForInitialSync(timeout: timeout)
+        } catch {
+            phaseSubject.send(.idle)
+            throw error
+        }
+
+        phaseSubject.send(.ready)
+    }
+
+    private func waitForCleanup(userID: String, timeout: TimeInterval) async throws {
+        let cleanupMarkerKey = "sync.anonymousMigrationCleanup.\(userID)"
+        if UserDefaults.standard.bool(forKey: cleanupMarkerKey) {
+            return
+        }
+
+        try await withTimeout(seconds: timeout) {
+            await self.cleanupCoordinator.cleanupCompletedPublisher
+                .filter { $0 == userID }
+                .firstValue()
+        }
+    }
+
+    private func waitForInitialSync(timeout: TimeInterval) async throws {
+        try await withTimeout(seconds: timeout) {
+            await Publishers.CombineLatest(
+                self.memoRouter.initialServerSyncPublisher,
+                self.categoryRouter.initialServerSyncPublisher
+            )
+            .first(where: { $0 && $1 })
+            .firstValue()
+        }
+    }
+
+    private func withTimeout<T: Sendable>(seconds: TimeInterval, _ work: @escaping @Sendable () async -> T) async throws -> T {
+        try await withThrowingTaskGroup(of: T?.self) { group in
+            group.addTask {
+                await work()
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                throw SignInReadinessError.timeout
+            }
+            guard let result = try await group.next(), let value = result else {
+                throw SignInReadinessError.timeout
+            }
+            group.cancelAll()
+            return value
+        }
+    }
+}
+
+private extension Publisher where Failure == Never {
+    func firstValue() async -> Output {
+        await withCheckedContinuation { continuation in
+            var resumed = false
+            var cancellable: AnyCancellable?
+            cancellable = self.first().sink(
+                receiveCompletion: { _ in
+                    cancellable?.cancel()
+                },
+                receiveValue: { value in
+                    guard !resumed else { return }
+                    resumed = true
+                    cancellable?.cancel()
+                    continuation.resume(returning: value)
+                }
+            )
+        }
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/FirebaseFirstSignInReadinessCoordinator.swift
+++ b/Projects/Core/SyncImpl/Sources/FirebaseFirstSignInReadinessCoordinator.swift
@@ -40,30 +40,23 @@ public final class FirebaseFirstSignInReadinessCoordinator: FirstSignInReadiness
     }
 
     public func awaitReady(userID: String, timeout: TimeInterval) async throws {
-        let t0 = CFAbsoluteTimeGetCurrent()
-        print("[DEBUG-Readiness] awaitReady start")
         phaseSubject.send(.uploading)
-        print("[DEBUG-Readiness] sent .uploading @ \(String(format: "%.1f", (CFAbsoluteTimeGetCurrent() - t0) * 1000))ms")
         do {
             try await waitForCleanup(userID: userID, timeout: timeout)
         } catch {
             phaseSubject.send(.idle)
             throw error
         }
-        print("[DEBUG-Readiness] cleanup done @ \(String(format: "%.1f", (CFAbsoluteTimeGetCurrent() - t0) * 1000))ms")
 
         phaseSubject.send(.downloading)
-        print("[DEBUG-Readiness] sent .downloading @ \(String(format: "%.1f", (CFAbsoluteTimeGetCurrent() - t0) * 1000))ms")
         do {
             try await waitForInitialSync(timeout: timeout)
         } catch {
             phaseSubject.send(.idle)
             throw error
         }
-        print("[DEBUG-Readiness] initialSync done @ \(String(format: "%.1f", (CFAbsoluteTimeGetCurrent() - t0) * 1000))ms")
 
         phaseSubject.send(.ready)
-        print("[DEBUG-Readiness] sent .ready @ \(String(format: "%.1f", (CFAbsoluteTimeGetCurrent() - t0) * 1000))ms")
     }
 
     public func retryReady(userID: String, timeout: TimeInterval) async throws {

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
@@ -242,36 +242,40 @@ public final class ImageRepositoryFirestoreImpl: ImageRepository, @unchecked Sen
 
     // MARK: - Migration
 
-    /// 외부 소스(익명 Core Data)에서 받은 이미지들을 Firestore + Storage로 import.
-    /// 로컬 파일이 있어야 업로드 가능 — 누락된 이미지는 스킵하고 계속.
-    /// 멱등: 같은 ID에 대해선 setData(merge:true)로 메타데이터 덮어쓰기, Storage는 동일 경로 putData로 덮어쓰기.
-    func importImages(_ images: [MemoImageInfo]) async throws {
+    /// 익명 Core Data 의 이미지 메타데이터만 Firestore 에 import. Storage 바이너리 업로드는 별도 단계.
+    /// 한 장 실패해도 다음 진행. setData(merge: true) 로 멱등.
+    func importImageMetadata(_ images: [MemoImageInfo]) async throws {
         for info in images {
             do {
-                try await migrateImage(info)
+                var payload = try Firestore.Encoder().encode(FirestoreMemoImage(info))
+                payload["serverUpdatedAt"] = FieldValue.serverTimestamp()
+                try await imageCollection(for: info.memoID).document(info.id.uuidString).setData(payload, merge: true)
             } catch {
-                // 한 장 실패해도 다음 진행 — 누락 이미지 등 흔한 케이스. 로그만 남김.
-                print("[ImageRepoFirestore] import skipped for \(info.id): \(error)")
+                print("[ImageRepoFirestore] meta import skipped for \(info.id): \(error)")
             }
         }
     }
 
-    private func migrateImage(_ info: MemoImageInfo) async throws {
-        let originalURL = try ImageFileHandler.getFileURL(for: info, thumbnail: false)
-        let thumbnailURL = try ImageFileHandler.getFileURL(for: info, thumbnail: true)
-        let originalData = try Data(contentsOf: originalURL)
-        let thumbnailData = try Data(contentsOf: thumbnailURL)
+    /// 익명 이미지의 원본 + 썸네일 바이너리를 Storage 로 업로드. 메타와 분리돼 사용자 readiness gate 와 무관하게
+    /// 백그라운드에서 진행. 한 장 실패해도 다음 진행. putData 가 동일 path 멱등 덮어쓰기.
+    func uploadImageBinaries(_ images: [MemoImageInfo]) async throws {
+        for info in images {
+            do {
+                let originalURL = try ImageFileHandler.getFileURL(for: info, thumbnail: false)
+                let thumbnailURL = try ImageFileHandler.getFileURL(for: info, thumbnail: true)
+                let originalData = try Data(contentsOf: originalURL)
+                let thumbnailData = try Data(contentsOf: thumbnailURL)
 
-        async let originalUpload: StorageMetadata = originalStorageRef(
-            memoID: info.memoID, imageID: info.id, fileExtension: info.fileExtension
-        ).putDataAsync(originalData)
-        async let thumbnailUpload: StorageMetadata = thumbnailStorageRef(
-            memoID: info.memoID, thumbnailID: info.thumbnailID
-        ).putDataAsync(thumbnailData)
-        _ = try await (originalUpload, thumbnailUpload)
-
-        var payload = try Firestore.Encoder().encode(FirestoreMemoImage(info))
-        payload["serverUpdatedAt"] = FieldValue.serverTimestamp()
-        try await imageCollection(for: info.memoID).document(info.id.uuidString).setData(payload, merge: true)
+                async let originalUpload: StorageMetadata = originalStorageRef(
+                    memoID: info.memoID, imageID: info.id, fileExtension: info.fileExtension
+                ).putDataAsync(originalData)
+                async let thumbnailUpload: StorageMetadata = thumbnailStorageRef(
+                    memoID: info.memoID, thumbnailID: info.thumbnailID
+                ).putDataAsync(thumbnailData)
+                _ = try await (originalUpload, thumbnailUpload)
+            } catch {
+                print("[ImageRepoFirestore] binary upload skipped for \(info.id): \(error)")
+            }
+        }
     }
 }

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
@@ -79,6 +79,16 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
         }
     }
 
+    /// AccountDetail 재시도 버튼 등 외부에서 마이그레이션을 수동으로 다시 시작할 때 호출.
+    /// marker 이미 set 이면 short-circuit. 현재 활성 Firestore impl 이 없으면 no-op.
+    public func retryMigrationIfNeeded(userID: String) {
+        lock.lock()
+        let impl = _firestoreImpl
+        lock.unlock()
+        guard let impl else { return }
+        triggerMigrationIfNeeded(to: impl, userID: userID)
+    }
+
     /// 익명 이미지 메타데이터를 Firestore 로 이관. UserDefaults 마커로 기기+사용자별 1회.
     /// 메타 업로드 완료 시점에 marker set + cleanupCoordinator 보고 (= readiness gate 통과 신호).
     /// 바이너리 업로드는 분리된 백그라운드 Task — readiness gate 와 무관.

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
@@ -79,11 +79,16 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
         }
     }
 
-    /// 익명 이미지를 새 Firestore impl로 이관. UserDefaults 마커로 기기+사용자별 1회.
+    /// 익명 이미지 메타데이터를 Firestore 로 이관. UserDefaults 마커로 기기+사용자별 1회.
+    /// 메타 업로드 완료 시점에 marker set + cleanupCoordinator 보고 (= readiness gate 통과 신호).
+    /// 바이너리 업로드는 분리된 백그라운드 Task — readiness gate 와 무관.
     private func triggerMigrationIfNeeded(to firestoreImpl: ImageRepositoryFirestoreImpl, userID: String) {
-        let markerKey = "sync.anonymousToFirestoreImageMigration.\(userID)"
+        let metaMarkerKey = Self.metaMarkerKey(for: userID)
+        let legacyMarkerKey = Self.legacyMarkerKey(for: userID)
         let coordinator = cleanupCoordinator
-        if UserDefaults.standard.bool(forKey: markerKey) {
+
+        // v2.5.0 에서 set 된 통합 marker 가 있으면 메타도 완료된 것으로 인정 (호환).
+        if UserDefaults.standard.bool(forKey: metaMarkerKey) || UserDefaults.standard.bool(forKey: legacyMarkerKey) {
             Task { await coordinator.reportMigrationCompleted(userID: userID) }
             return
         }
@@ -92,7 +97,6 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
         Task { [weak firestoreImpl] in
             guard let firestoreImpl else { return }
             do {
-                // 활성 메모 + 휴지통 메모 양쪽에서 이미지 수집
                 let active = try await memoRepo.getAllMemos()
                 let trashed = try await memoRepo.getAllMemosInTrash()
                 var collected: [MemoImageInfo] = []
@@ -101,14 +105,25 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
                     collected.append(contentsOf: images)
                 }
                 if !collected.isEmpty {
-                    try await firestoreImpl.importImages(collected)
+                    try await firestoreImpl.importImageMetadata(collected)
                 }
-                UserDefaults.standard.set(true, forKey: markerKey)
+                UserDefaults.standard.set(true, forKey: metaMarkerKey)
                 await coordinator.reportMigrationCompleted(userID: userID)
+                if !collected.isEmpty {
+                    try await firestoreImpl.uploadImageBinaries(collected)
+                }
             } catch {
                 print("[ImageRepositoryRouter] migration error: \(error)")
             }
         }
+    }
+
+    static func metaMarkerKey(for userID: String) -> String {
+        "sync.anonymousToFirestoreImageMetadataMigration.\(userID)"
+    }
+
+    static func legacyMarkerKey(for userID: String) -> String {
+        "sync.anonymousToFirestoreImageMigration.\(userID)"
     }
 
     private func attachForwarding(from impl: ImageRepository) {

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
@@ -85,21 +85,15 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
     // MARK: - Listener
 
     private func startListening() {
-        print("[DEBUG-MemoListener] startListening for uid=\(userID)")
         listenerRegistration = collection.addSnapshotListener { [weak self] snapshot, error in
             guard let self else { return }
             if let error {
-                print("[DEBUG-MemoListener] error: \(error)")
+                print("[MemoRepoFirestore] listener error: \(error)")
                 self.listenerErrorSubject.send(error)
                 return
             }
-            guard let snapshot else {
-                print("[DEBUG-MemoListener] nil snapshot")
-                return
-            }
-            print("[DEBUG-MemoListener] snapshot received: docCount=\(snapshot.documents.count), isFromCache=\(snapshot.metadata.isFromCache), pendingWrites=\(snapshot.metadata.hasPendingWrites)")
+            guard let snapshot else { return }
             if !self.initialServerSyncSubject.value {
-                print("[DEBUG-MemoListener] initialServerSync → true (isFromCache=\(snapshot.metadata.isFromCache))")
                 self.initialServerSyncSubject.send(true)
             }
             self.handleSnapshot(snapshot)

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
@@ -40,6 +40,12 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
         listenerErrorSubject.eraseToAnyPublisher()
     }
 
+    /// listener 가 첫 비-캐시(server) snapshot 을 받으면 true 로 전이. readiness gate 신호.
+    private let initialServerSyncSubject = CurrentValueSubject<Bool, Never>(false)
+    public var initialServerSyncPublisher: AnyPublisher<Bool, Never> {
+        initialServerSyncSubject.eraseToAnyPublisher()
+    }
+
     /// listener가 채우는 in-memory DTO 스냅샷. 카테고리는 read 시점에 해석.
     private let snapshotLock = NSLock()
     private var snapshotDTOByID: [UUID: FirestoreMemo] = [:]
@@ -85,6 +91,9 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
                 return
             }
             guard let snapshot else { return }
+            if !snapshot.metadata.isFromCache, !self.initialServerSyncSubject.value {
+                self.initialServerSyncSubject.send(true)
+            }
             self.handleSnapshot(snapshot)
         }
     }

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
@@ -83,15 +83,21 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
     // MARK: - Listener
 
     private func startListening() {
+        print("[DEBUG-MemoListener] startListening for uid=\(userID)")
         listenerRegistration = collection.addSnapshotListener { [weak self] snapshot, error in
             guard let self else { return }
             if let error {
-                print("[MemoRepoFirestore] listener error: \(error)")
+                print("[DEBUG-MemoListener] error: \(error)")
                 self.listenerErrorSubject.send(error)
                 return
             }
-            guard let snapshot else { return }
+            guard let snapshot else {
+                print("[DEBUG-MemoListener] nil snapshot")
+                return
+            }
+            print("[DEBUG-MemoListener] snapshot received: docCount=\(snapshot.documents.count), isFromCache=\(snapshot.metadata.isFromCache), pendingWrites=\(snapshot.metadata.hasPendingWrites)")
             if !snapshot.metadata.isFromCache, !self.initialServerSyncSubject.value {
+                print("[DEBUG-MemoListener] initialServerSync → true")
                 self.initialServerSyncSubject.send(true)
             }
             self.handleSnapshot(snapshot)

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryFirestoreImpl.swift
@@ -40,7 +40,9 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
         listenerErrorSubject.eraseToAnyPublisher()
     }
 
-    /// listener 가 첫 비-캐시(server) snapshot 을 받으면 true 로 전이. readiness gate 신호.
+    /// listener 가 첫 snapshot 을 받으면 true 로 전이. readiness gate 신호.
+    /// cache / server 어느 source 든 인정 — re-sign-in 직후엔 SDK 가 cache 만 발화하고 server fetch 를 생략하는 경우가 있음.
+    /// cache emission 인 경우 home 은 stale 데이터로 빠르게 진입하고, 후속 server snapshot 도착 시 memoUpdatedPublisher 가 fire 돼 자동 refetch 됨.
     private let initialServerSyncSubject = CurrentValueSubject<Bool, Never>(false)
     public var initialServerSyncPublisher: AnyPublisher<Bool, Never> {
         initialServerSyncSubject.eraseToAnyPublisher()
@@ -96,8 +98,8 @@ public final class MemoRepositoryFirestoreImpl: MemoRepository, @unchecked Senda
                 return
             }
             print("[DEBUG-MemoListener] snapshot received: docCount=\(snapshot.documents.count), isFromCache=\(snapshot.metadata.isFromCache), pendingWrites=\(snapshot.metadata.hasPendingWrites)")
-            if !snapshot.metadata.isFromCache, !self.initialServerSyncSubject.value {
-                print("[DEBUG-MemoListener] initialServerSync → true")
+            if !self.initialServerSyncSubject.value {
+                print("[DEBUG-MemoListener] initialServerSync → true (isFromCache=\(snapshot.metadata.isFromCache))")
                 self.initialServerSyncSubject.send(true)
             }
             self.handleSnapshot(snapshot)

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryRouter.swift
@@ -98,7 +98,9 @@ public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
     }
 
     private func attachInitialSyncForwarding(from impl: MemoRepositoryFirestoreImpl) {
+        print("[DEBUG-MemoRouter] attachInitialSyncForwarding")
         let newCancellable = impl.initialServerSyncPublisher.sink { [weak self] synced in
+            print("[DEBUG-MemoRouter] forwarding initialSync=\(synced)")
             self?.initialServerSyncSubject.send(synced)
         }
         lock.lock()

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryRouter.swift
@@ -98,9 +98,7 @@ public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
     }
 
     private func attachInitialSyncForwarding(from impl: MemoRepositoryFirestoreImpl) {
-        print("[DEBUG-MemoRouter] attachInitialSyncForwarding")
         let newCancellable = impl.initialServerSyncPublisher.sink { [weak self] synced in
-            print("[DEBUG-MemoRouter] forwarding initialSync=\(synced)")
             self?.initialServerSyncSubject.send(synced)
         }
         lock.lock()

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryRouter.swift
@@ -31,10 +31,17 @@ public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
     private var _authCancellable: AnyCancellable?
     private var _publisherCancellable: AnyCancellable?
     private var _listenerErrorCancellable: AnyCancellable?
+    private var _initialSyncCancellable: AnyCancellable?
 
     private let updatedSubject = PassthroughSubject<MemoUpdateType, Never>()
     public var memoUpdatedPublisher: AnyPublisher<MemoUpdateType, Never> {
         updatedSubject.eraseToAnyPublisher()
+    }
+
+    private let initialServerSyncSubject = CurrentValueSubject<Bool, Never>(false)
+    /// 현재 활성 FirestoreImpl 의 초기 server snapshot 도착 여부. 사인아웃 시 false 로 리셋.
+    public var initialServerSyncPublisher: AnyPublisher<Bool, Never> {
+        initialServerSyncSubject.eraseToAnyPublisher()
     }
 
     public init(
@@ -72,6 +79,7 @@ public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
             lock.unlock()
             attachForwarding(from: impl)
             attachListenerErrorHandling(from: impl)
+            attachInitialSyncForwarding(from: impl)
             triggerMigrationIfNeeded(to: impl, userID: userID)
         } else {
             lock.lock()
@@ -79,11 +87,24 @@ public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
             _activeImpl = anonymousImpl
             _listenerErrorCancellable?.cancel()
             _listenerErrorCancellable = nil
+            _initialSyncCancellable?.cancel()
+            _initialSyncCancellable = nil
             lock.unlock()
             attachForwarding(from: anonymousImpl)
+            initialServerSyncSubject.send(false)
         }
         // 백엔드 전환을 UI에 알려 재조회 유도.
         updatedSubject.send(.update(content: .titleText(memoIDs: [])))
+    }
+
+    private func attachInitialSyncForwarding(from impl: MemoRepositoryFirestoreImpl) {
+        let newCancellable = impl.initialServerSyncPublisher.sink { [weak self] synced in
+            self?.initialServerSyncSubject.send(synced)
+        }
+        lock.lock()
+        _initialSyncCancellable?.cancel()
+        _initialSyncCancellable = newCancellable
+        lock.unlock()
     }
 
     /// Firestore listener 가 permission denied 등으로 발화하면 — 보통 다른 기기에서 본 계정이

--- a/Projects/Core/SyncImpl/Sources/MemoRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/MemoRepositoryRouter.swift
@@ -126,6 +126,16 @@ public final class MemoRepositoryRouter: MemoRepository, @unchecked Sendable {
         lock.unlock()
     }
 
+    /// AccountDetail 재시도 버튼 등 외부에서 마이그레이션을 수동으로 다시 시작할 때 호출.
+    /// marker 이미 set 이면 short-circuit. 현재 활성 Firestore impl 이 없으면 no-op.
+    public func retryMigrationIfNeeded(userID: String) {
+        lock.lock()
+        let impl = _firestoreImpl
+        lock.unlock()
+        guard let impl else { return }
+        triggerMigrationIfNeeded(to: impl, userID: userID)
+    }
+
     /// 익명 메모(휴지통 포함)를 새 Firestore impl로 이관. UserDefaults 마커로 기기+사용자별 1회.
     private func triggerMigrationIfNeeded(to firestoreImpl: MemoRepositoryFirestoreImpl, userID: String) {
         let markerKey = "sync.anonymousToFirestoreMemoMigration.\(userID)"

--- a/Projects/Core/SyncImpl/Sources/NoOpFirstSignInReadinessCoordinator.swift
+++ b/Projects/Core/SyncImpl/Sources/NoOpFirstSignInReadinessCoordinator.swift
@@ -1,0 +1,23 @@
+//
+//  NoOpFirstSignInReadinessCoordinator.swift
+//  NoteCard
+//
+
+import Combine
+import Foundation
+import SyncInterface
+
+/// Firebase 미설정 환경에서 사용. 모든 메서드 즉시 반환 / no-op.
+public final class NoOpFirstSignInReadinessCoordinator: FirstSignInReadinessCoordinator, @unchecked Sendable {
+
+    private let phaseSubject = CurrentValueSubject<SignInPhase, Never>(.idle)
+    public var phasePublisher: AnyPublisher<SignInPhase, Never> {
+        phaseSubject.eraseToAnyPublisher()
+    }
+
+    public init() {}
+
+    public func reportSigningIn() {}
+    public func reset() {}
+    public func awaitReady(userID: String, timeout: TimeInterval) async throws {}
+}

--- a/Projects/Core/SyncImpl/Sources/NoOpFirstSignInReadinessCoordinator.swift
+++ b/Projects/Core/SyncImpl/Sources/NoOpFirstSignInReadinessCoordinator.swift
@@ -20,4 +20,5 @@ public final class NoOpFirstSignInReadinessCoordinator: FirstSignInReadinessCoor
     public func reportSigningIn() {}
     public func reset() {}
     public func awaitReady(userID: String, timeout: TimeInterval) async throws {}
+    public func retryReady(userID: String, timeout: TimeInterval) async throws {}
 }

--- a/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
+++ b/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
@@ -132,4 +132,24 @@ public enum SyncBootstrap {
             categoryRepository: categoryRepository
         )
     }
+
+    /// 첫 사인인 후 home 진입 가능 시점까지 대기시키는 readiness gate. Firebase 미설정 시 즉시 통과.
+    /// memoRepository / categoryRepository 가 Router 구현이 아니면 (= 익명 단독) 게이트가 의미 없어 NoOp 반환.
+    public static func makeFirstSignInReadinessCoordinator(
+        cleanupCoordinator: AnonymousMigrationCleanupCoordinator,
+        memoRepository: MemoRepository,
+        categoryRepository: CategoryRepository
+    ) -> FirstSignInReadinessCoordinator {
+        guard FirebaseApp.app() != nil,
+              let memoRouter = memoRepository as? MemoRepositoryRouter,
+              let categoryRouter = categoryRepository as? CategoryRepositoryRouter
+        else {
+            return NoOpFirstSignInReadinessCoordinator()
+        }
+        return FirebaseFirstSignInReadinessCoordinator(
+            cleanupCoordinator: cleanupCoordinator,
+            memoRouter: memoRouter,
+            categoryRouter: categoryRouter
+        )
+    }
 }

--- a/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
+++ b/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
@@ -134,22 +134,25 @@ public enum SyncBootstrap {
     }
 
     /// 첫 사인인 후 home 진입 가능 시점까지 대기시키는 readiness gate. Firebase 미설정 시 즉시 통과.
-    /// memoRepository / categoryRepository 가 Router 구현이 아니면 (= 익명 단독) 게이트가 의미 없어 NoOp 반환.
+    /// 세 Repository 가 모두 Router 구현이 아니면 (= 익명 단독) 게이트가 의미 없어 NoOp 반환.
     public static func makeFirstSignInReadinessCoordinator(
         cleanupCoordinator: AnonymousMigrationCleanupCoordinator,
         memoRepository: MemoRepository,
-        categoryRepository: CategoryRepository
+        categoryRepository: CategoryRepository,
+        imageRepository: ImageRepository
     ) -> FirstSignInReadinessCoordinator {
         guard FirebaseApp.app() != nil,
               let memoRouter = memoRepository as? MemoRepositoryRouter,
-              let categoryRouter = categoryRepository as? CategoryRepositoryRouter
+              let categoryRouter = categoryRepository as? CategoryRepositoryRouter,
+              let imageRouter = imageRepository as? ImageRepositoryRouter
         else {
             return NoOpFirstSignInReadinessCoordinator()
         }
         return FirebaseFirstSignInReadinessCoordinator(
             cleanupCoordinator: cleanupCoordinator,
             memoRouter: memoRouter,
-            categoryRouter: categoryRouter
+            categoryRouter: categoryRouter,
+            imageRouter: imageRouter
         )
     }
 }

--- a/Projects/Core/SyncInterface/Sources/FirstSignInReadinessCoordinator.swift
+++ b/Projects/Core/SyncInterface/Sources/FirstSignInReadinessCoordinator.swift
@@ -1,0 +1,34 @@
+//
+//  FirstSignInReadinessCoordinator.swift
+//  NoteCard
+//
+
+import Combine
+import Foundation
+
+/// 사인인 시점부터 home 진입 가능 상태까지의 단계를 표현.
+public enum SignInPhase: Equatable, Sendable {
+    case idle
+    case signingIn
+    case uploading
+    case downloading
+    case ready
+}
+
+public enum SignInReadinessError: Error, Sendable {
+    case timeout
+}
+
+/// 첫 사인인 후 사용자가 home 으로 진입해도 안전한 시점까지 대기.
+///
+/// awaitReady 는 다음 조건을 모두 만족할 때 반환:
+/// - 익명 → Firestore 마이그레이션 완료 (Memo / Category / Image 메타 marker set + cleanup 완료)
+/// - 사용자 데이터의 첫 server snapshot 도착 (Memo + Category listener)
+///
+/// phasePublisher 는 UI 가 사인인 진행 상태를 표시할 수 있도록 단계를 emit.
+public protocol FirstSignInReadinessCoordinator: Sendable {
+    var phasePublisher: AnyPublisher<SignInPhase, Never> { get }
+    func reportSigningIn()
+    func awaitReady(userID: String, timeout: TimeInterval) async throws
+    func reset()
+}

--- a/Projects/Core/SyncInterface/Sources/FirstSignInReadinessCoordinator.swift
+++ b/Projects/Core/SyncInterface/Sources/FirstSignInReadinessCoordinator.swift
@@ -30,5 +30,14 @@ public protocol FirstSignInReadinessCoordinator: Sendable {
     var phasePublisher: AnyPublisher<SignInPhase, Never> { get }
     func reportSigningIn()
     func awaitReady(userID: String, timeout: TimeInterval) async throws
+    func retryReady(userID: String, timeout: TimeInterval) async throws
     func reset()
+}
+
+public extension FirstSignInReadinessCoordinator {
+    /// 현재 사용자에 대해 동기화가 완료됐는지 검사. cleanup 마커 set 이면 완료로 간주.
+    /// AccountDetail 등 UI 가 재시도 버튼 노출 여부를 결정할 때 사용.
+    func isSyncCompleted(for userID: String) -> Bool {
+        UserDefaults.standard.bool(forKey: "sync.anonymousMigrationCleanup.\(userID)")
+    }
 }

--- a/Projects/Feature/LoginFeature/Sources/LoginView.swift
+++ b/Projects/Feature/LoginFeature/Sources/LoginView.swift
@@ -56,6 +56,16 @@ final class LoginView: UIView {
         return view
     }()
 
+    let phaseLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 13)
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
     private lazy var topStack: UIStackView = {
         let stack = UIStackView(arrangedSubviews: [titleLabel, promptLabel])
         stack.axis = .vertical
@@ -91,6 +101,7 @@ final class LoginView: UIView {
         addSubview(topStack)
         addSubview(buttonStack)
         addSubview(activityIndicator)
+        addSubview(phaseLabel)
     }
 
     private func setupConstraints() {
@@ -108,6 +119,10 @@ final class LoginView: UIView {
 
             activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
             activityIndicator.topAnchor.constraint(equalTo: signInButton.bottomAnchor, constant: 12),
+
+            phaseLabel.topAnchor.constraint(equalTo: activityIndicator.bottomAnchor, constant: 8),
+            phaseLabel.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            phaseLabel.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -24)
         ])
     }
 }

--- a/Projects/Feature/LoginFeature/Sources/LoginView.swift
+++ b/Projects/Feature/LoginFeature/Sources/LoginView.swift
@@ -50,21 +50,6 @@ final class LoginView: UIView {
         return label
     }()
 
-    let activityIndicator: UIActivityIndicatorView = {
-        let view = UIActivityIndicatorView(style: .medium)
-        view.hidesWhenStopped = true
-        return view
-    }()
-
-    let phaseLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 13)
-        label.textColor = .secondaryLabel
-        label.textAlignment = .center
-        label.numberOfLines = 0
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
 
     private lazy var topStack: UIStackView = {
         let stack = UIStackView(arrangedSubviews: [titleLabel, promptLabel])
@@ -96,12 +81,9 @@ final class LoginView: UIView {
 
     private func setupUI() {
         backgroundColor = .loginBackground
-        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
 
         addSubview(topStack)
         addSubview(buttonStack)
-        addSubview(activityIndicator)
-        addSubview(phaseLabel)
     }
 
     private func setupConstraints() {
@@ -115,14 +97,7 @@ final class LoginView: UIView {
             buttonStack.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -24),
             buttonStack.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -40),
 
-            signInButton.heightAnchor.constraint(equalToConstant: 50),
-
-            activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
-            activityIndicator.topAnchor.constraint(equalTo: signInButton.bottomAnchor, constant: 12),
-
-            phaseLabel.topAnchor.constraint(equalTo: activityIndicator.bottomAnchor, constant: 8),
-            phaseLabel.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 24),
-            phaseLabel.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -24)
+            signInButton.heightAnchor.constraint(equalToConstant: 50)
         ])
     }
 }

--- a/Projects/Feature/LoginFeature/Sources/LoginViewController.swift
+++ b/Projects/Feature/LoginFeature/Sources/LoginViewController.swift
@@ -126,9 +126,27 @@ public final class LoginViewController: UIViewController {
         )
         alert.addAction(UIAlertAction(title: L10n.Common.cancel, style: .cancel))
         alert.addAction(UIAlertAction(title: L10n.Login.skipConfirmationProceed, style: .default) { [weak self] _ in
-            self?.onCompletion(.skipped)
+            self?.proceedWithSkip()
         })
         present(alert, animated: true)
+    }
+
+    /// readiness gate 가 실패한 뒤 사용자가 skip 을 누른 경우, Firebase 측은 sign-in 된 상태가 잔존.
+    /// UI 와 인증 상태를 일치시키기 위해 sign-out 후 .skipped emit.
+    private func proceedWithSkip() {
+        if authService.currentUser == nil {
+            onCompletion(.skipped)
+            return
+        }
+        setLoading(true)
+        Task { [weak self] in
+            guard let self else { return }
+            try? await self.authService.signOut()
+            await MainActor.run {
+                self.setLoading(false)
+                self.onCompletion(.skipped)
+            }
+        }
     }
 
     // MARK: - Private

--- a/Projects/Feature/LoginFeature/Sources/LoginViewController.swift
+++ b/Projects/Feature/LoginFeature/Sources/LoginViewController.swift
@@ -59,29 +59,6 @@ public final class LoginViewController: UIViewController {
         super.viewDidLoad()
         rootView.signInButton.addTarget(self, action: #selector(signInTapped), for: .touchUpInside)
         rootView.skipButton.addTarget(self, action: #selector(skipTapped), for: .touchUpInside)
-        bindPhase()
-    }
-
-    private func bindPhase() {
-        readinessCoordinator.phasePublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] phase in
-                self?.renderPhase(phase)
-            }
-            .store(in: &cancellables)
-    }
-
-    private func renderPhase(_ phase: SignInPhase) {
-        switch phase {
-        case .idle, .ready:
-            rootView.phaseLabel.text = nil
-        case .signingIn:
-            rootView.phaseLabel.text = L10n.Login.phaseSigningIn
-        case .uploading:
-            rootView.phaseLabel.text = L10n.Login.phaseUploading
-        case .downloading:
-            rootView.phaseLabel.text = L10n.Login.phaseDownloading
-        }
     }
 
     // MARK: - Actions
@@ -168,10 +145,7 @@ public final class LoginViewController: UIViewController {
     private func setLoading(_ loading: Bool) {
         rootView.signInButton.isEnabled = !loading
         rootView.skipButton.isEnabled = !loading
-        if loading {
-            rootView.activityIndicator.startAnimating()
-        } else {
-            rootView.activityIndicator.stopAnimating()
+        if !loading {
             readinessCoordinator.reset()
         }
     }

--- a/Projects/Feature/LoginFeature/Sources/LoginViewController.swift
+++ b/Projects/Feature/LoginFeature/Sources/LoginViewController.swift
@@ -3,6 +3,7 @@
 //  NoteCard
 //
 
+import Combine
 import Shared
 import SyncInterface
 import UIKit
@@ -20,14 +21,25 @@ public final class LoginViewController: UIViewController {
     }
 
     private let authService: AuthService
+    private let readinessCoordinator: FirstSignInReadinessCoordinator
+    private let readinessTimeout: TimeInterval
     private let onCompletion: (Outcome) -> Void
+
+    private var cancellables = Set<AnyCancellable>()
 
     private lazy var rootView = self.view as! LoginView
 
     // MARK: - Init
 
-    public init(authService: AuthService, onCompletion: @escaping (Outcome) -> Void) {
+    public init(
+        authService: AuthService,
+        readinessCoordinator: FirstSignInReadinessCoordinator,
+        readinessTimeout: TimeInterval = 90,
+        onCompletion: @escaping (Outcome) -> Void
+    ) {
         self.authService = authService
+        self.readinessCoordinator = readinessCoordinator
+        self.readinessTimeout = readinessTimeout
         self.onCompletion = onCompletion
         super.init(nibName: nil, bundle: nil)
         // 첫 진입은 swipe-down으로 닫을 수 없게. skip 버튼이 명시적 대안.
@@ -47,6 +59,29 @@ public final class LoginViewController: UIViewController {
         super.viewDidLoad()
         rootView.signInButton.addTarget(self, action: #selector(signInTapped), for: .touchUpInside)
         rootView.skipButton.addTarget(self, action: #selector(skipTapped), for: .touchUpInside)
+        bindPhase()
+    }
+
+    private func bindPhase() {
+        readinessCoordinator.phasePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] phase in
+                self?.renderPhase(phase)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func renderPhase(_ phase: SignInPhase) {
+        switch phase {
+        case .idle, .ready:
+            rootView.phaseLabel.text = nil
+        case .signingIn:
+            rootView.phaseLabel.text = L10n.Login.phaseSigningIn
+        case .uploading:
+            rootView.phaseLabel.text = L10n.Login.phaseUploading
+        case .downloading:
+            rootView.phaseLabel.text = L10n.Login.phaseDownloading
+        }
     }
 
     // MARK: - Actions
@@ -54,10 +89,12 @@ public final class LoginViewController: UIViewController {
     @objc private func signInTapped() {
         rootView.errorLabel.text = nil
         setLoading(true)
+        readinessCoordinator.reportSigningIn()
         Task { [weak self] in
             guard let self else { return }
             do {
-                _ = try await self.authService.signInWithApple()
+                let user = try await self.authService.signInWithApple()
+                try await self.readinessCoordinator.awaitReady(userID: user.id, timeout: self.readinessTimeout)
                 await MainActor.run {
                     self.setLoading(false)
                     self.onCompletion(.signedIn)
@@ -66,6 +103,11 @@ public final class LoginViewController: UIViewController {
                 await MainActor.run {
                     self.setLoading(false)
                     self.present(error: error)
+                }
+            } catch is SignInReadinessError {
+                await MainActor.run {
+                    self.setLoading(false)
+                    self.rootView.errorLabel.text = L10n.Login.syncTimeoutError
                 }
             } catch {
                 await MainActor.run {
@@ -112,6 +154,7 @@ public final class LoginViewController: UIViewController {
             rootView.activityIndicator.startAnimating()
         } else {
             rootView.activityIndicator.stopAnimating()
+            readinessCoordinator.reset()
         }
     }
 }

--- a/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailView.swift
+++ b/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailView.swift
@@ -78,6 +78,34 @@ final class AccountDetailView: UIView {
     let syncStatusRow = AccountDetailView.makeInfoRow(title: L10n.Account.syncStatusLabel, value: L10n.Account.syncStatusComingSoon)
     let lastSyncedRow = AccountDetailView.makeInfoRow(title: L10n.Account.lastSyncedLabel, value: L10n.Account.lastSyncedNever)
 
+    let syncRetryMessageLabel: UILabel = {
+        let label = UILabel()
+        label.text = L10n.Account.syncIncompleteMessage
+        label.font = .systemFont(ofSize: 14)
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        return label
+    }()
+
+    let syncRetryButton: UIButton = {
+        var config = UIButton.Configuration.tinted()
+        config.title = L10n.Account.syncRetryButton
+        config.cornerStyle = .large
+        config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0)
+        let button = UIButton(configuration: config)
+        return button
+    }()
+
+    let syncRetryContainer: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 8
+        stack.alignment = .fill
+        stack.isHidden = true
+        return stack
+    }()
+
     let signOutButton: UIButton = {
         var config = UIButton.Configuration.tinted()
         config.title = L10n.Account.signOut
@@ -129,11 +157,16 @@ final class AccountDetailView: UIView {
         infoStack.spacing = 8
         infoStack.alignment = .fill
 
+        syncRetryContainer.addArrangedSubview(syncRetryMessageLabel)
+        syncRetryContainer.addArrangedSubview(syncRetryButton)
+
         signedInContainer.addArrangedSubview(identityStack)
         signedInContainer.addArrangedSubview(infoStack)
         signedInContainer.setCustomSpacing(28, after: identityStack)
+        signedInContainer.addArrangedSubview(syncRetryContainer)
+        signedInContainer.setCustomSpacing(20, after: infoStack)
         signedInContainer.addArrangedSubview(signOutButton)
-        signedInContainer.setCustomSpacing(32, after: infoStack)
+        signedInContainer.setCustomSpacing(32, after: syncRetryContainer)
         signedInContainer.addArrangedSubview(deleteAccountButton)
 
         signedOutContainer.addArrangedSubview(signInPromptLabel)

--- a/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
+++ b/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
@@ -229,7 +229,12 @@ public final class AccountDetailViewController: UIViewController {
         rootView.signOutButton.isEnabled = !loading
         rootView.deleteAccountButton.isEnabled = !loading
         rootView.syncRetryButton.isEnabled = !loading
-        if loading { rootView.activityIndicator.startAnimating() } else { rootView.activityIndicator.stopAnimating() }
+        if loading {
+            rootView.activityIndicator.startAnimating()
+        } else {
+            rootView.activityIndicator.stopAnimating()
+            readinessCoordinator.reset()
+        }
     }
 
     private func presentInline(error: AuthError) {

--- a/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
+++ b/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
@@ -17,6 +17,8 @@ public final class AccountDetailViewController: UIViewController {
     private let authService: AuthService
     private let accountDeletionService: AccountDeletionService
     private let syncStatusService: SyncStatusService
+    private let readinessCoordinator: FirstSignInReadinessCoordinator
+    private let readinessTimeout: TimeInterval
     private var cancellables = Set<AnyCancellable>()
     private var lastSyncedAt: Date?
     private var lastSyncedRefreshTimer: Timer?
@@ -32,11 +34,15 @@ public final class AccountDetailViewController: UIViewController {
     public init(
         authService: AuthService,
         accountDeletionService: AccountDeletionService,
-        syncStatusService: SyncStatusService
+        syncStatusService: SyncStatusService,
+        readinessCoordinator: FirstSignInReadinessCoordinator,
+        readinessTimeout: TimeInterval = 90
     ) {
         self.authService = authService
         self.accountDeletionService = accountDeletionService
         self.syncStatusService = syncStatusService
+        self.readinessCoordinator = readinessCoordinator
+        self.readinessTimeout = readinessTimeout
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -63,6 +69,7 @@ public final class AccountDetailViewController: UIViewController {
         }
         rootView.signOutButton.addTarget(self, action: #selector(signOutTapped), for: .touchUpInside)
         rootView.deleteAccountButton.addTarget(self, action: #selector(deleteAccountTapped), for: .touchUpInside)
+        rootView.syncRetryButton.addTarget(self, action: #selector(syncRetryTapped), for: .touchUpInside)
 
         // 인증 상태 변경에 따라 화면 상태 토글.
         authService.authStatePublisher
@@ -124,10 +131,17 @@ public final class AccountDetailViewController: UIViewController {
             rootView.displayNameLabel.text = user.displayName ?? user.email ?? L10n.Account.title
             rootView.emailLabel.text = user.email
             rootView.emailLabel.isHidden = (user.email == nil)
+            updateSyncRetryVisibility(userID: user.id)
         } else {
             rootView.signedOutContainer.isHidden = false
             rootView.signedInContainer.isHidden = true
+            rootView.syncRetryContainer.isHidden = true
         }
+    }
+
+    private func updateSyncRetryVisibility(userID: String) {
+        let incomplete = !readinessCoordinator.isSyncCompleted(for: userID)
+        rootView.syncRetryContainer.isHidden = !incomplete
     }
 
     // MARK: - Actions
@@ -170,6 +184,26 @@ public final class AccountDetailViewController: UIViewController {
         present(deletionVC, animated: true)
     }
 
+    @objc private func syncRetryTapped() {
+        guard let userID = authService.currentUser?.id else { return }
+        setLoading(true)
+        Task { [weak self] in
+            guard let self else { return }
+            defer { Task { @MainActor in self.setLoading(false) } }
+            do {
+                try await self.readinessCoordinator.retryReady(userID: userID, timeout: self.readinessTimeout)
+                await MainActor.run {
+                    self.rootView.syncRetryContainer.isHidden = true
+                    self.showAlert(title: L10n.Account.syncRetrySuccessMessage)
+                }
+            } catch is SignInReadinessError {
+                await MainActor.run { self.showAlert(title: L10n.Login.syncTimeoutError) }
+            } catch {
+                await MainActor.run { self.showAlert(title: L10n.Sync.Auth.unknown) }
+            }
+        }
+    }
+
     private func performSignOut() {
         setLoading(true)
         Task { [weak self] in
@@ -190,6 +224,7 @@ public final class AccountDetailViewController: UIViewController {
         rootView.signInButton.isEnabled = !loading
         rootView.signOutButton.isEnabled = !loading
         rootView.deleteAccountButton.isEnabled = !loading
+        rootView.syncRetryButton.isEnabled = !loading
         if loading { rootView.activityIndicator.startAnimating() } else { rootView.activityIndicator.stopAnimating() }
     }
 

--- a/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
+++ b/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
@@ -152,14 +152,18 @@ public final class AccountDetailViewController: UIViewController {
 
     @objc private func signInTapped() {
         setLoading(true)
+        readinessCoordinator.reportSigningIn()
         Task { [weak self] in
             guard let self else { return }
             defer { Task { @MainActor in self.setLoading(false) } }
             do {
-                _ = try await self.authService.signInWithApple()
-                // 성공 시 authStatePublisher가 새 user를 emit → render에서 자동 전환
+                let user = try await self.authService.signInWithApple()
+                try await self.readinessCoordinator.awaitReady(userID: user.id, timeout: self.readinessTimeout)
+                // 성공 시 authStatePublisher가 새 user를 emit → SceneDelegate.observeAuthStateChanges 가 home 으로 전환
             } catch let error as AuthError {
                 await MainActor.run { self.presentInline(error: error) }
+            } catch is SignInReadinessError {
+                await MainActor.run { self.showAlert(title: L10n.Login.syncTimeoutError) }
             } catch {
                 await MainActor.run { self.showAlert(title: L10n.Sync.Auth.unknown) }
             }

--- a/Projects/Feature/SettingsFeature/Sources/SettingsViewController.swift
+++ b/Projects/Feature/SettingsFeature/Sources/SettingsViewController.swift
@@ -21,6 +21,7 @@ public final class SettingsViewController: UITableViewController {
     private let authService: AuthService
     private let accountDeletionService: AccountDeletionService
     private let syncStatusService: SyncStatusService
+    private let readinessCoordinator: FirstSignInReadinessCoordinator
     private let makeTrashViewController: () -> UIViewController
 
     public init(
@@ -30,6 +31,7 @@ public final class SettingsViewController: UITableViewController {
         authService: AuthService,
         accountDeletionService: AccountDeletionService,
         syncStatusService: SyncStatusService,
+        readinessCoordinator: FirstSignInReadinessCoordinator,
         makeTrashViewController: @escaping () -> UIViewController
     ) {
         self.memoRepository = memoRepository
@@ -38,6 +40,7 @@ public final class SettingsViewController: UITableViewController {
         self.authService = authService
         self.accountDeletionService = accountDeletionService
         self.syncStatusService = syncStatusService
+        self.readinessCoordinator = readinessCoordinator
         self.makeTrashViewController = makeTrashViewController
         super.init(nibName: nil, bundle: nil)
     }
@@ -398,7 +401,8 @@ extension SettingsViewController {
             targetVC = AccountDetailViewController(
                 authService: authService,
                 accountDeletionService: accountDeletionService,
-                syncStatusService: syncStatusService
+                syncStatusService: syncStatusService,
+                readinessCoordinator: readinessCoordinator
             )
         case IndexPath(row: 0, section: 1):
             targetVC = ThemeColorPickingViewController()


### PR DESCRIPTION
## 배경
- v2.5.0 출시 후 발견된 UX 문제: sign-in 후 마이그레이션 / 초기 sync 가 끝나기 전에 home 화면 노출 → 사용자가 빈 / stale 데이터 보고 혼란
- 메모/카테고리/이미지 메타데이터가 서버에 올라가고 다시 받아오는 단계까지 끝나야 home 진입 가능하도록 게이트 도입

## 변경사항
- **FirstSignInReadinessCoordinator** 신설 (SyncInterface protocol + Firebase / NoOp 구현)
  - 마이그레이션 cleanup + Memo / Category listener 첫 server snapshot 두 신호 합산
  - phasePublisher 로 .signingIn → .uploading → .downloading → .ready 단계 emit
  - awaitReady(timeout:) async + retryReady (AccountDetail 재시도)
- **이미지 마이그레이션 메타 / 바이너리 분리**
  - 새 marker sync.anonymousToFirestoreImageMetadataMigration.<uid> — 메타 업로드 완료 시점에 readiness gate 통과 신호
  - 바이너리는 분리된 백그라운드 Task — readiness gate 와 무관
  - 기존 통합 marker sync.anonymousToFirestoreImageMigration.<uid> 가 set 돼있으면 메타도 완료된 것으로 인정 (배포 사용자 호환)
- **Window 레벨 SignInProgressOverlay**
  - 전체 화면 터치 차단 + phase 라벨 ("로그인 중" / "데이터 올리는 중" / "데이터 받아오는 중")
  - rootVC 교체와 무관하게 window 에 직접 attach 돼 sign-in 흐름 전체 동안 살아남음
- **SceneDelegate auto-transition 을 readiness phase 완료까지 지연**
  - AccountDetail 처럼 LoginVC 가 아닌 경로에서 sign-in 시 UIView.transition window snapshot 이 phase 라벨 갱신을 시각적으로 덮어쓰던 버그 해결
- **LoginVC / AccountDetail / HomeVC** readiness gate 통합
  - LoginVC: signInWithApple 직후 awaitReady 까지 await 한 뒤 onCompletion(.signedIn). timeout 시 errorLabel 표시
  - AccountDetail: 동일 패턴 + 동기화 재시도 버튼 (cleanup marker 미설정 시 노출)
  - HomeVC: awaitingMigrationCleanup / 3초 fallback / loadingIndicator 제거
- **Skip 시 sign-in 잔존 상태면 signOut 후 진행** — UI 와 Firebase Auth 상태 일관성
- **Listener 첫 emission 으로 sync ready 인정** (cache or server)
  - re-sign-in 직후 Firestore SDK 가 cache 데이터를 신선하다고 판단해 server fetch 를 생략하는 케이스에서 hang 방지
  - cache emission 으로 통과한 경우라도 후속 server snapshot 도착 시 updatedPublisher 가 fire 돼 home VC 가 자동 refetch
- L10n 키 추가: phaseSigningIn / phaseUploading / phaseDownloading / syncTimeoutError / syncIncompleteMessage / syncRetryButton / syncRetrySuccessMessage

## 테스트 방법
- tuist generate --no-open && xcodebuild build ... — BUILD SUCCEEDED
- tuist test — 12 테스트 통과
- 시뮬레이터 + 실기기 수동 검증
  - LoginVC fresh install sign-in: phase 라벨 단계별 노출 확인 / home 진입 시 데이터 준비된 상태
  - AccountDetail sign-in: 동일하게 phase 노출 (auto-transition 지연 적용 후 정상 노출 확인 완료)
  - Sign-out → re-sign-in: hang 없이 정상 진행 (cache emission 인정으로 해결)
  - Timeout 시 LoginVC errorLabel 표시 + 재시도 가능
  - AccountDetail 의 incomplete sync 상태에서 재시도 버튼 노출 / 동작 확인

## 리뷰 노트
- 본 PR 작업 중 발견된 부수 사안 두 건 별도 task 로 분리:
  - Sign-out / 계정 삭제 흐름에도 window overlay 적용 (다음 PR)
  - 이미지 바이너리 업로드 보장 + 다운로드 실패 시 UX (assertionFailure 제거 / placeholder / 재시도)
- 이미지 마이그레이션 marker 의미 변경 ("전체 완료" → "메타 완료") 됐으나 기존 marker 호환을 코드에서 명시적으로 처리해 배포 사용자엔 영향 없음
- SignInProgressOverlay 의 일반화 (sign-out / 계정 삭제 재사용) 는 다음 PR 에서