### PR TITLE
feat(sync): 첫 동기화 이미지 업로드 점진적 재개

### DIFF
--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -30,6 +30,7 @@ struct AppEnvironment {
     let migrationCleanupCoordinator: AnonymousMigrationCleanupCoordinator
     let firstSignInReadinessCoordinator: FirstSignInReadinessCoordinator
     let signOutCoordinator: SignOutCoordinator
+    let pendingUploadResumeTrigger: PendingUploadResumeTrigger
 
     let coreDataStack: CoreDataStack
 
@@ -103,6 +104,9 @@ struct AppEnvironment {
             imageRepository: imageRepository
         )
         self.signOutCoordinator = SyncBootstrap.makeSignOutCoordinator(authService: authService)
+        self.pendingUploadResumeTrigger = SyncBootstrap.makePendingUploadResumeTrigger(
+            imageRepository: imageRepository
+        )
     }
 
     /// Crashlytics를 켜고(가능하면) Amplitude 기반 `Analytics`를 만든다.

--- a/NoteCard/Global/Application/SceneDelegate.swift
+++ b/NoteCard/Global/Application/SceneDelegate.swift
@@ -242,7 +242,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         print(#function)
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
-        
+
+        // 끊긴 이미지 바이너리 마이그레이션 업로드를 재개. sign-in 안 됐거나 진행 중이면 no-op.
+        (UIApplication.shared.delegate as? AppDelegate)?
+            .environment.pendingUploadResumeTrigger.resumePendingUploadsIfNeeded()
+
 //        guard let mainTabBarCon = self.window?.rootViewController as? MainTabBarController else { fatalError() }
 //        
 //        let blurAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)

--- a/NoteCard/Global/Application/SceneDelegate.swift
+++ b/NoteCard/Global/Application/SceneDelegate.swift
@@ -244,9 +244,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
 
         // 끊긴 이미지 바이너리 마이그레이션 업로드를 재개. sign-in 안 됐거나 진행 중이면 no-op.
-        (UIApplication.shared.delegate as? AppDelegate)?
-            .environment.pendingUploadResumeTrigger.resumePendingUploadsIfNeeded()
-
+        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+            appDelegate.environment.pendingUploadResumeTrigger.resumePendingUploadsIfNeeded()
+        }
 //        guard let mainTabBarCon = self.window?.rootViewController as? MainTabBarController else { fatalError() }
 //        
 //        let blurAnimator = UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1)

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
@@ -28,16 +28,25 @@ public final class ImageRepositoryFirestoreImpl: ImageRepository, @unchecked Sen
     private let firestore: Firestore
     private let storage: Storage
     private let userID: String
+    /// 익명 → Firestore 마이그레이션의 바이너리 업로드 단계에서 한 장씩 완료 표시를 남기는 저장소.
+    /// nil 이면 skip 판정·기록 모두 생략 (마이그레이션 외 경로에선 주입할 필요 없음).
+    private let progressStore: ImageUploadProgressStore?
 
     private let imageUpdatedSubject = PassthroughSubject<ImageUpdateType, Never>()
     public var imageUpdatedPublisher: AnyPublisher<ImageUpdateType, Never> {
         imageUpdatedSubject.eraseToAnyPublisher()
     }
 
-    public init(userID: String, firestore: Firestore = .firestore(), storage: Storage = .storage()) {
+    init(
+        userID: String,
+        firestore: Firestore = .firestore(),
+        storage: Storage = .storage(),
+        progressStore: ImageUploadProgressStore? = nil
+    ) {
         self.userID = userID
         self.firestore = firestore
         self.storage = storage
+        self.progressStore = progressStore
     }
 
     // MARK: - Path helpers
@@ -257,25 +266,39 @@ public final class ImageRepositoryFirestoreImpl: ImageRepository, @unchecked Sen
     }
 
     /// 익명 이미지의 원본 + 썸네일 바이너리를 Storage 로 업로드. 메타와 분리돼 사용자 readiness gate 와 무관하게
