### PR TITLE
feat(app): sign-out / 계정 삭제 흐름에도 window 차단 overlay 적용

### DIFF
--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -29,6 +29,7 @@ struct AppEnvironment {
     let syncStatusService: SyncStatusService
     let migrationCleanupCoordinator: AnonymousMigrationCleanupCoordinator
     let firstSignInReadinessCoordinator: FirstSignInReadinessCoordinator
+    let signOutCoordinator: SignOutCoordinator
 
     let coreDataStack: CoreDataStack
 
@@ -101,6 +102,7 @@ struct AppEnvironment {
             categoryRepository: categoryRepository,
             imageRepository: imageRepository
         )
+        self.signOutCoordinator = SyncBootstrap.makeSignOutCoordinator(authService: authService)
     }
 
     /// Crashlytics를 켜고(가능하면) Amplitude 기반 `Analytics`를 만든다.

--- a/NoteCard/Global/Application/BlockingProgressOverlay.swift
+++ b/NoteCard/Global/Application/BlockingProgressOverlay.swift
@@ -1,16 +1,14 @@
 //
-//  SignInProgressOverlay.swift
+//  BlockingProgressOverlay.swift
 //  NoteCard
 //
 
-import Shared
-import SyncInterface
 import UIKit
 
-/// Window 레벨에서 전체 화면 터치를 가로채고 현재 sign-in phase 를 안내하는 overlay.
-/// rootViewController 교체 (LoginVC → MainTabBar / AccountDetail → MainTabBar) 와 무관하게
-/// window 에 직접 add 되어 sign-in 전체 흐름 동안 살아남음.
-final class SignInProgressOverlay: UIView {
+/// Window 레벨에서 전체 화면 터치를 가로채고 진행 상황 텍스트를 보여주는 overlay.
+/// rootViewController 교체와 무관하게 살아남도록 window 에 직접 add 됨.
+/// Sign-in / sign-out / 계정 삭제 같은 비동기 흐름이 끝날 때까지 사용자 인터랙션을 차단.
+final class BlockingProgressOverlay: UIView {
 
     private let backgroundView: UIView = {
         let view = UIView()
@@ -25,7 +23,7 @@ final class SignInProgressOverlay: UIView {
         return view
     }()
 
-    private let phaseLabel: UILabel = {
+    private let messageLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 15, weight: .medium)
         label.textColor = .label
@@ -49,7 +47,7 @@ final class SignInProgressOverlay: UIView {
 
         addSubview(backgroundView)
         addSubview(activityIndicator)
-        addSubview(phaseLabel)
+        addSubview(messageLabel)
 
         NSLayoutConstraint.activate([
             backgroundView.topAnchor.constraint(equalTo: topAnchor),
@@ -60,24 +58,15 @@ final class SignInProgressOverlay: UIView {
             activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
             activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor, constant: -12),
 
-            phaseLabel.topAnchor.constraint(equalTo: activityIndicator.bottomAnchor, constant: 16),
-            phaseLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 32),
-            phaseLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -32)
+            messageLabel.topAnchor.constraint(equalTo: activityIndicator.bottomAnchor, constant: 16),
+            messageLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 32),
+            messageLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -32)
         ])
 
         activityIndicator.startAnimating()
     }
 
-    func update(phase: SignInPhase) {
-        switch phase {
-        case .signingIn:
-            phaseLabel.text = L10n.Login.phaseSigningIn
-        case .uploading:
-            phaseLabel.text = L10n.Login.phaseUploading
-        case .downloading:
-            phaseLabel.text = L10n.Login.phaseDownloading
-        case .idle, .ready:
-            phaseLabel.text = nil
-        }
+    func update(text: String?) {
+        messageLabel.text = text
     }
 }

--- a/NoteCard/Global/Application/SceneDelegate.swift
+++ b/NoteCard/Global/Application/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
     private var cancellables = Set<AnyCancellable>()
-    private var signInProgressOverlay: SignInProgressOverlay?
+    private var blockingProgressOverlay: BlockingProgressOverlay?
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
@@ -51,29 +51,37 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         observeReadinessPhase(environment: appDelegate.environment)
     }
 
