### PR TITLE
feat(popup-card): 이미지 lazy 로딩 + 재시도 UI

### DIFF
--- a/NoteCard/Presentation/CardImageShowingView/CardImageShowingCollectionViewCell.swift
+++ b/NoteCard/Presentation/CardImageShowingView/CardImageShowingCollectionViewCell.swift
@@ -12,15 +12,36 @@ import DesignSystem
 import Shared
 
 class CardImageShowingCollectionViewCell: UICollectionViewCell {
-    
+
     static var cellID: String {
         return String(describing: self)
     }
-    
+
     let doubleTapGesture = UITapGestureRecognizer()
-    
+
     private let imageView = UIImageView()
     private let scrollView = CardImageShowingScrollView()
+
+    private var onRetry: (() -> Void)?
+
+    private let activityIndicator: UIActivityIndicatorView = {
+        let view = UIActivityIndicatorView(style: .large)
+        view.color = .white
+        view.hidesWhenStopped = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let retryButton: UIButton = {
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "arrow.clockwise")
+        config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 12, bottom: 12, trailing: 12)
+        let button = UIButton(configuration: config)
+        button.tintColor = .white
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.isHidden = true
+        return button
+    }()
     
     lazy var scrollViewCenterXConstraint = scrollView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor, constant: 0)
     lazy var scrollViewCenterYConstraint = scrollView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: 0)
@@ -34,12 +55,13 @@ class CardImageShowingCollectionViewCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
+
         setupUIProperties()
         configureHierarchy()
         setupConstraints()
         setupDelegates()
         setupGestures()
+        retryButton.addTarget(self, action: #selector(retryTapped), for: .touchUpInside)
     }
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -47,11 +69,17 @@ class CardImageShowingCollectionViewCell: UICollectionViewCell {
     
     override func prepareForReuse() {
         scrollView.setZoomScale(1.0, animated: false)
+        imageView.image = UIImage(systemName: "photo")
+        activityIndicator.stopAnimating()
+        retryButton.isHidden = true
+        onRetry = nil
     }
-    
+
     private func configureHierarchy() {
         contentView.addSubview(scrollView)
         scrollView.addSubview(imageView)
+        contentView.addSubview(activityIndicator)
+        contentView.addSubview(retryButton)
     }
     
     private func setupUIProperties() {
@@ -85,11 +113,18 @@ class CardImageShowingCollectionViewCell: UICollectionViewCell {
         scrollViewCenterYConstraint.isActive = true
         scrollViewWidthConstraint.isActive = true
         scrollViewHeightConstraint.isActive = true
-        
+
         imageViewCenterXConstraint.isActive = true
         imageViewCenterYConstraint.isActive = true
         imageViewWidthConstraint.isActive = true
         imageViewHeightConstraint.isActive = true
+
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            retryButton.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            retryButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
+        ])
     }
     
     private func setupDelegates() {
@@ -120,25 +155,47 @@ class CardImageShowingCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    func configureCell(with image: UIImage) {
+    func configure(state: ImageLoadState, onRetry: @escaping () -> Void) {
+        self.onRetry = onRetry
+        switch state {
+        case .loading:
+            imageView.image = UIImage(systemName: "photo")
+            activityIndicator.startAnimating()
+            retryButton.isHidden = true
+        case .loaded(let image):
+            activityIndicator.stopAnimating()
+            retryButton.isHidden = true
+            applyImage(image)
+        case .failed:
+            imageView.image = UIImage(systemName: "photo")
+            activityIndicator.stopAnimating()
+            retryButton.isHidden = false
+        }
+    }
+
+    private func applyImage(_ image: UIImage) {
         imageView.image = image
         let contentViewRatio = self.contentView.bounds.height / self.contentView.bounds.width
         let imageSizeRatio = image.size.height / image.size.width
-        
+
         if imageSizeRatio <= contentViewRatio {
             scrollViewWidthConstraint.constant = contentView.bounds.width
             imageViewWidthConstraint.constant = contentView.bounds.width
-            
+
             scrollViewHeightConstraint.constant = contentView.bounds.width * imageSizeRatio
             imageViewHeightConstraint.constant = contentView.bounds.width * imageSizeRatio
         } else {
             scrollViewHeightConstraint.constant = contentView.bounds.height
             imageViewHeightConstraint.constant = contentView.bounds.height
-            
+
             scrollViewWidthConstraint.constant = contentView.bounds.height / imageSizeRatio
             imageViewWidthConstraint.constant = contentView.bounds.height / imageSizeRatio
         }
         updateConstraints()
+    }
+
+    @objc private func retryTapped() {
+        onRetry?()
     }
 }
 

--- a/NoteCard/Presentation/CardImageShowingView/CardImageShowingCollectionViewCell.swift
+++ b/NoteCard/Presentation/CardImageShowingView/CardImageShowingCollectionViewCell.swift
@@ -42,6 +42,15 @@ class CardImageShowingCollectionViewCell: UICollectionViewCell {
         button.isHidden = true
         return button
     }()
+
+    private let placeholderIconView: UIImageView = {
+        let view = UIImageView()
+        view.image = UIImage(systemName: "photo")
+        view.tintColor = .white.withAlphaComponent(0.6)
+        view.contentMode = .scaleAspectFit
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
     
     lazy var scrollViewCenterXConstraint = scrollView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor, constant: 0)
     lazy var scrollViewCenterYConstraint = scrollView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: 0)