-    /// 백그라운드에서 진행. 한 장 실패해도 다음 진행. putData 가 동일 path 멱등 덮어쓰기.
+    /// 백그라운드에서 진행. putData 가 동일 path 멱등 덮어쓰기.
+    ///
+    /// `progressStore` 가 주입돼 있으면 시작 전 이미 완료된 variant 는 skip 하고 성공한 variant 만 mark.
+    /// 같은 이미지의 원본·썸네일은 병렬 업로드 후 각각 mark — 한 쪽이 실패해도 다른 쪽 mark 가 남아
+    /// 다음 시도에서 실패한 쪽만 재시도된다.
     func uploadImageBinaries(_ images: [MemoImageInfo]) async throws {
         for info in images {
-            do {
-                let originalURL = try ImageFileHandler.getFileURL(for: info, thumbnail: false)
-                let thumbnailURL = try ImageFileHandler.getFileURL(for: info, thumbnail: true)
-                let originalData = try Data(contentsOf: originalURL)
-                let thumbnailData = try Data(contentsOf: thumbnailURL)
+            async let originalDone: Void = uploadVariantIfNeeded(.original, of: info)
+            async let thumbnailDone: Void = uploadVariantIfNeeded(.thumbnail, of: info)
+            _ = await (originalDone, thumbnailDone)
+        }
+    }
 
-                async let originalUpload: StorageMetadata = originalStorageRef(
+    private func uploadVariantIfNeeded(_ variant: ImageUploadProgressStore.Variant, of info: MemoImageInfo) async {
+        if progressStore?.isUploaded(imageInfo: info, variant: variant) == true { return }
+        do {
+            switch variant {
+            case .original:
+                let url = try ImageFileHandler.getFileURL(for: info, thumbnail: false)
+                let data = try Data(contentsOf: url)
+                _ = try await originalStorageRef(
                     memoID: info.memoID, imageID: info.id, fileExtension: info.fileExtension
-                ).putDataAsync(originalData)
-                async let thumbnailUpload: StorageMetadata = thumbnailStorageRef(
+                ).putDataAsync(data)
+            case .thumbnail:
+                let url = try ImageFileHandler.getFileURL(for: info, thumbnail: true)
+                let data = try Data(contentsOf: url)
+                _ = try await thumbnailStorageRef(
                     memoID: info.memoID, thumbnailID: info.thumbnailID
-                ).putDataAsync(thumbnailData)
-                _ = try await (originalUpload, thumbnailUpload)
-            } catch {
-                print("[ImageRepoFirestore] binary upload skipped for \(info.id): \(error)")
+                ).putDataAsync(data)
             }
+            progressStore?.markUploaded(imageInfo: info, variant: variant)
+        } catch {
+            print("[ImageRepoFirestore] binary upload skipped for \(info.id) \(variant.rawValue): \(error)")
         }
     }
 }

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
@@ -251,6 +251,26 @@ public final class ImageRepositoryFirestoreImpl: ImageRepository, @unchecked Sen
 
     // MARK: - Migration
 