-    /// readiness gate phase 에 따라 window 위에 SignInProgressOverlay 를 show / hide.
+    /// readiness gate phase 에 따라 window 위에 BlockingProgressOverlay 를 show / hide.
     /// rootVC 교체와 무관하게 살아남아 sign-in 흐름 전체 동안 터치 차단 + 단계 표시.
     private func observeReadinessPhase(environment: AppEnvironment) {
         environment.firstSignInReadinessCoordinator.phasePublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] phase in
-                self?.handle(phase: phase)
+                self?.handle(signInPhase: phase)
             }
             .store(in: &cancellables)
     }
 
-    private func handle(phase: SignInPhase) {
-        switch phase {
-        case .idle, .ready:
-            hideSignInProgressOverlay()
-        case .signingIn, .uploading, .downloading:
-            showSignInProgressOverlay(phase: phase)
+    private func handle(signInPhase phase: SignInPhase) {
+        if let text = Self.text(for: phase) {
+            showBlockingOverlay(text: text)
+        } else {
+            hideBlockingOverlay()
         }
     }
 
-    private func showSignInProgressOverlay(phase: SignInPhase) {
+    private static func text(for phase: SignInPhase) -> String? {
+        switch phase {
+        case .idle, .ready: return nil
+        case .signingIn: return L10n.Login.phaseSigningIn
+        case .uploading: return L10n.Login.phaseUploading
+        case .downloading: return L10n.Login.phaseDownloading
+        }
+    }
+
+    private func showBlockingOverlay(text: String) {
         guard let window = self.window else { return }
-        let overlay = signInProgressOverlay ?? SignInProgressOverlay()
+        let overlay = blockingProgressOverlay ?? BlockingProgressOverlay()
         if overlay.superview == nil {
             overlay.alpha = 0
             window.addSubview(overlay)
@@ -83,19 +91,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 overlay.trailingAnchor.constraint(equalTo: window.trailingAnchor),
                 overlay.bottomAnchor.constraint(equalTo: window.bottomAnchor)
             ])
-            signInProgressOverlay = overlay
+            blockingProgressOverlay = overlay
             UIView.animate(withDuration: 0.2) { overlay.alpha = 1 }
         }
-        overlay.update(phase: phase)
+        overlay.update(text: text)
     }
 
-    private func hideSignInProgressOverlay() {
-        guard let overlay = signInProgressOverlay, overlay.superview != nil else { return }
+    private func hideBlockingOverlay() {
+        guard let overlay = blockingProgressOverlay, overlay.superview != nil else { return }
         UIView.animate(withDuration: 0.2, animations: {
             overlay.alpha = 0
         }, completion: { [weak self] _ in
             overlay.removeFromSuperview()
-            self?.signInProgressOverlay = nil
+            self?.blockingProgressOverlay = nil
         })
     }
 

--- a/NoteCard/Global/Application/SceneDelegate.swift
+++ b/NoteCard/Global/Application/SceneDelegate.swift
@@ -48,34 +48,55 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
 
         observeAuthStateChanges(environment: appDelegate.environment)
-        observeReadinessPhase(environment: appDelegate.environment)
+        observeBlockingPhases(environment: appDelegate.environment)
     }
 
-    /// readiness gate phase 에 따라 window 위에 BlockingProgressOverlay 를 show / hide.
-    /// rootVC 교체와 무관하게 살아남아 sign-in 흐름 전체 동안 터치 차단 + 단계 표시.
-    private func observeReadinessPhase(environment: AppEnvironment) {
-        environment.firstSignInReadinessCoordinator.phasePublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] phase in
-                self?.handle(signInPhase: phase)
-            }
-            .store(in: &cancellables)
-    }
-
-    private func handle(signInPhase phase: SignInPhase) {
-        if let text = Self.text(for: phase) {
-            showBlockingOverlay(text: text)
-        } else {
-            hideBlockingOverlay()
+    /// Sign-in readiness / sign-out / 계정 삭제 의 phase 를 합쳐 BlockingProgressOverlay 의 표시 여부와 텍스트를 결정.
+    /// rootVC 교체와 무관하게 window 에 살아남아 비동기 흐름 전체 동안 터치 차단 + 단계 표시.
+    /// 우선순위: 계정 삭제 > 로그아웃 > 로그인. 동시 active 는 정상 흐름엔 없지만 안전 가드.
+    private func observeBlockingPhases(environment: AppEnvironment) {
+        Publishers.CombineLatest3(
+            environment.firstSignInReadinessCoordinator.phasePublisher.map(Self.text(forSignIn:)),
+            environment.signOutCoordinator.phasePublisher.map(Self.text(forSignOut:)),
+            environment.accountDeletionService.phasePublisher.map(Self.text(forDeletion:))
+        )
+        .map { signInText, signOutText, deletionText -> String? in
+            deletionText ?? signOutText ?? signInText
         }
+        .removeDuplicates()
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] text in
+            if let text {
+                self?.showBlockingOverlay(text: text)
+            } else {
+                self?.hideBlockingOverlay()
+            }
+        }
+        .store(in: &cancellables)
     }
 