@@ -69,7 +78,8 @@ class CardImageShowingCollectionViewCell: UICollectionViewCell {
     
     override func prepareForReuse() {
         scrollView.setZoomScale(1.0, animated: false)
-        imageView.image = UIImage(systemName: "photo")
+        imageView.image = nil
+        placeholderIconView.isHidden = false
         activityIndicator.stopAnimating()
         retryButton.isHidden = true
         onRetry = nil
@@ -78,6 +88,7 @@ class CardImageShowingCollectionViewCell: UICollectionViewCell {
     private func configureHierarchy() {
         contentView.addSubview(scrollView)
         scrollView.addSubview(imageView)
+        contentView.addSubview(placeholderIconView)
         contentView.addSubview(activityIndicator)
         contentView.addSubview(retryButton)
     }
@@ -90,7 +101,6 @@ class CardImageShowingCollectionViewCell: UICollectionViewCell {
         
         imageView.contentMode = UIImageView.ContentMode.scaleAspectFit
         imageView.sizeToFit()
-        imageView.image = UIImage(systemName: "photo")
         imageView.backgroundColor = .clear
         imageView.isUserInteractionEnabled = true
         imageView.translatesAutoresizingMaskIntoConstraints = false
@@ -120,6 +130,11 @@ class CardImageShowingCollectionViewCell: UICollectionViewCell {
         imageViewHeightConstraint.isActive = true
 
         NSLayoutConstraint.activate([
+            placeholderIconView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            placeholderIconView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            placeholderIconView.widthAnchor.constraint(equalToConstant: 48),
+            placeholderIconView.heightAnchor.constraint(equalToConstant: 48),
+
             activityIndicator.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             activityIndicator.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             retryButton.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
@@ -159,15 +174,18 @@ class CardImageShowingCollectionViewCell: UICollectionViewCell {
         self.onRetry = onRetry
         switch state {
         case .loading:
-            imageView.image = UIImage(systemName: "photo")
+            imageView.image = nil
+            placeholderIconView.isHidden = false
             activityIndicator.startAnimating()
             retryButton.isHidden = true
         case .loaded(let image):
+            placeholderIconView.isHidden = true
             activityIndicator.stopAnimating()
             retryButton.isHidden = true
             applyImage(image)
         case .failed:
-            imageView.image = UIImage(systemName: "photo")
+            imageView.image = nil
+            placeholderIconView.isHidden = true
             activityIndicator.stopAnimating()
             retryButton.isHidden = false
         }

--- a/NoteCard/Presentation/CardImageShowingView/CardImageShowingViewController.swift
+++ b/NoteCard/Presentation/CardImageShowingView/CardImageShowingViewController.swift
@@ -25,12 +25,16 @@ class CardImageShowingViewController: UIViewController {
 
     private let rootView = CardImageShowingView()
 
-    /// Lazy: PopupCard 에서 메모 셀 탭 시 사용. 셀이 보이면 그 이미지의 원본 다운로드 시작.
+    /// Lazy: PopupCard 에서 메모 셀 탭 시 사용. 로컬 캐시 hit 이면 즉시 .loaded, 아니면 .loading.
     init(indexPath: IndexPath, imageInfos: [MemoImageInfo], imageRepository: ImageRepository) {
         self.initialIndexPath = indexPath
         self.source = .lazy(infos: imageInfos, repository: imageRepository)
         for info in imageInfos {
-            self.imageStates[info.id] = .loading
+            if let cached = ImageLoadingHelper.loadCachedImage(for: info, thumbnail: false) {
+                self.imageStates[info.id] = .loaded(cached)
+            } else {
+                self.imageStates[info.id] = .loading
+            }
         }
         super.init(nibName: nil, bundle: nil)
     }
@@ -62,6 +66,7 @@ class CardImageShowingViewController: UIViewController {
 
         if case .lazy(let infos, _) = source {
             for info in infos {
+                if case .loaded = imageStates[info.id] { continue }
                 Task { await self.loadImage(forImageID: info.id) }
             }
         }

--- a/NoteCard/Presentation/CardImageShowingView/CardImageShowingViewController.swift
+++ b/NoteCard/Presentation/CardImageShowingView/CardImageShowingViewController.swift
@@ -2,77 +2,153 @@
 //  CardImageShowingViewController.swift
 //  CardMemo
 //
-//  Created by 김민성 on 2023/11/02.
-//
 
-import UIKit
 import Data
-import Domain
 import DesignSystem
+import Domain
 import Shared
+import UIKit
 
 class CardImageShowingViewController: UIViewController {
-    
+
+    private enum Source {
+        /// PopupCard 경로 — 서버에서 lazy 로드.
+        case lazy(infos: [MemoImageInfo], repository: ImageRepository)
+        /// MemoDetail (편집 중) 경로 — 이미 받은 이미지 직접 표시.
+        case eager(images: [UIImage])
+    }
+
     private let initialIndexPath: IndexPath
-    private var imageArray: [UIImage] = []
-    
+    private let source: Source
+    private var imageStates: [UUID: ImageLoadState] = [:]
+    private var eagerIDs: [UUID] = []
+
     private let rootView = CardImageShowingView()
-    
-    init(indexPath: IndexPath, images: [UIImage]) {
+
+    /// Lazy: PopupCard 에서 메모 셀 탭 시 사용. 셀이 보이면 그 이미지의 원본 다운로드 시작.
+    init(indexPath: IndexPath, imageInfos: [MemoImageInfo], imageRepository: ImageRepository) {
         self.initialIndexPath = indexPath
-        self.imageArray = images
+        self.source = .lazy(infos: imageInfos, repository: imageRepository)
+        for info in imageInfos {
+            self.imageStates[info.id] = .loading
+        }
         super.init(nibName: nil, bundle: nil)
     }
-    
+
+    /// Eager: MemoDetail (편집 중) 에서 이미 받은 이미지로 표시. lazy 로딩 / 재시도 흐름 적용 X.
+    init(indexPath: IndexPath, images: [UIImage]) {
+        self.initialIndexPath = indexPath
+        self.source = .eager(images: images)
+        self.eagerIDs = images.map { _ in UUID() }
+        for (id, image) in zip(eagerIDs, images) {
+            self.imageStates[id] = .loaded(image)
+        }
+        super.init(nibName: nil, bundle: nil)
+    }
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func loadView() {
         view = rootView
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         setupDelegates()
         rootView.dismissButton.addTarget(self, action: #selector(dismissButtonTapped), for: .touchUpInside)
-        
+
+        if case .lazy(let infos, _) = source {
+            for info in infos {
+                Task { await self.loadImage(forImageID: info.id) }
+            }
+        }
     }
-    
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        
+
         rootView.imageCollectionView.scrollToItem(at: initialIndexPath, at: .centeredHorizontally, animated: false)
         rootView.imageCollectionView.alpha = 1.0
     }
-    
+
     private func setupDelegates() {
         rootView.imageCollectionView.dataSource = self
     }
-    
+
     @objc private func dismissButtonTapped() {
         dismiss(animated: true)
     }
-    
+
+    private func retryImage(forImageID imageID: UUID) async {
+        imageStates[imageID] = .loading
+        reloadCell(forImageID: imageID)
+        await loadImage(forImageID: imageID)
+    }
+
+    private func loadImage(forImageID imageID: UUID) async {
+        guard case .lazy(let infos, let imageRepository) = source,
+              let info = infos.first(where: { $0.id == imageID }) else { return }
+        let result = await ImageLoadingHelper.loadWithRetry {
+            try await imageRepository.getImage(from: info)
+        }
+        switch result {
+        case .success(let image):
+            imageStates[imageID] = .loaded(image)
+        case .failure(let error):
+            print("CardImageShowing 원본 로드 실패 (\(imageID)): \(error)")
+            imageStates[imageID] = .failed
+        }
+        reloadCell(forImageID: imageID)
+    }
+
+    private func reloadCell(forImageID imageID: UUID) {
+        let index: Int?
+        switch source {
+        case .lazy(let infos, _):
+            index = infos.firstIndex(where: { $0.id == imageID })
+        case .eager:
+            index = eagerIDs.firstIndex(of: imageID)
+        }
+        guard let index else { return }
+        rootView.imageCollectionView.reloadItems(at: [IndexPath(item: index, section: 0)])
+    }
+
+    private func imageID(at index: Int) -> UUID? {
+        switch source {
+        case .lazy(let infos, _):
+            guard index < infos.count else { return nil }
+            return infos[index].id
+        case .eager:
+            guard index < eagerIDs.count else { return nil }
+            return eagerIDs[index]
+        }
+    }
 }
 
 
 // MARK: - UICollectionViewDataSource
 extension CardImageShowingViewController: UICollectionViewDataSource {
-    
+
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return imageArray.count
+        switch source {
+        case .lazy(let infos, _): return infos.count
+        case .eager(let images): return images.count
+        }
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = self.rootView.imageCollectionView.dequeueReusableCell(
             withReuseIdentifier: CardImageShowingCollectionViewCell.cellID,
             for: indexPath
         ) as! CardImageShowingCollectionViewCell
-        cell.configureCell(with: imageArray[indexPath.item])
-        
+        guard let id = imageID(at: indexPath.item) else { return cell }
+        let state = imageStates[id] ?? .loading
+        cell.configure(state: state) { [weak self] in
+            Task { await self?.retryImage(forImageID: id) }
+        }
         return cell
     }
-    
 }

--- a/NoteCard/Presentation/PopupCardView/PopupCardView.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardView.swift
@@ -371,8 +371,8 @@ extension PopupCardView {
     
     private func setupImageCollectionView() {
         imageCollectionView.register(
-            MemoImageCollectionViewCell.self,
-            forCellWithReuseIdentifier: MemoImageCollectionViewCell.cellID
+            PopupImageCell.self,
+            forCellWithReuseIdentifier: PopupImageCell.cellID
         )
         imageCollectionView.isScrollEnabled = true
         imageCollectionView.backgroundColor = .clear

--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -21,9 +21,9 @@ class PopupCardViewController: UIViewController {
     
     private var memo: Memo
     private var categories: [Domain.Category] = []
-    private var imageUIModels: [ImageUIModel] = [] {
+    private var popupImageItems: [PopupImageItem] = [] {
         didSet {
-            rootView.imageCollectionViewHeight.constant = imageUIModels.isEmpty ? 0 : 70
+            rootView.imageCollectionViewHeight.constant = popupImageItems.isEmpty ? 0 : 70
             rootView.setNeedsLayout()
         }
     }
@@ -59,17 +59,15 @@ class PopupCardViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         Task {
             do {
                 self.categories = try await self.fetchCategories()
-                self.imageUIModels = try await self.makeImageUIModels()
-                
                 self.rootView.categoryCollectionView.reloadData()
-                self.rootView.imageCollectionView.reloadData()
             } catch {
-                assertionFailure("메모의 카테고리 혹은 이미지를 가져오는 데 에러 발생!!!")
+                print("PopupCard 카테고리 fetch 실패: \(error)")
             }
+            await self.loadImageItems()
         }
         
         rootView.memoTextView.addGestureRecognizer(memoTextViewTapGesture)
@@ -107,15 +105,7 @@ class PopupCardViewController: UIViewController {
             .sink { [weak self] _ in
                 guard let self else { return }
                 Task {
-                    do {
-                        self.imageUIModels = try await self.makeImageUIModels()
-                        self.rootView.imageCollectionView.reloadData()
-                    } catch RepositoryError.notFound {
-                        // 디바운스 중 메모가 삭제되면 더 이상 표시할 게 없으므로 닫기.
-                        self.dismiss(animated: true)
-                    } catch {
-                        print("PopupCard 이미지 업데이트 실패: \(error)")
-                    }
+                    await self.loadImageItems()
                 }
             }
             .store(in: &cancellables)
@@ -225,14 +215,7 @@ private extension PopupCardViewController {
             image: UIImage(systemName: "pencil"),
             handler: { [weak self] action in
                 guard let self else { return }
-                
-                let memoEditingVC = MemoDetailViewController(
-                    type: .editing(memo: self.memo, images: self.imageUIModels),
-                    environment: self.environment
-                )
-                let naviCon = UINavigationController(rootViewController: memoEditingVC)
-                naviCon.modalPresentationStyle = .formSheet
-                self.present(naviCon, animated: true)
+                Task { await self.enterEditingMode() }
             }
         )
         
@@ -301,10 +284,10 @@ extension PopupCardViewController: UICollectionViewDataSource {
         if collectionView == self.rootView.categoryCollectionView {
             return categories.count
         } else {
-            return imageUIModels.count
+            return popupImageItems.count
         }
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if collectionView == self.rootView.categoryCollectionView {
             guard let cell = self.rootView.categoryCollectionView.dequeueReusableCell(
@@ -319,10 +302,14 @@ extension PopupCardViewController: UICollectionViewDataSource {
             return cell
         } else {
             let cell = self.rootView.imageCollectionView.dequeueReusableCell(
-                withReuseIdentifier: MemoImageCollectionViewCell.cellID,
+                withReuseIdentifier: PopupImageCell.cellID,
                 for: indexPath
-            ) as! MemoImageCollectionViewCell
-            cell.configure(with: imageUIModels[indexPath.item])
+            ) as! PopupImageCell
+            let item = popupImageItems[indexPath.item]
+            let imageID = item.info.id
+            cell.configure(state: item.thumbnailState) { [weak self] in
+                Task { await self?.retryThumbnail(forImageID: imageID) }
+            }
             return cell
         }
     }
@@ -335,8 +322,12 @@ extension PopupCardViewController: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         self.view.endEditing(true)
-        let images = imageUIModels.map(\.originalImage)
-        let cardImageShowingVC = CardImageShowingViewController(indexPath: indexPath, images: images)
+        let infos = popupImageItems.map(\.info)
+        let cardImageShowingVC = CardImageShowingViewController(
+            indexPath: indexPath,
+            imageInfos: infos,
+            imageRepository: environment.imageRepository
+        )
         cardImageShowingVC.modalPresentationStyle = .overFullScreen
         self.present(cardImageShowingVC, animated: true)
     }
@@ -415,67 +406,102 @@ private extension PopupCardViewController {
 }
 
 
-// MARK: - Fetching Image Model And Making UIModels
+// MARK: - 이미지 lazy 로딩
 private extension PopupCardViewController {
-    
-    private func makeImageUIModels() async throws -> [ImageUIModel] {
-        var imageUIModels: [ImageUIModel] = []
-        
-        let fetchedImageInfoList = try await environment.imageRepository.getAllImageInfo(for: memo)
-        let fetchedThumbnails = try await fetchThumbnailsConcurrently(for: fetchedImageInfoList)
-        let fetchedImages = try await fetchImagesConcurrently(for: fetchedImageInfoList)
-        
-        guard fetchedImageInfoList.count == fetchedImages.count,
-              fetchedImageInfoList.count == fetchedThumbnails.count
-        else {
-            throw ImageFileError.fileNotFound
+
+    /// 메타만 받아 placeholder 즉시 노출 → 각 thumbnail 비동기 병렬 로드.
+    /// 메모 자체가 trash 등으로 사라진 경우 dismiss.
+    func loadImageItems() async {
+        let infos: [MemoImageInfo]
+        do {
+            infos = try await environment.imageRepository.getAllImageInfo(for: memo)
+        } catch RepositoryError.notFound {
+            self.dismiss(animated: true)
+            return
+        } catch {
+            print("PopupCard 이미지 메타 fetch 실패: \(error)")
+            return
         }
-        
-        for imageInfo in fetchedImageInfoList.enumerated() {
-            let imageUIModel = ImageUIModel(
-                from: imageInfo.element,
-                image: fetchedImages[imageInfo.offset],
-                thumbnail: fetchedThumbnails[imageInfo.offset]
+
+        popupImageItems = infos.map { PopupImageItem(info: $0, thumbnailState: .loading) }
+        rootView.imageCollectionView.reloadData()
+
+        for info in infos {
+            Task { await self.loadThumbnail(forImageID: info.id) }
+        }
+    }
+
+    /// retry 버튼에서 호출. state 를 .loading 으로 되돌리고 다시 로드.
+    func retryThumbnail(forImageID imageID: UUID) async {
+        guard let index = popupImageItems.firstIndex(where: { $0.info.id == imageID }) else { return }
+        popupImageItems[index].thumbnailState = .loading
+        rootView.imageCollectionView.reloadItems(at: [IndexPath(item: index, section: 0)])
+        await loadThumbnail(forImageID: imageID)
+    }
+
+    /// 편집 진입 — MemoDetailVC 가 원본 + 썸네일 둘 다 필요한 ImageUIModel 을 요구하므로
+    /// 모든 이미지를 sync 로 받아서 변환 후 진입. 한 장이라도 실패하면 alert.
+    func enterEditingMode() async {
+        do {
+            let models = try await fetchAllImageUIModelsForEditing()
+            let memoEditingVC = MemoDetailViewController(
+                type: .editing(memo: memo, images: models),
+                environment: environment
             )
-            imageUIModels.append(imageUIModel)
+            let naviCon = UINavigationController(rootViewController: memoEditingVC)
+            naviCon.modalPresentationStyle = .formSheet
+            self.present(naviCon, animated: true)
+        } catch {
+            print("PopupCard 편집 진입 위한 이미지 로드 실패: \(error)")
+            let alert = UIAlertController(
+                title: L10n.PopupCard.editingPreloadFailedTitle,
+                message: L10n.PopupCard.editingPreloadFailedMessage,
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: L10n.Common.ok, style: .default))
+            self.present(alert, animated: true)
         }
-        return imageUIModels
     }
-    
-    private func fetchThumbnailsConcurrently(for imageInfos: [MemoImageInfo]) async throws -> [UIImage] {
+
+    private func fetchAllImageUIModelsForEditing() async throws -> [ImageUIModel] {
+        let infos = popupImageItems.map(\.info)
         let imageRepository = environment.imageRepository
-        var thumbnailResults: [Int: UIImage] = [:]
-        try await withThrowingTaskGroup(of: (Int, UIImage).self) { group in
-            for (index, info) in imageInfos.enumerated() {
+        return try await withThrowingTaskGroup(of: (Int, ImageUIModel).self) { group in
+            for (index, info) in infos.enumerated() {
                 group.addTask {
+                    let original = try await imageRepository.getImage(from: info)
                     let thumbnail = try await imageRepository.getThumbnailImage(from: info)
-                    return (index, thumbnail)
+                    return (index, ImageUIModel(from: info, image: original, thumbnail: thumbnail))
                 }
             }
-            for try await (index, thumbnail) in group {
-                thumbnailResults[index] = thumbnail
+            var results: [Int: ImageUIModel] = [:]
+            for try await (index, model) in group {
+                results[index] = model
             }
+            return results.sorted { $0.key < $1.key }.map { $0.value }
         }
-        return thumbnailResults.sorted { $0.key < $1.key }.map { $0.value }
     }
-    
-    private func fetchImagesConcurrently(for imageInfos: [MemoImageInfo]) async throws -> [UIImage] {
+
+    /// 단일 thumbnail 로드. transient 실패에 대응해 자동 재시도 (exponential backoff).
+    /// 끝까지 실패 시 state = .failed → 셀에 재시도 버튼 노출.
+    func loadThumbnail(forImageID imageID: UUID) async {
+        guard let info = popupImageItems.first(where: { $0.info.id == imageID })?.info else { return }
         let imageRepository = environment.imageRepository
-        var imageResults: [Int: UIImage] = [:]
-        try await withThrowingTaskGroup(of: (Int, UIImage).self) { group in
-            for (index, info) in imageInfos.enumerated() {
-                group.addTask {
-                    let image = try await imageRepository.getImage(from: info)
-                    return (index, image)
-                }
-            }
-            for try await (index, image) in group {
-                imageResults[index] = image
-            }
+
+        let result = await ImageLoadingHelper.loadWithRetry {
+            try await imageRepository.getThumbnailImage(from: info)
         }
-        return imageResults.sorted { $0.key < $1.key }.map { $0.value }
+
+        guard let index = popupImageItems.firstIndex(where: { $0.info.id == imageID }) else { return }
+        switch result {
+        case .success(let image):
+            popupImageItems[index].thumbnailState = .loaded(image)
+        case .failure(let error):
+            print("PopupCard thumbnail 로드 실패 (\(imageID)): \(error)")
+            popupImageItems[index].thumbnailState = .failed
+        }
+        rootView.imageCollectionView.reloadItems(at: [IndexPath(item: index, section: 0)])
     }
-    
 }
 
 

--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -410,6 +410,7 @@ private extension PopupCardViewController {
 private extension PopupCardViewController {
 
     /// 메타만 받아 placeholder 즉시 노출 → 각 thumbnail 비동기 병렬 로드.
+    /// 로컬 캐시 hit 이면 sync 로 즉시 .loaded 로 표시 (스피너 거치지 않음).
     /// 메모 자체가 trash 등으로 사라진 경우 dismiss.
     func loadImageItems() async {
         let infos: [MemoImageInfo]
@@ -423,11 +424,18 @@ private extension PopupCardViewController {
             return
         }
 
-        popupImageItems = infos.map { PopupImageItem(info: $0, thumbnailState: .loading) }
+        popupImageItems = infos.map { info in
+            if let cached = ImageLoadingHelper.loadCachedImage(for: info, thumbnail: true) {
+                return PopupImageItem(info: info, thumbnailState: .loaded(cached))
+            }
+            return PopupImageItem(info: info, thumbnailState: .loading)
+        }
         rootView.imageCollectionView.reloadData()
 
-        for info in infos {
-            Task { await self.loadThumbnail(forImageID: info.id) }
+        for item in popupImageItems {
+            if case .loading = item.thumbnailState {
+                Task { await self.loadThumbnail(forImageID: item.info.id) }
+            }
         }
     }
 

--- a/NoteCard/Presentation/PopupCardView/PopupImageCell.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupImageCell.swift
@@ -1,0 +1,104 @@
+//
+//  PopupImageCell.swift
+//  NoteCard
+//
+
+import UIKit
+
+/// PopupCard 의 이미지 collection view 셀.
+/// 메타만 도착한 시점 즉시 표시 가능하도록 placeholder 배경 + 상태별 overlay (loading / failed) 구조.
+final class PopupImageCell: UICollectionViewCell {
+
+    static var cellID: String { String(describing: self) }
+
+    private var onRetry: (() -> Void)?
+
+    private let imageView: UIImageView = {
+        let view = UIImageView()
+        view.contentMode = .scaleAspectFill
+        view.clipsToBounds = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let activityIndicator: UIActivityIndicatorView = {
+        let view = UIActivityIndicatorView(style: .medium)
+        view.hidesWhenStopped = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let retryButton: UIButton = {
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "arrow.clockwise")
+        config.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
+        let button = UIButton(configuration: config)
+        button.tintColor = .secondaryLabel
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.isHidden = true
+        return button
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        retryButton.addTarget(self, action: #selector(retryTapped), for: .touchUpInside)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) is unavailable") }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        imageView.image = nil
+        activityIndicator.stopAnimating()
+        retryButton.isHidden = true
+        onRetry = nil
+    }
+
+    private func setupUI() {
+        contentView.backgroundColor = .systemGray5
+        contentView.clipsToBounds = true
+        contentView.layer.cornerRadius = 13
+        contentView.layer.cornerCurve = .continuous
+
+        contentView.addSubview(imageView)
+        contentView.addSubview(activityIndicator)
+        contentView.addSubview(retryButton)
+
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            imageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+
+            activityIndicator.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            retryButton.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            retryButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
+        ])
+    }
+
+    func configure(state: ImageLoadState, onRetry: @escaping () -> Void) {
+        self.onRetry = onRetry
+        switch state {
+        case .loading:
+            imageView.image = nil
+            activityIndicator.startAnimating()
+            retryButton.isHidden = true
+        case .loaded(let image):
+            imageView.image = image
+            activityIndicator.stopAnimating()
+            retryButton.isHidden = true
+        case .failed:
+            imageView.image = nil
+            activityIndicator.stopAnimating()
+            retryButton.isHidden = false
+        }
+    }
+
+    @objc private func retryTapped() {
+        onRetry?()
+    }
+}

--- a/NoteCard/Presentation/PopupCardView/PopupImageItem.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupImageItem.swift
@@ -1,0 +1,15 @@
+//
+//  PopupImageItem.swift
+//  NoteCard
+//
+
+import Domain
+import UIKit
+
+/// PopupCard 의 collection view 가 사용하는 단일 항목 모델.
+/// 메타데이터는 즉시 받고 thumbnail binary 는 비동기 로드되는 구조라
+/// 모델이 로딩 / 성공 / 실패 상태를 들고 있어야 함.
+struct PopupImageItem {
+    let info: MemoImageInfo
+    var thumbnailState: ImageLoadState
+}

--- a/NoteCard/Presentation/Shared/ImageLoading.swift
+++ b/NoteCard/Presentation/Shared/ImageLoading.swift
@@ -1,0 +1,32 @@
+//
+//  ImageLoading.swift
+//  NoteCard
+//
+
+import UIKit
+
+/// 비동기 이미지 로딩의 셀 표시 상태.
+enum ImageLoadState {
+    case loading
+    case loaded(UIImage)
+    case failed
+}
+
+enum ImageLoadingHelper {
+    /// transient 실패 (네트워크 일시 끊김, token propagation 지연 등) 대응. 1초 → 3초 backoff 후 포기.
+    static func loadWithRetry<T>(_ work: @escaping () async throws -> T) async -> Result<T, Error> {
+        let backoffsNs: [UInt64] = [1_000_000_000, 3_000_000_000]
+        var lastError: Error?
+        for attempt in 0...backoffsNs.count {
+            do {
+                return .success(try await work())
+            } catch {
+                lastError = error
+                if attempt < backoffsNs.count {
+                    try? await Task.sleep(nanoseconds: backoffsNs[attempt])
+                }
+            }
+        }
+        return .failure(lastError ?? CancellationError())
+    }
+}

--- a/NoteCard/Presentation/Shared/ImageLoading.swift
+++ b/NoteCard/Presentation/Shared/ImageLoading.swift
@@ -3,6 +3,8 @@
 //  NoteCard
 //
 
+import Data
+import Domain
 import UIKit
 
 /// 비동기 이미지 로딩의 셀 표시 상태.
@@ -28,5 +30,17 @@ enum ImageLoadingHelper {
             }
         }
         return .failure(lastError ?? CancellationError())
+    }
+
+    /// 로컬 캐시(Documents)에 이미지가 이미 있으면 sync 로 즉시 로드. 없으면 nil.
+    /// 캐시 hit 시 loading spinner 없이 즉시 표시하기 위함.
+    static func loadCachedImage(for info: MemoImageInfo, thumbnail: Bool) -> UIImage? {
+        do {
+            let url = try ImageFileHandler.getFileURL(for: info, thumbnail: thumbnail)
+            guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+            return try ImageFileHandler.loadUIImage(from: url)
+        } catch {
+            return nil
+        }
     }
 }

--- a/Projects/Core/Shared/Resources/Localizable.xcstrings
+++ b/Projects/Core/Shared/Resources/Localizable.xcstrings
@@ -1208,6 +1208,20 @@
         }
       }
     },
+    "popupCard.editingPreloadFailedTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Cannot start editing" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "편집을 시작할 수 없습니다" } }
+      }
+    },
+    "popupCard.editingPreloadFailedMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Failed to load some images. Please try again in a moment." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이미지 일부를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요." } }
+      }
+    },
     "popupCard.recoverAsUncategorizedSingle": {
       "extractionState": "manual",
       "localizations": {

--- a/Projects/Core/Shared/Sources/Localization/L10n.swift
+++ b/Projects/Core/Shared/Sources/Localization/L10n.swift
@@ -57,6 +57,8 @@ public enum L10n {
         public static let deleteMemoTitle = "popupCard.deleteMemoTitle".localized()
         public static let deleteMemoConfirm = "popupCard.deleteMemoConfirm".localized()
         public static let noTitle = "popupCard.noTitle".localized()
+        public static let editingPreloadFailedTitle = "popupCard.editingPreloadFailedTitle".localized()
+        public static let editingPreloadFailedMessage = "popupCard.editingPreloadFailedMessage".localized()
     }
 
     public enum MemoView {


### PR DESCRIPTION
## 배경
- v2.5.0 출시 후 발견된 시나리오: 다른 기기에서 사용자가 본 메모의 이미지 binary 가 Storage 에 아직 없을 때 PopupCardVC.viewDidLoad 에서 assertionFailure (Debug crash / Release silent dismiss)
- 기존 흐름은 메모 진입 시 모든 thumbnail + 원본을 동기로 받음 → 한 장이라도 실패하면 viewDidLoad 전체 throw
- 메타만 즉시, binary 는 비동기 lazy 로딩 + 실패 셀별 재시도 UI

## 변경사항
- **신규 helper**: ImageLoading.swift
  - 공용 ImageLoadState (loading / loaded / failed)
  - ImageLoadingHelper.loadWithRetry — 자동 1-2회 재시도 (1초 → 3초 backoff). transient (네트워크 일시 끊김, token propagation 지연 등) 대응
  - ImageLoadingHelper.loadCachedImage — 로컬 캐시 sync 체크 후 즉시 로드
- **신규 UI**: PopupCard 전용
  - PopupImageItem — info + thumbnailState 모델
  - PopupImageCell — 회색 placeholder 배경 + activity indicator / 이미지 / 재시도 버튼 (arrow.clockwise) overlay
- **PopupCardViewController**
  - viewDidLoad / memo 변경 sink: 메타 fetch → 캐시 hit 인 이미지는 .loaded 로 즉시 / miss 는 .loading → 비동기 병렬 다운로드
  - assertionFailure 제거. 카테고리 fetch 실패는 print 만
  - 편집 진입 시 모든 이미지 sync 다운로드 + ImageUIModel 변환 (실패 시 alert)
- **CardImageShowingViewController**
  - 두 init 분리 — lazy (PopupCard 진입, 서버 다운로드) / eager (MemoDetailVC 편집 중)
  - lazy 경로도 캐시 hit 이면 즉시 .loaded
  - 셀에 state 기반 UI (loading / loaded / failed)
- **CardImageShowingCollectionViewCell**
  - 별도 placeholderIconView (48×48, 중앙) 도입 — 기존 imageView 전체 채우던 큰 SF Symbol 제거
  - state 별: loading (placeholder 아이콘 + spinner) / loaded (zoom 가능 이미지) / failed (재시도 버튼)
- **L10n**: popupCard.editingPreloadFailedTitle / editingPreloadFailedMessage (ko/en)

## 테스트 방법
- tuist generate --no-open && xcodebuild build ... — BUILD SUCCEEDED
- tuist test — 12 테스트 통과
- 시뮬레이터 / 실기기 수동 검증
  - PopupCard 처음 열기: 회색 placeholder + spinner → 비동기 thumbnail 로드
  - PopupCard 재진입 (캐시 hit): spinner 없이 즉시 표시
  - 이미지 셀 탭 → 전체화면 보기: 캐시 hit 즉시 / miss 시 작은 placeholder 아이콘 + spinner → 원본 로드
  - 다운로드 실패 (오프라인 등): 자동 1-2회 재시도 후 retry 버튼 노출. 탭하면 재시도
  - 편집 진입: 이미지 sync 다운로드 후 진입. 실패 시 alert

## 리뷰 노트
- 본 PR 의 lazy 패턴은 PopupCard + CardImageShowing 한정. MemoDetailVC 의 편집 중 이미지는 기존 eager 흐름 유지 (편집 진입 시 sync 다운로드해 ImageUIModel 로 전달)
- 캐시 hit 판단은 ImageFileHandler 의 Documents 폴더 기반 — Firestore SDK 의 내부 cache 와는 별개. 본 앱이 createImage 시 로컬 Documents 에 사본 저장하는 정책 활용
- ImageLoadState 가 enum 이라 모델이 Equatable 자동 채택 안 됨 — 셀 갱신은 명시 reloadItems 로 처리
- 자동 재시도의 backoff (1초 → 3초) 는 transient race 의 일반 propagation window 기준. 너무 짧으면 무의미, 너무 길면 사용자 답답함의 균형