+    /// 현재 사용자의 모든 메모 sub-collection 을 Firestore 에서 enumerate 해 이미지 메타를 모은다.
+    /// 메타 마이그가 이미 끝난 상태에서 재진입할 때 익명 Core Data 가 cleanup 됐을 수 있으므로,
+    /// 익명 enumerate 대신 Firestore 를 진실의 출처로 삼는다.
+    func enumerateAllImageInfosFromFirestore() async throws -> [MemoImageInfo] {
+        let memosCollection = firestore.collection("users").document(userID).collection("memos")
+        let memoSnapshot = try await memosCollection.getDocuments()
+        var collected: [MemoImageInfo] = []
+        for memoDoc in memoSnapshot.documents {
+            guard let memoID = UUID(uuidString: memoDoc.documentID) else { continue }
+            let images = try await imageCollection(for: memoID).order(by: "orderIndex").getDocuments()
+            for imgDoc in images.documents {
+                if let dto = try? imgDoc.data(as: FirestoreMemoImage.self),
+                   let info = dto.toDomain() {
+                    collected.append(info)
+                }
+            }
+        }
+        return collected
+    }
+
     /// 익명 Core Data 의 이미지 메타데이터만 Firestore 에 import. Storage 바이너리 업로드는 별도 단계.
     /// 한 장 실패해도 다음 진행. setData(merge: true) 로 멱등.
     func importImageMetadata(_ images: [MemoImageInfo]) async throws {

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
@@ -307,13 +307,16 @@ public final class ImageRepositoryFirestoreImpl: ImageRepository, @unchecked Sen
                 let url = try ImageFileHandler.getFileURL(for: info, thumbnail: false)
                 let data = try Data(contentsOf: url)
                 _ = try await originalStorageRef(
-                    memoID: info.memoID, imageID: info.id, fileExtension: info.fileExtension
+                    memoID: info.memoID,
+                    imageID: info.id,
+                    fileExtension: info.fileExtension
                 ).putDataAsync(data)
             case .thumbnail:
                 let url = try ImageFileHandler.getFileURL(for: info, thumbnail: true)
                 let data = try Data(contentsOf: url)
                 _ = try await thumbnailStorageRef(
-                    memoID: info.memoID, thumbnailID: info.thumbnailID
+                    memoID: info.memoID,
+                    thumbnailID: info.thumbnailID
                 ).putDataAsync(data)
             }
             progressStore?.markUploaded(imageInfo: info, variant: variant)

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
@@ -125,12 +125,8 @@ public final class ImageRepositoryRouter: ImageRepository, PendingUploadResumeTr
     private func triggerMigrationIfNeeded(to firestoreImpl: ImageRepositoryFirestoreImpl, userID: String) {
         let metaMarkerKey = Self.metaMarkerKey(for: userID)
         let legacyMarkerKey = Self.legacyMarkerKey(for: userID)
-        let coordinator = cleanupCoordinator
-        let metaDone = UserDefaults.standard.bool(forKey: metaMarkerKey)
+        let isImageMetaDataMigrated = UserDefaults.standard.bool(forKey: metaMarkerKey)
             || UserDefaults.standard.bool(forKey: legacyMarkerKey)
-
-        let memoRepo = anonymousMemoRepository
-        let imageRepo = anonymousImpl
 
         let canProceed: Bool = lock.withLock {
             guard !_isMigrationInFlight else { return false }
@@ -140,7 +136,13 @@ public final class ImageRepositoryRouter: ImageRepository, PendingUploadResumeTr
         guard canProceed else { return }
         let progressStore = lock.withLock { _progressStore }
 
-        Task { [weak firestoreImpl, weak self] in
+        Task { [
+            cleanupCoordinator,
+            anonymousMemoRepository,
+            anonymousImpl,
+            weak firestoreImpl,
+            weak self
+        ] in
             defer {
                 if let self {
                     self.lock.withLock { self._isMigrationInFlight = false }
@@ -148,32 +150,32 @@ public final class ImageRepositoryRouter: ImageRepository, PendingUploadResumeTr
             }
             guard let firestoreImpl else { return }
             do {
-                let collected: [MemoImageInfo]
-                if metaDone {
+                let imageInfosToUpload: [MemoImageInfo]
+                if isImageMetaDataMigrated {
                     // 익명 Core Data 가 cleanup 됐을 수 있으므로 Firestore 가 진실의 출처.
-                    collected = try await firestoreImpl.enumerateAllImageInfosFromFirestore()
-                    await coordinator.reportMigrationCompleted(userID: userID)
-                    if let progressStore, progressStore.isAllUploaded(amongst: collected) {
+                    imageInfosToUpload = try await firestoreImpl.enumerateAllImageInfosFromFirestore()
+                    await cleanupCoordinator.reportMigrationCompleted(userID: userID)
+                    if let progressStore, progressStore.isAllUploaded(amongst: imageInfosToUpload) {
                         return // 바이너리까지 다 끝남 — 진짜 short-circuit
                     }
                 } else {
-                    let active = try await memoRepo.getAllMemos()
-                    let trashed = try await memoRepo.getAllMemosInTrash()
-                    var items: [MemoImageInfo] = []
-                    for memo in active + trashed {
-                        let images = try await imageRepo.getAllImageInfo(for: memo)
-                        items.append(contentsOf: images)
+                    let activeMemos = try await anonymousMemoRepository.getAllMemos()
+                    let trashedMemos = try await anonymousMemoRepository.getAllMemosInTrash()
+                    var collectedImageInfos: [MemoImageInfo] = []
+                    for memo in activeMemos + trashedMemos {
+                        let imageInfosOfMemo = try await anonymousImpl.getAllImageInfo(for: memo)
+                        collectedImageInfos.append(contentsOf: imageInfosOfMemo)
                     }
-                    if !items.isEmpty {
-                        try await firestoreImpl.importImageMetadata(items)
+                    if !collectedImageInfos.isEmpty {
+                        try await firestoreImpl.importImageMetadata(collectedImageInfos)
                     }
                     UserDefaults.standard.set(true, forKey: metaMarkerKey)
-                    await coordinator.reportMigrationCompleted(userID: userID)
-                    collected = items
+                    await cleanupCoordinator.reportMigrationCompleted(userID: userID)
+                    imageInfosToUpload = collectedImageInfos
                 }
 
-                if !collected.isEmpty {
-                    try await firestoreImpl.uploadImageBinaries(collected)
+                if !imageInfosToUpload.isEmpty {
+                    try await firestoreImpl.uploadImageBinaries(imageInfosToUpload)
                 }
             } catch {
                 print("[ImageRepositoryRouter] migration error: \(error)")

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
@@ -20,7 +20,7 @@ import UIKit
 /// - 전환 시 활성 impl의 `imageUpdatedPublisher`를 내부 subject로 forward.
 /// - 로그인 시 익명 이미지(전 메모 + 휴지통)를 Storage + Firestore로 1회 마이그레이션.
 ///   메모 마이그레이션과 병렬로 진행되므로, 익명 enumeration은 `anonymousMemoRepository`를 직접 조회.
-public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
+public final class ImageRepositoryRouter: ImageRepository, PendingUploadResumeTrigger, @unchecked Sendable {
 
     private let authService: AuthService
     private let anonymousImpl: ImageRepository
@@ -33,6 +33,8 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
     private var _activeImpl: ImageRepository
     private var _firestoreImpl: ImageRepositoryFirestoreImpl?
     private var _progressStore: ImageUploadProgressStore?
+    private var _currentUserID: String?
+    private var _isMigrationInFlight: Bool = false
     private var _authCancellable: AnyCancellable?
     private var _publisherCancellable: AnyCancellable?
 
@@ -75,6 +77,7 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
             _progressStore = progressStore
             _firestoreImpl = impl
             _activeImpl = impl
+            _currentUserID = userID
             lock.unlock()
             attachForwarding(from: impl)
             triggerMigrationIfNeeded(to: impl, userID: userID)
@@ -83,9 +86,21 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
             _firestoreImpl = nil
             _progressStore = nil
             _activeImpl = anonymousImpl
+            _currentUserID = nil
             lock.unlock()
             attachForwarding(from: anonymousImpl)
         }
+    }
+
+    /// 현재 sign-in 사용자가 있으면 미완료 이미지 바이너리 업로드를 재개. 진행 중이면 no-op.
+    /// `sceneDidBecomeActive` 등 app lifecycle 시점에서 호출.
+    public func resumePendingUploadsIfNeeded() {
+        lock.lock()
+        let impl = _firestoreImpl
+        let userID = _currentUserID
+        lock.unlock()
+        guard let impl, let userID else { return }
+        triggerMigrationIfNeeded(to: impl, userID: userID)
     }
 
     /// AccountDetail 재시도 버튼 등 외부에서 마이그레이션을 수동으로 다시 시작할 때 호출.
@@ -116,11 +131,21 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
 
         let memoRepo = anonymousMemoRepository
         let imageRepo = anonymousImpl
-        lock.lock()
-        let progressStore = _progressStore
-        lock.unlock()
 
-        Task { [weak firestoreImpl] in
+        let canProceed: Bool = lock.withLock {
+            guard !_isMigrationInFlight else { return false }
+            _isMigrationInFlight = true
+            return true
+        }
+        guard canProceed else { return }
+        let progressStore = lock.withLock { _progressStore }
+
+        Task { [weak firestoreImpl, weak self] in
+            defer {
+                if let self {
+                    self.lock.withLock { self._isMigrationInFlight = false }
+                }
+            }
             guard let firestoreImpl else { return }
             do {
                 let collected: [MemoImageInfo]

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
@@ -98,36 +98,55 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
         triggerMigrationIfNeeded(to: impl, userID: userID)
     }
 
-    /// 익명 이미지 메타데이터를 Firestore 로 이관. UserDefaults 마커로 기기+사용자별 1회.
-    /// 메타 업로드 완료 시점에 marker set + cleanupCoordinator 보고 (= readiness gate 통과 신호).
+    /// 익명 이미지 메타데이터를 Firestore 로 이관 + 바이너리를 Storage 로 업로드.
+    /// 메타 업로드 완료 시점에 marker set + cleanupCoordinator 보고 — readiness gate 통과 신호.
     /// 바이너리 업로드는 분리된 백그라운드 Task — readiness gate 와 무관.
+    ///
+    /// 재진입 동작:
+    /// - 메타 미완 → 메타 업로드 + 바이너리 업로드 둘 다 진행.
+    /// - 메타 완료, 바이너리 미완 → 메타 skip, Firestore 에서 이미지 enumerate 후 바이너리만 재개
+    ///   (per-image progress store 가 이미 완료된 variant 는 skip).
+    /// - 메타 + 바이너리 모두 완료 → short-circuit (cleanup 보고만).
     private func triggerMigrationIfNeeded(to firestoreImpl: ImageRepositoryFirestoreImpl, userID: String) {
         let metaMarkerKey = Self.metaMarkerKey(for: userID)
         let legacyMarkerKey = Self.legacyMarkerKey(for: userID)
         let coordinator = cleanupCoordinator
+        let metaDone = UserDefaults.standard.bool(forKey: metaMarkerKey)
+            || UserDefaults.standard.bool(forKey: legacyMarkerKey)
 
-        // v2.5.0 에서 set 된 통합 marker 가 있으면 메타도 완료된 것으로 인정 (호환).
-        if UserDefaults.standard.bool(forKey: metaMarkerKey) || UserDefaults.standard.bool(forKey: legacyMarkerKey) {
-            Task { await coordinator.reportMigrationCompleted(userID: userID) }
-            return
-        }
         let memoRepo = anonymousMemoRepository
         let imageRepo = anonymousImpl
+        lock.lock()
+        let progressStore = _progressStore
+        lock.unlock()
+
         Task { [weak firestoreImpl] in
             guard let firestoreImpl else { return }
             do {
-                let active = try await memoRepo.getAllMemos()
-                let trashed = try await memoRepo.getAllMemosInTrash()
-                var collected: [MemoImageInfo] = []
-                for memo in active + trashed {
-                    let images = try await imageRepo.getAllImageInfo(for: memo)
-                    collected.append(contentsOf: images)
+                let collected: [MemoImageInfo]
+                if metaDone {
+                    // 익명 Core Data 가 cleanup 됐을 수 있으므로 Firestore 가 진실의 출처.
+                    collected = try await firestoreImpl.enumerateAllImageInfosFromFirestore()
+                    await coordinator.reportMigrationCompleted(userID: userID)
+                    if let progressStore, progressStore.isAllUploaded(amongst: collected) {
+                        return // 바이너리까지 다 끝남 — 진짜 short-circuit
+                    }
+                } else {
+                    let active = try await memoRepo.getAllMemos()
+                    let trashed = try await memoRepo.getAllMemosInTrash()
+                    var items: [MemoImageInfo] = []
+                    for memo in active + trashed {
+                        let images = try await imageRepo.getAllImageInfo(for: memo)
+                        items.append(contentsOf: images)
+                    }
+                    if !items.isEmpty {
+                        try await firestoreImpl.importImageMetadata(items)
+                    }
+                    UserDefaults.standard.set(true, forKey: metaMarkerKey)
+                    await coordinator.reportMigrationCompleted(userID: userID)
+                    collected = items
                 }
-                if !collected.isEmpty {
-                    try await firestoreImpl.importImageMetadata(collected)
-                }
-                UserDefaults.standard.set(true, forKey: metaMarkerKey)
-                await coordinator.reportMigrationCompleted(userID: userID)
+
                 if !collected.isEmpty {
                     try await firestoreImpl.uploadImageBinaries(collected)
                 }

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
@@ -32,6 +32,7 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
     private let lock = NSLock()
     private var _activeImpl: ImageRepository
     private var _firestoreImpl: ImageRepositoryFirestoreImpl?
+    private var _progressStore: ImageUploadProgressStore?
     private var _authCancellable: AnyCancellable?
     private var _publisherCancellable: AnyCancellable?
 
@@ -63,8 +64,15 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
 
     private func handleAuthChange(user: AuthUser?) {
         if let userID = user?.id {
-            let impl = ImageRepositoryFirestoreImpl(userID: userID, firestore: firestore, storage: storage)
+            let progressStore = ImageUploadProgressStore(userID: userID)
+            let impl = ImageRepositoryFirestoreImpl(
+                userID: userID,
+                firestore: firestore,
+                storage: storage,
+                progressStore: progressStore
+            )
             lock.lock()
+            _progressStore = progressStore
             _firestoreImpl = impl
             _activeImpl = impl
             lock.unlock()
@@ -73,6 +81,7 @@ public final class ImageRepositoryRouter: ImageRepository, @unchecked Sendable {
         } else {
             lock.lock()
             _firestoreImpl = nil
+            _progressStore = nil
             _activeImpl = anonymousImpl
             lock.unlock()
             attachForwarding(from: anonymousImpl)

--- a/Projects/Core/SyncImpl/Sources/ImageUploadProgressStore.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageUploadProgressStore.swift
@@ -1,0 +1,106 @@
+//
+//  ImageUploadProgressStore.swift
+//  NoteCard
+//
+
+import Domain
+import Foundation
+
+/// 익명 → Firestore 마이그레이션에서 이미지 바이너리(Storage) 업로드의 per-image 완료 여부를
+/// UserDefaults 에 영속화한다.
+///
+/// 한 사용자 안에서 원본·썸네일을 **별도로** 추적해, 한 쪽만 올라간 상태에서 끊겨도 복원 시
+/// 남은 쪽만 다시 시도할 수 있게 한다.
+///
+/// - 키: `sync.imageBinaryUpload.<userID>` 한 개. 값은 `Set<String>` 직렬화 (`[String]`).
+/// - 토큰 형식: `"original:<imageInfo.id>"`, `"thumbnail:<imageInfo.thumbnailID>"`.
+/// - 동시 호출 보호: 내부 NSLock. 모든 API 는 동기 — async 컨텍스트에서도 짧게 호출하고 빠짐.
+final class ImageUploadProgressStore: @unchecked Sendable {
+
+    enum Variant: String, Sendable {
+        case original
+        case thumbnail
+    }
+
+    private let userID: String
+    private let userDefaults: UserDefaults
+    private let lock = NSLock()
+
+    init(userID: String, userDefaults: UserDefaults = .standard) {
+        self.userID = userID
+        self.userDefaults = userDefaults
+    }
+
+    static func storageKey(for userID: String) -> String {
+        "sync.imageBinaryUpload.\(userID)"
+    }
+
+    private var storageKey: String { Self.storageKey(for: userID) }
+
+    // MARK: - API
+
+    func markUploaded(imageInfo: MemoImageInfo, variant: Variant) {
+        lock.lock()
+        defer { lock.unlock() }
+        var set = currentSet()
+        set.insert(token(for: imageInfo, variant: variant))
+        save(set)
+    }
+
+    func isUploaded(imageInfo: MemoImageInfo, variant: Variant) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return currentSet().contains(token(for: imageInfo, variant: variant))
+    }
+
+    /// 주어진 이미지 전부의 원본·썸네일이 모두 마킹되어 있으면 true. 빈 배열은 true.
+    func isAllUploaded(amongst infos: [MemoImageInfo]) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        let set = currentSet()
+        for info in infos {
+            if !set.contains(token(for: info, variant: .original)) { return false }
+            if !set.contains(token(for: info, variant: .thumbnail)) { return false }
+        }
+        return true
+    }
+
+    /// 미완료 항목의 variant 합 — 원본/썸네일 각각 1 카운트. UI 진행 표시용 (이번 PR 미사용).
+    func pendingCount(amongst infos: [MemoImageInfo]) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        let set = currentSet()
+        var count = 0
+        for info in infos {
+            if !set.contains(token(for: info, variant: .original)) { count += 1 }
+            if !set.contains(token(for: info, variant: .thumbnail)) { count += 1 }
+        }
+        return count
+    }
+
+    func clearAll() {
+        lock.lock()
+        defer { lock.unlock() }
+        userDefaults.removeObject(forKey: storageKey)
+    }
+
+    // MARK: - Internals
+
+    private func token(for info: MemoImageInfo, variant: Variant) -> String {
+        switch variant {
+        case .original:
+            return "\(Variant.original.rawValue):\(info.id.uuidString)"
+        case .thumbnail:
+            return "\(Variant.thumbnail.rawValue):\(info.thumbnailID.uuidString)"
+        }
+    }
+
+    private func currentSet() -> Set<String> {
+        guard let array = userDefaults.array(forKey: storageKey) as? [String] else { return [] }
+        return Set(array)
+    }
+
+    private func save(_ set: Set<String>) {
+        userDefaults.set(Array(set), forKey: storageKey)
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/NoOpPendingUploadResumeTrigger.swift
+++ b/Projects/Core/SyncImpl/Sources/NoOpPendingUploadResumeTrigger.swift
@@ -1,0 +1,12 @@
+//
+//  NoOpPendingUploadResumeTrigger.swift
+//  NoteCard
+//
+
+import Foundation
+import SyncInterface
+
+/// Firebase 미설정·익명 단독 환경에서 사용. 호출해도 아무 일도 하지 않음.
+final class NoOpPendingUploadResumeTrigger: PendingUploadResumeTrigger, @unchecked Sendable {
+    func resumePendingUploadsIfNeeded() {}
+}

--- a/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
+++ b/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
@@ -141,6 +141,17 @@ public enum SyncBootstrap {
         )
     }
 
+    /// `makeImageRepository` 의 결과가 Router 면 그걸 그대로 `PendingUploadResumeTrigger` 로 노출.
+    /// 익명 단독(Firebase 미설정) 환경에선 호출해도 no-op 인 트리거 반환.
+    public static func makePendingUploadResumeTrigger(
+        imageRepository: ImageRepository
+    ) -> PendingUploadResumeTrigger {
+        if let router = imageRepository as? ImageRepositoryRouter {
+            return router
+        }
+        return NoOpPendingUploadResumeTrigger()
+    }
+
     /// 첫 사인인 후 home 진입 가능 시점까지 대기시키는 readiness gate. Firebase 미설정 시 즉시 통과.
     /// 세 Repository 가 모두 Router 구현이 아니면 (= 익명 단독) 게이트가 의미 없어 NoOp 반환.
     public static func makeFirstSignInReadinessCoordinator(

--- a/Projects/Core/SyncImpl/Tests/ImageUploadProgressStoreTests.swift
+++ b/Projects/Core/SyncImpl/Tests/ImageUploadProgressStoreTests.swift
@@ -1,0 +1,229 @@
+import XCTest
+import Domain
+@testable import SyncImpl
+
+/// `ImageUploadProgressStore` 의 mark·조회·영속화·격리 동작을 검증.
+/// 각 테스트는 UserDefaults suite 를 새로 만들어 다른 테스트와 격리.
+final class ImageUploadProgressStoreTests: XCTestCase {
+
+    private var suiteName: String!
+    private var userDefaults: UserDefaults!
+    private let userID = "test-user"
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "ImageUploadProgressStoreTests-\(UUID().uuidString)"
+        userDefaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        userDefaults.removePersistentDomain(forName: suiteName)
+        userDefaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: - 헬퍼
+
+    private func makeSUT() -> ImageUploadProgressStore {
+        ImageUploadProgressStore(userID: userID, userDefaults: userDefaults)
+    }
+
+    private func makeImageInfo() -> MemoImageInfo {
+        MemoImageInfo(
+            id: UUID(),
+            thumbnailID: UUID(),
+            temporaryOrderIndex: 0,
+            orderIndex: 0,
+            memoID: UUID(),
+            isTemporaryDeleted: false,
+            isTemporaryAppended: false,
+            fileExtension: "jpeg"
+        )
+    }
+
+    // MARK: - mark / isUploaded
+
+    func test_초기상태에서_isUploaded_는_false_를_반환한다() {
+        // given
+        let sut = makeSUT()
+        let info = makeImageInfo()
+
+        // then
+        XCTAssertFalse(sut.isUploaded(imageInfo: info, variant: .original))
+        XCTAssertFalse(sut.isUploaded(imageInfo: info, variant: .thumbnail))
+    }
+
+    func test_mark_한_뒤_isUploaded_는_true_를_반환한다() {
+        // given
+        let sut = makeSUT()
+        let info = makeImageInfo()
+
+        // when
+        sut.markUploaded(imageInfo: info, variant: .original)
+
+        // then
+        XCTAssertTrue(sut.isUploaded(imageInfo: info, variant: .original))
+    }
+
+    func test_같은_mark_를_여러번_호출해도_상태가_바뀌지_않는다() {
+        // given
+        let sut = makeSUT()
+        let info = makeImageInfo()
+
+        // when
+        sut.markUploaded(imageInfo: info, variant: .original)
+        sut.markUploaded(imageInfo: info, variant: .original)
+        sut.markUploaded(imageInfo: info, variant: .original)
+
+        // then
+        XCTAssertTrue(sut.isUploaded(imageInfo: info, variant: .original))
+        XCTAssertEqual(sut.pendingCount(amongst: [info]), 1) // 썸네일만 남음
+    }
+
+    func test_원본과_썸네일은_독립적으로_추적된다() {
+        // given
+        let sut = makeSUT()
+        let info = makeImageInfo()
+
+        // when
+        sut.markUploaded(imageInfo: info, variant: .original)
+
+        // then
+        XCTAssertTrue(sut.isUploaded(imageInfo: info, variant: .original))
+        XCTAssertFalse(sut.isUploaded(imageInfo: info, variant: .thumbnail))
+    }
+
+    func test_다른_이미지의_mark_는_서로_영향을_주지_않는다() {
+        // given
+        let sut = makeSUT()
+        let infoA = makeImageInfo()
+        let infoB = makeImageInfo()
+
+        // when
+        sut.markUploaded(imageInfo: infoA, variant: .original)
+
+        // then
+        XCTAssertTrue(sut.isUploaded(imageInfo: infoA, variant: .original))
+        XCTAssertFalse(sut.isUploaded(imageInfo: infoB, variant: .original))
+    }
+
+    // MARK: - 영속화
+
+    func test_새_인스턴스에서도_이전_mark_가_그대로_조회된다() {
+        // given
+        let info = makeImageInfo()
+        let firstSUT = makeSUT()
+
+        // when
+        firstSUT.markUploaded(imageInfo: info, variant: .original)
+        firstSUT.markUploaded(imageInfo: info, variant: .thumbnail)
+        let secondSUT = makeSUT()
+
+        // then
+        XCTAssertTrue(secondSUT.isUploaded(imageInfo: info, variant: .original))
+        XCTAssertTrue(secondSUT.isUploaded(imageInfo: info, variant: .thumbnail))
+    }
+
+    // MARK: - isAllUploaded
+
+    func test_isAllUploaded_빈_배열은_true() {
+        // given
+        let sut = makeSUT()
+
+        // then
+        XCTAssertTrue(sut.isAllUploaded(amongst: []))
+    }
+
+    func test_isAllUploaded_원본과_썸네일_모두_mark_되어야_true() {
+        // given
+        let sut = makeSUT()
+        let info = makeImageInfo()
+
+        // when: 원본만 mark
+        sut.markUploaded(imageInfo: info, variant: .original)
+
+        // then: 썸네일이 남아 false
+        XCTAssertFalse(sut.isAllUploaded(amongst: [info]))
+
+        // when: 썸네일도 mark
+        sut.markUploaded(imageInfo: info, variant: .thumbnail)
+
+        // then: 둘 다 끝나 true
+        XCTAssertTrue(sut.isAllUploaded(amongst: [info]))
+    }
+
+    func test_isAllUploaded_여러장_중_한장이라도_미완이면_false() {
+        // given
+        let sut = makeSUT()
+        let infoA = makeImageInfo()
+        let infoB = makeImageInfo()
+
+        // when: infoA 는 둘 다 mark, infoB 는 원본만 mark
+        sut.markUploaded(imageInfo: infoA, variant: .original)
+        sut.markUploaded(imageInfo: infoA, variant: .thumbnail)
+        sut.markUploaded(imageInfo: infoB, variant: .original)
+
+        // then
+        XCTAssertFalse(sut.isAllUploaded(amongst: [infoA, infoB]))
+    }
+
+    // MARK: - pendingCount
+
+    func test_pendingCount_는_미완료_variant_의_합이다() {
+        // given
+        let sut = makeSUT()
+        let infoA = makeImageInfo()
+        let infoB = makeImageInfo()
+
+        // then: 아무것도 mark 안 됐을 때 두 장 × 두 variant = 4
+        XCTAssertEqual(sut.pendingCount(amongst: [infoA, infoB]), 4)
+
+        // when: infoA 원본만 mark
+        sut.markUploaded(imageInfo: infoA, variant: .original)
+
+        // then
+        XCTAssertEqual(sut.pendingCount(amongst: [infoA, infoB]), 3)
+
+        // when: 나머지도 모두 mark
+        sut.markUploaded(imageInfo: infoA, variant: .thumbnail)
+        sut.markUploaded(imageInfo: infoB, variant: .original)
+        sut.markUploaded(imageInfo: infoB, variant: .thumbnail)
+
+        // then
+        XCTAssertEqual(sut.pendingCount(amongst: [infoA, infoB]), 0)
+    }
+
+    // MARK: - clearAll
+
+    func test_clearAll_후에는_모든_mark_가_사라진다() {
+        // given
+        let sut = makeSUT()
+        let info = makeImageInfo()
+        sut.markUploaded(imageInfo: info, variant: .original)
+        sut.markUploaded(imageInfo: info, variant: .thumbnail)
+
+        // when
+        sut.clearAll()
+
+        // then
+        XCTAssertFalse(sut.isUploaded(imageInfo: info, variant: .original))
+        XCTAssertFalse(sut.isUploaded(imageInfo: info, variant: .thumbnail))
+    }
+
+    // MARK: - 사용자 격리
+
+    func test_다른_userID_의_store_는_상태가_분리된다() {
+        // given
+        let info = makeImageInfo()
+        let sutA = ImageUploadProgressStore(userID: "user-A", userDefaults: userDefaults)
+        let sutB = ImageUploadProgressStore(userID: "user-B", userDefaults: userDefaults)
+
+        // when
+        sutA.markUploaded(imageInfo: info, variant: .original)
+
+        // then
+        XCTAssertTrue(sutA.isUploaded(imageInfo: info, variant: .original))
+        XCTAssertFalse(sutB.isUploaded(imageInfo: info, variant: .original))
+    }
+}

--- a/Projects/Core/SyncInterface/Sources/PendingUploadResumeTrigger.swift
+++ b/Projects/Core/SyncInterface/Sources/PendingUploadResumeTrigger.swift
@@ -1,0 +1,17 @@
+//
+//  PendingUploadResumeTrigger.swift
+//  NoteCard
+//
+
+import Foundation
+
+/// 첫 sign-in 마이그레이션의 미완료 이미지 바이너리 업로드를 재개시키는 진입점.
+/// app lifecycle 시점 (포그라운드 복귀 / launch) 에서 호출되어 끊긴 업로드를 이어 받는다.
+///
+/// 호출 측은 sign-in 여부·진행 중 여부를 알 필요 없이 호출만 하면 되도록 idempotent 설계:
+/// - sign-in 안 됨 → no-op
+/// - 이미 진행 중 → no-op
+/// - 메타·바이너리 모두 완료됨 → no-op
+public protocol PendingUploadResumeTrigger: Sendable {
+    func resumePendingUploadsIfNeeded()
+}


### PR DESCRIPTION
## 배경
- 익명 → Firestore 첫 마이그레이션에서 이미지 바이너리 업로드가 가장 오래 걸림. 이미지가 많은 사용자가 도중에 앱을 종료하면, 어디까지 올라갔는지 흔적이 없어 다음 진입 시 전체를 처음부터 재시도해야 했음.
- 또한 메타 마커가 set 된 직후엔 `triggerMigrationIfNeeded` 가 cleanup 보고만 하고 일찍 종료돼, 바이너리가 끊긴 채 남아도 다음 진입 / AccountDetail 의 동기화 재시도 버튼이 바이너리 단계로 진입조차 못 하는 regression 이 main 에 있었음. v2.5.0 배포 사용자에게는 영향 없음 (그 시점은 메타+바이너리 통합 함수라 마커가 진짜 완료를 의미).

## 변경사항
- per-image 업로드 추적 도입.
  - `ImageUploadProgressStore` (UserDefaults backed) 신규. 원본·썸네일 variant 를 별도로 추적, 사용자 ID 별 키 분리.
  - 단위 테스트 12 개 추가.
- `uploadImageBinaries` 가 progress store 와 결합.
  - 시작 전 이미 완료된 variant 는 skip, 성공 직후 mark.
  - 같은 이미지 안에서 원본·썸네일 병렬 업로드. 한 쪽이 실패해도 다른 쪽 mark 가 남아 다음 시도에서 실패한 쪽만 재시도됨.
- `triggerMigrationIfNeeded` 재진입 흐름 수정.
  - 메타 마커 set 상태에선 익명 Core Data 가 cleanup 됐을 수 있으므로 Firestore 를 진실의 출처로 enumerate (`enumerateAllImageInfosFromFirestore` 추가).
  - 진짜 short-circuit 조건은 "메타 완료 + per-image 모두 완료". 그 외엔 바이너리 단계로 진입해 끊긴 지점부터 이어 진행.
  - AccountDetail 의 동기화 재시도 버튼이 정상 동작하게 됨.
- 포그라운드 복귀 시 자동 재개.
  - `PendingUploadResumeTrigger` protocol (`SyncInterface` 신규) + `ImageRepositoryRouter` conform + NoOp + `SyncBootstrap` factory + `AppEnvironment` 노출.
  - `SceneDelegate.sceneDidBecomeActive` 가 호출해 미완 업로드 자동 재개.
  - 중복 실행 방지를 위해 `_isMigrationInFlight` in-flight 가드 추가.
- 변수명 / 코드 스타일 정리.
  - `triggerMigrationIfNeeded` 안의 단축 alias (`metaDone`, `collected`, `items`, `active` 등) 를 명시적 이름으로. capture 트릭용 local alias 들은 capture list 로 이동해 함수 본문은 실제 마이그 로직에만 집중.
  - `SceneDelegate` 의 optional chaining 한 줄을 `if let` 패턴으로 풀어 가독성 ↑.
  - `ImageRepositoryFirestoreImpl` 의 Storage ref 호출 인자를 한 줄에 하나씩 배치.

## 테스트 방법
- 익명 모드에서 메모 + 이미지 다수 추가 → 사인 인 → 이미지 업로드가 진행되는 동안 앱 강제 종료 → 다시 켜기 → 끊긴 이미지만 이어서 업로드되는지 확인.
- AccountDetail 의 "동기화 재시도" 버튼을 끊긴 상태에서 눌러 끊긴 바이너리 단계로 진입해 진행하는지 확인.
- 백그라운드 → 포그라운드 복귀 시 미완 업로드가 자동 재개되는지 확인.
- `SyncImpl` 단위 테스트 24 개 (`ImageUploadProgressStoreTests` 12 신규 + 기존 12) 통과 확인.

## 리뷰 노트
- v2.5.0 배포 사용자에게는 retry short-circuit 영향이 없음 (당시 코드가 메타+바이너리 통합 함수라 마커가 진짜 완료를 의미). 이번 수정은 v2.5.0 이후 main 에 들어온 regression 을 다음 배포 전에 함께 보내는 의도.
- 앱 종료 상태에서 OS 가 깨워 업로드 진행하는 백그라운드 동작은 이번 스코프 밖. Firebase Storage iOS SDK 가 표준 background URLSession 을 지원하지 않아 구현 비용이 크므로 별도 작업으로 미룸.
- AccountDetail 에 진행 상황 (X / Y) 표시는 후속 PR 로 분리 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)