-    private static func text(for phase: SignInPhase) -> String? {
+    private static func text(forSignIn phase: SignInPhase) -> String? {
         switch phase {
         case .idle, .ready: return nil
         case .signingIn: return L10n.Login.phaseSigningIn
         case .uploading: return L10n.Login.phaseUploading
         case .downloading: return L10n.Login.phaseDownloading
+        }
+    }
+
+    private static func text(forSignOut phase: SignOutPhase) -> String? {
+        switch phase {
+        case .idle: return nil
+        case .signingOut: return L10n.Sync.SignOut.phaseInProgress
+        }
+    }
+
+    private static func text(forDeletion phase: AccountDeletionPhase) -> String? {
+        switch phase {
+        case .idle: return nil
+        case .reauthenticating: return L10n.Sync.AccountDeletion.phaseReauthenticating
+        case .deletingCloudData: return L10n.Sync.AccountDeletion.phaseDeletingData
+        case .removingAccount: return L10n.Sync.AccountDeletion.phaseRemovingAccount
         }
     }
 

--- a/NoteCard/Presentation/TabBar/MainTabBarController.swift
+++ b/NoteCard/Presentation/TabBar/MainTabBarController.swift
@@ -105,6 +105,7 @@ class MainTabBarController: UITabBarController {
             accountDeletionService: environment.accountDeletionService,
             syncStatusService: environment.syncStatusService,
             readinessCoordinator: environment.firstSignInReadinessCoordinator,
+            signOutCoordinator: environment.signOutCoordinator,
             makeTrashViewController: { [environment] in
                 MemoViewController(memoVCType: .trash, environment: environment)
             }

--- a/Projects/Core/Shared/Resources/Localizable.xcstrings
+++ b/Projects/Core/Shared/Resources/Localizable.xcstrings
@@ -1888,6 +1888,34 @@
         }
       }
     },
+    "sync.accountDeletion.phaseReauthenticating": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Reauthenticating…" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "재로그인 중…" } }
+      }
+    },
+    "sync.accountDeletion.phaseDeletingData": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Deleting account data…" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "계정 데이터 삭제 중…" } }
+      }
+    },
+    "sync.accountDeletion.phaseRemovingAccount": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Removing account…" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "계정 정리 중…" } }
+      }
+    },
+    "sync.signOut.phaseInProgress": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Signing out…" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "로그아웃 중…" } }
+      }
+    },
     "sync.error.network": {
       "extractionState": "manual",
       "localizations": {

--- a/Projects/Core/Shared/Sources/Localization/L10n.swift
+++ b/Projects/Core/Shared/Sources/Localization/L10n.swift
@@ -141,6 +141,13 @@ public enum L10n {
             public static let dataCleanupFailed = "sync.accountDeletion.dataCleanupFailed".localized()
             public static let reauthRequired = "sync.accountDeletion.reauthRequired".localized()
             public static let invalidatedRemotely = "sync.accountDeletion.invalidatedRemotely".localized()
+            public static let phaseReauthenticating = "sync.accountDeletion.phaseReauthenticating".localized()
+            public static let phaseDeletingData = "sync.accountDeletion.phaseDeletingData".localized()
+            public static let phaseRemovingAccount = "sync.accountDeletion.phaseRemovingAccount".localized()
+        }
+
+        public enum SignOut {
+            public static let phaseInProgress = "sync.signOut.phaseInProgress".localized()
         }
 
         public enum Error {

--- a/Projects/Core/SyncImpl/Sources/FirebaseAccountDeletionService.swift
+++ b/Projects/Core/SyncImpl/Sources/FirebaseAccountDeletionService.swift
@@ -3,6 +3,7 @@
 //  NoteCard
 //
 
+import Combine
 import Domain
 import Foundation
 import SyncInterface
@@ -23,6 +24,11 @@ public final class FirebaseAccountDeletionService: AccountDeletionService, @unch
     private let categoryRepository: CategoryRepository
     private let imageRepository: ImageRepository
 
+    private let phaseSubject = CurrentValueSubject<AccountDeletionPhase, Never>(.idle)
+    public var phasePublisher: AnyPublisher<AccountDeletionPhase, Never> {
+        phaseSubject.eraseToAnyPublisher()
+    }
+
     public init(
         authService: AuthService,
         accountSentinelService: AccountSentinelService,
@@ -38,18 +44,22 @@ public final class FirebaseAccountDeletionService: AccountDeletionService, @unch
     }
 
     public func deleteAccountAndAllData() async throws {
+        defer { phaseSubject.send(.idle) }
         // 1. 파괴적 작업 전에 reauth 먼저 — Apple sign-in 시트가 즉시 뜸. 사용자가 여기서 취소하면
         //    `AuthError.cancelled` 가 던져지고 데이터·계정 모두 그대로 보존.
+        phaseSubject.send(.reauthenticating)
         _ = try await authService.signInWithApple()
 
         // 2. sentinel doc 삭제 — 다른 기기의 listener 가 .removed 받자마자 signOut.
         //    본 기기 listener 는 service 내부에서 detach 되어 self-trigger 방지됨.
+        phaseSubject.send(.deletingCloudData)
         try await accountSentinelService.deleteSentinel()
 
         // 3. 데이터 삭제. token 신선해서 Firestore 접근 정상.
         try await deleteAllUserData()
 
         // 4. Auth user 삭제. 방금 reauth 했으므로 requiresRecentLogin 발생하지 않음.
+        phaseSubject.send(.removingAccount)
         try await authService.deleteAccount()
     }
 

--- a/Projects/Core/SyncImpl/Sources/FirebaseSignOutCoordinator.swift
+++ b/Projects/Core/SyncImpl/Sources/FirebaseSignOutCoordinator.swift
@@ -1,0 +1,28 @@
+//
+//  FirebaseSignOutCoordinator.swift
+//  NoteCard
+//
+
+import Combine
+import Foundation
+import SyncInterface
+
+public final class FirebaseSignOutCoordinator: SignOutCoordinator, @unchecked Sendable {
+
+    private let authService: AuthService
+    private let phaseSubject = CurrentValueSubject<SignOutPhase, Never>(.idle)
+
+    public var phasePublisher: AnyPublisher<SignOutPhase, Never> {
+        phaseSubject.eraseToAnyPublisher()
+    }
+
+    public init(authService: AuthService) {
+        self.authService = authService
+    }
+
+    public func performSignOut() async throws {
+        phaseSubject.send(.signingOut)
+        defer { phaseSubject.send(.idle) }
+        try await authService.signOut()
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/NoOpAccountDeletionService.swift
+++ b/Projects/Core/SyncImpl/Sources/NoOpAccountDeletionService.swift
@@ -3,11 +3,18 @@
 //  NoteCard
 //
 
+import Combine
 import Foundation
 import SyncInterface
 
 /// Firebase 미설정 환경에서 사용. 호출 시 `missingFirebase` 던짐.
 public final class NoOpAccountDeletionService: AccountDeletionService, @unchecked Sendable {
+
+    private let phaseSubject = CurrentValueSubject<AccountDeletionPhase, Never>(.idle)
+    public var phasePublisher: AnyPublisher<AccountDeletionPhase, Never> {
+        phaseSubject.eraseToAnyPublisher()
+    }
+
     public init() {}
 
     public func deleteAccountAndAllData() async throws {

--- a/Projects/Core/SyncImpl/Sources/NoOpSignOutCoordinator.swift
+++ b/Projects/Core/SyncImpl/Sources/NoOpSignOutCoordinator.swift
@@ -1,0 +1,20 @@
+//
+//  NoOpSignOutCoordinator.swift
+//  NoteCard
+//
+
+import Combine
+import Foundation
+import SyncInterface
+
+public final class NoOpSignOutCoordinator: SignOutCoordinator, @unchecked Sendable {
+
+    private let phaseSubject = CurrentValueSubject<SignOutPhase, Never>(.idle)
+    public var phasePublisher: AnyPublisher<SignOutPhase, Never> {
+        phaseSubject.eraseToAnyPublisher()
+    }
+
+    public init() {}
+
+    public func performSignOut() async throws {}
+}

--- a/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
+++ b/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
@@ -106,6 +106,14 @@ public enum SyncBootstrap {
         )
     }
 
+    /// Sign-out 흐름의 phase 신호와 실제 signOut 호출을 하나로 묶은 코디네이터. Firebase 미설정 시 NoOp.
+    public static func makeSignOutCoordinator(authService: AuthService) -> SignOutCoordinator {
+        guard FirebaseApp.app() != nil else {
+            return NoOpSignOutCoordinator()
+        }
+        return FirebaseSignOutCoordinator(authService: authService)
+    }
+
     /// 계정의 sentinel doc 을 관리하는 서비스. 사인인 시 자동 생성·감시, cross-device 계정 삭제를
     /// .removed 이벤트로 즉시 감지해 강제 signOut.
     public static func makeAccountSentinelService(

--- a/Projects/Core/SyncInterface/Sources/AccountDeletionService.swift
+++ b/Projects/Core/SyncInterface/Sources/AccountDeletionService.swift
@@ -3,7 +3,15 @@
 //  NoteCard
 //
 
+import Combine
 import Foundation
+
+public enum AccountDeletionPhase: Equatable, Sendable {
+    case idle
+    case reauthenticating
+    case deletingCloudData
+    case removingAccount
+}
 
 /// 사용자가 계정 삭제를 요청했을 때 클라우드 데이터 정리와 Auth user 삭제를 함께 수행하는 오케스트레이터.
 ///
@@ -11,6 +19,9 @@ import Foundation
 /// 본 서비스는 reauth 로 token 을 갱신한 뒤 사용자의 모든 데이터 (메모 / 카테고리 / 이미지 + 바이너리) 를
 /// 삭제하고 마지막에 Auth user 를 삭제한다.
 public protocol AccountDeletionService: AnyObject, Sendable {
+
+    /// 현재 진행 단계. UI 가 차단 overlay 메시지 갱신 등에 활용. 흐름이 끝나면 .idle 로 복귀.
+    var phasePublisher: AnyPublisher<AccountDeletionPhase, Never> { get }
 
     /// 모든 클라우드 데이터 + Auth user 삭제. 호출 시 Apple sign-in 시트로 reauth 가 먼저 진행되며,
     /// 사용자가 시트를 취소하면 아무것도 삭제되지 않은 채 종료. 데이터 삭제 도중 실패 시엔 부분

--- a/Projects/Core/SyncInterface/Sources/SignOutCoordinator.swift
+++ b/Projects/Core/SyncInterface/Sources/SignOutCoordinator.swift
@@ -1,0 +1,21 @@
+//
+//  SignOutCoordinator.swift
+//  NoteCard
+//
+
+import Combine
+import Foundation
+
+public enum SignOutPhase: Equatable, Sendable {
+    case idle
+    case signingOut
+}
+
+/// Sign-out 흐름을 단일 지점으로 모은 코디네이터.
+///
+/// Auth signOut + Router 들의 익명 impl 복귀 + rootVC 교체까지의 짧은 구간 동안
+/// window 레벨 차단 overlay 표시를 위한 phase 신호를 노출.
+public protocol SignOutCoordinator: Sendable {
+    var phasePublisher: AnyPublisher<SignOutPhase, Never> { get }
+    func performSignOut() async throws
+}

--- a/Projects/Feature/AccountDeletionFeature/Sources/AccountDeletionViewController.swift
+++ b/Projects/Feature/AccountDeletionFeature/Sources/AccountDeletionViewController.swift
@@ -11,11 +11,9 @@ import UIKit
 ///
 /// 호출 측 (예: 계정 상세 화면) 은 본 VC 를 present 하기만 하면 됨:
 /// - 확인 alert 표시 → 사용자가 진행하면 `AccountDeletionService` 호출
-/// - 진행 중 ActivityIndicator 표시
+/// - 진행 단계 표시는 window 레벨 BlockingProgressOverlay 가 담당 (SceneDelegate 가 service.phasePublisher 구독)
 /// - 성공 시 dismiss (이후 `authStatePublisher` 가 nil emit → 호출 측 UI 자동 전환)
 /// - 실패 시 사용자 친화적 메시지로 alert + 재시도 가능 상태 유지
-///
-/// 추후 폴리시 여지: 진행률 화면, 데이터 항목 별 진행 단계, reauth 안내 화면 등을 본 VC 안에서 확장.
 public final class AccountDeletionViewController: UIViewController {
 
     private let accountDeletionService: AccountDeletionService
@@ -25,26 +23,6 @@ public final class AccountDeletionViewController: UIViewController {
         view.backgroundColor = UIColor.black.withAlphaComponent(0.4)
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
-    }()
-
-    private let activityIndicator: UIActivityIndicatorView = {
-        let indicator = UIActivityIndicatorView(style: .large)
-        indicator.color = .white
-        indicator.translatesAutoresizingMaskIntoConstraints = false
-        indicator.hidesWhenStopped = true
-        return indicator
-    }()
-
-    private let progressLabel: UILabel = {
-        let label = UILabel()
-        label.text = L10n.Sync.AccountDeletion.inProgress
-        label.textColor = .white
-        label.font = .preferredFont(forTextStyle: .body)
-        label.textAlignment = .center
-        label.numberOfLines = 0
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.isHidden = true
-        return label
     }()
 
     public init(accountDeletionService: AccountDeletionService) {
@@ -72,21 +50,11 @@ public final class AccountDeletionViewController: UIViewController {
 
     private func setupLayout() {
         view.addSubview(dimmingView)
-        view.addSubview(activityIndicator)
-        view.addSubview(progressLabel)
-
         NSLayoutConstraint.activate([
             dimmingView.topAnchor.constraint(equalTo: view.topAnchor),
             dimmingView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             dimmingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            dimmingView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-
-            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-
-            progressLabel.topAnchor.constraint(equalTo: activityIndicator.bottomAnchor, constant: 16),
-            progressLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 32),
-            progressLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -32)
+            dimmingView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
     }
 
@@ -108,7 +76,6 @@ public final class AccountDeletionViewController: UIViewController {
     }
 
     private func startDeletion() {
-        setProgress(true)
         Task { [weak self] in
             guard let self else { return }
             do {
@@ -119,25 +86,13 @@ public final class AccountDeletionViewController: UIViewController {
                 await MainActor.run { self.dismiss(animated: true) }
             } catch let error as AuthError {
                 await MainActor.run {
-                    self.setProgress(false)
                     self.presentError(message: error.errorDescription ?? L10n.Sync.Auth.unknown)
                 }
             } catch {
                 await MainActor.run {
-                    self.setProgress(false)
                     self.presentError(message: L10n.Sync.AccountDeletion.dataCleanupFailed)
                 }
             }
-        }
-    }
-
-    private func setProgress(_ active: Bool) {
-        if active {
-            activityIndicator.startAnimating()
-            progressLabel.isHidden = false
-        } else {
-            activityIndicator.stopAnimating()
-            progressLabel.isHidden = true
         }
     }
 

--- a/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailView.swift
+++ b/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailView.swift
@@ -127,13 +127,6 @@ final class AccountDetailView: UIView {
         return button
     }()
 
-    let activityIndicator: UIActivityIndicatorView = {
-        let view = UIActivityIndicatorView(style: .medium)
-        view.hidesWhenStopped = true
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
-    }()
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
@@ -174,7 +167,6 @@ final class AccountDetailView: UIView {
 
         addSubview(signedOutContainer)
         addSubview(signedInContainer)
-        addSubview(activityIndicator)
     }
 
     private func setupConstraints() {
@@ -186,9 +178,6 @@ final class AccountDetailView: UIView {
             signedInContainer.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 24),
             signedInContainer.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -24),
             signedInContainer.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 40),
-
-            activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
-            activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])
     }
 

--- a/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
+++ b/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
@@ -18,6 +18,7 @@ public final class AccountDetailViewController: UIViewController {
     private let accountDeletionService: AccountDeletionService
     private let syncStatusService: SyncStatusService
     private let readinessCoordinator: FirstSignInReadinessCoordinator
+    private let signOutCoordinator: SignOutCoordinator
     private let readinessTimeout: TimeInterval
     private var cancellables = Set<AnyCancellable>()
     private var lastSyncedAt: Date?
@@ -36,12 +37,14 @@ public final class AccountDetailViewController: UIViewController {
         accountDeletionService: AccountDeletionService,
         syncStatusService: SyncStatusService,
         readinessCoordinator: FirstSignInReadinessCoordinator,
+        signOutCoordinator: SignOutCoordinator,
         readinessTimeout: TimeInterval = 90
     ) {
         self.authService = authService
         self.accountDeletionService = accountDeletionService
         self.syncStatusService = syncStatusService
         self.readinessCoordinator = readinessCoordinator
+        self.signOutCoordinator = signOutCoordinator
         self.readinessTimeout = readinessTimeout
         super.init(nibName: nil, bundle: nil)
     }
@@ -214,7 +217,7 @@ public final class AccountDetailViewController: UIViewController {
             guard let self else { return }
             defer { Task { @MainActor in self.setLoading(false) } }
             do {
-                try await self.authService.signOut()
+                try await self.signOutCoordinator.performSignOut()
                 // authStatePublisher가 nil emit → 미로그인 상태로 자동 전환
             } catch {
                 await MainActor.run { self.showAlert(title: L10n.Sync.Auth.unknown) }
@@ -229,10 +232,7 @@ public final class AccountDetailViewController: UIViewController {
         rootView.signOutButton.isEnabled = !loading
         rootView.deleteAccountButton.isEnabled = !loading
         rootView.syncRetryButton.isEnabled = !loading
-        if loading {
-            rootView.activityIndicator.startAnimating()
-        } else {
-            rootView.activityIndicator.stopAnimating()
+        if !loading {
             readinessCoordinator.reset()
         }
     }

--- a/Projects/Feature/SettingsFeature/Sources/SettingsViewController.swift
+++ b/Projects/Feature/SettingsFeature/Sources/SettingsViewController.swift
@@ -22,6 +22,7 @@ public final class SettingsViewController: UITableViewController {
     private let accountDeletionService: AccountDeletionService
     private let syncStatusService: SyncStatusService
     private let readinessCoordinator: FirstSignInReadinessCoordinator
+    private let signOutCoordinator: SignOutCoordinator
     private let makeTrashViewController: () -> UIViewController
 
     public init(
@@ -32,6 +33,7 @@ public final class SettingsViewController: UITableViewController {
         accountDeletionService: AccountDeletionService,
         syncStatusService: SyncStatusService,
         readinessCoordinator: FirstSignInReadinessCoordinator,
+        signOutCoordinator: SignOutCoordinator,
         makeTrashViewController: @escaping () -> UIViewController
     ) {
         self.memoRepository = memoRepository
@@ -41,6 +43,7 @@ public final class SettingsViewController: UITableViewController {
         self.accountDeletionService = accountDeletionService
         self.syncStatusService = syncStatusService
         self.readinessCoordinator = readinessCoordinator
+        self.signOutCoordinator = signOutCoordinator
         self.makeTrashViewController = makeTrashViewController
         super.init(nibName: nil, bundle: nil)
     }
@@ -402,7 +405,8 @@ extension SettingsViewController {
                 authService: authService,
                 accountDeletionService: accountDeletionService,
                 syncStatusService: syncStatusService,
-                readinessCoordinator: readinessCoordinator
+                readinessCoordinator: readinessCoordinator,
+                signOutCoordinator: signOutCoordinator
             )
         case IndexPath(row: 0, section: 1):
             targetVC = ThemeColorPickingViewController()


### PR DESCRIPTION
## 배경
- 직전 PR (#78) 에서 sign-in 흐름은 window 레벨 차단 overlay 로 처리해 단계 표시 + 인터랙션 차단 일관성 확보
- sign-out / 계정 삭제 흐름은 여전히 화면 종속 progress UI 만 사용 — 동일한 인터랙션 차단 / 일관성 부족
- overlay 인프라가 일반화 가능한 상태라 같은 패턴을 두 흐름에 확장

## 변경사항
- **SignInProgressOverlay → BlockingProgressOverlay rename + API 일반화**
  - `update(phase: SignInPhase)` → `update(text: String?)` 로 도메인 중립화
  - 도메인별 phase → text mapping 은 SceneDelegate 의 static helper 가 담당
- **SignOutCoordinator 신설** (SyncInterface protocol + Firebase / NoOp 구현)
  - `SignOutPhase` enum (idle / signingOut)
  - `performSignOut()` 가 phase 갱신 + `authService.signOut()` 래핑
  - SyncBootstrap factory + AppEnvironment 노출
- **AccountDeletionService 에 phasePublisher 추가**
  - `AccountDeletionPhase` enum (idle / reauthenticating / deletingCloudData / removingAccount)
  - `deleteAccountAndAllData` 가 각 단계 시작 시 send. defer 로 .idle 복귀
- **SceneDelegate 가 세 phase publisher 통합**
  - `Publishers.CombineLatest3` 로 sign-in / sign-out / 계정 삭제 phase 의 text mapping 합산
  - 우선순위: 계정 삭제 > 로그아웃 > 로그인 (동시 active 안전 가드)
  - `removeDuplicates` 로 같은 텍스트 반복 emit 시 overlay 깜빡임 방지
- **AccountDetail / AccountDeletionVC 의 local progress UI 제거**
  - `AccountDetail.performSignOut` 이 `signOutCoordinator.performSignOut()` 호출
  - `AccountDetailView` 의 `activityIndicator` subview 제거 (window overlay 가 대체)
  - `AccountDeletionViewController` 의 `activityIndicator` / `progressLabel` / `setProgress` 메서드 제거. `dimmingView` 는 confirm alert 배경 강조 위해 유지
- **L10n 4개 키 추가** (ko/en)
  - `sync.signOut.phaseInProgress`
  - `sync.accountDeletion.phaseReauthenticating`
  - `sync.accountDeletion.phaseDeletingData`
  - `sync.accountDeletion.phaseRemovingAccount`

## 테스트 방법
- `tuist generate --no-open && xcodebuild build ...` — BUILD SUCCEEDED
- `tuist test` — 12 테스트 통과
- 시뮬레이터 / 실기기 수동 검증
  - 사인아웃: AccountDetail → 로그아웃 버튼 → "로그아웃 중…" overlay → home 전환
  - 계정 삭제 정상: confirm → "재로그인 중…" (Apple 시트 위에 표시) → "계정 데이터 삭제 중…" → "계정 정리 중…" → 자동 dismiss + sign-out
  - 계정 삭제 reauth 취소: Apple 시트 취소 → overlay 사라짐 + VC dismiss
  - 계정 삭제 중 에러: overlay 사라짐 + 에러 alert
  - 사인인 (regression): 기존 흐름 정상 동작

## 리뷰 노트
- AccountDeletionVC 의 `dimmingView` 는 의도적으로 유지 — confirm alert 의 배경 강조 역할. dim 자체는 진행 중 표시가 아니므로 overlay 와 무관
- overlay 우선순위 (deletion > signOut > signIn) 는 동시 active 가 정상 흐름엔 없지만 안전 가드. 만약 동시에 발생하면 가장 critical 한 흐름의 phase 가 표시됨
- 계정 삭제의 reauth 단계 동안 Apple 시트가 overlay 위에 풀스크린 modal 로 떠서 overlay 텍스트가 시각적으로 가려지지만, 시트 닫히면 다음 phase 의 텍스트가 자연스럽게 보임