### PR TITLE
feat(account-detail): 첫 sign-in 이미지 업로드 진행 상황 표시

### DIFF
--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -31,6 +31,7 @@ struct AppEnvironment {
     let firstSignInReadinessCoordinator: FirstSignInReadinessCoordinator
     let signOutCoordinator: SignOutCoordinator
     let pendingUploadResumeTrigger: PendingUploadResumeTrigger
+    let uploadProgressObservable: UploadProgressObservable
 
     let coreDataStack: CoreDataStack
 
@@ -105,6 +106,9 @@ struct AppEnvironment {
         )
         self.signOutCoordinator = SyncBootstrap.makeSignOutCoordinator(authService: authService)
         self.pendingUploadResumeTrigger = SyncBootstrap.makePendingUploadResumeTrigger(
+            imageRepository: imageRepository
+        )
+        self.uploadProgressObservable = SyncBootstrap.makeUploadProgressObservable(
             imageRepository: imageRepository
         )
     }

--- a/NoteCard/Presentation/TabBar/MainTabBarController.swift
+++ b/NoteCard/Presentation/TabBar/MainTabBarController.swift
@@ -106,6 +106,7 @@ class MainTabBarController: UITabBarController {
             syncStatusService: environment.syncStatusService,
             readinessCoordinator: environment.firstSignInReadinessCoordinator,
             signOutCoordinator: environment.signOutCoordinator,
+            uploadProgressObservable: environment.uploadProgressObservable,
             makeTrashViewController: { [environment] in
                 MemoViewController(memoVCType: .trash, environment: environment)
             }

--- a/Projects/Core/Shared/Resources/Localizable.xcstrings
+++ b/Projects/Core/Shared/Resources/Localizable.xcstrings
@@ -2605,6 +2605,20 @@
         "ko": { "stringUnit": { "state": "translated", "value": "—" } }
       }
     },
+    "account.imageUploadLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Image upload" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이미지 업로드" } }
+      }
+    },
+    "account.imageUploadProgressFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "%1$d of %2$d" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "%1$d장 / %2$d장" } }
+      }
+    },
     "account.signOut": {
       "extractionState": "manual",
       "localizations": {

--- a/Projects/Core/Shared/Resources/Localizable.xcstrings
+++ b/Projects/Core/Shared/Resources/Localizable.xcstrings
@@ -2608,8 +2608,8 @@
     "account.imageUploadLabel": {
       "extractionState": "manual",
       "localizations": {
-        "en": { "stringUnit": { "state": "translated", "value": "Image upload" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "이미지 업로드" } }
+        "en": { "stringUnit": { "state": "translated", "value": "Initial image upload" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "초기 이미지 업로드" } }
       }
     },
     "account.imageUploadProgressFormat": {

--- a/Projects/Core/Shared/Sources/Localization/L10n.swift
+++ b/Projects/Core/Shared/Sources/Localization/L10n.swift
@@ -193,6 +193,8 @@ public enum L10n {
         public static let syncStatusSynced = "account.syncStatusSynced".localized()
         public static let lastSyncedLabel = "account.lastSyncedLabel".localized()
         public static let lastSyncedNever = "account.lastSyncedNever".localized()
+        public static let imageUploadLabel = "account.imageUploadLabel".localized()
+        public static let imageUploadProgressFormat = "account.imageUploadProgressFormat".localized()
         public static let signOut = "account.signOut".localized()
         public static let signOutConfirmTitle = "account.signOutConfirmTitle".localized()
         public static let signOutConfirmMessage = "account.signOutConfirmMessage".localized()

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
@@ -252,7 +252,7 @@ public final class ImageRepositoryFirestoreImpl: ImageRepository, @unchecked Sen
     // MARK: - Migration
 
     /// 현재 사용자의 모든 메모 sub-collection 을 Firestore 에서 enumerate 해 이미지 메타를 모은다.
-    /// 메타 마이그가 이미 끝난 상태에서 재진입할 때 익명 Core Data 가 cleanup 됐을 수 있으므로,
+    /// 메타 마이그레이션이 이미 끝난 상태에서 재진입할 때 익명 Core Data 가 cleanup 됐을 수 있으므로,
     /// 익명 enumerate 대신 Firestore 를 진실의 출처로 삼는다.
     func enumerateAllImageInfosFromFirestore() async throws -> [MemoImageInfo] {
         let memosCollection = firestore.collection("users").document(userID).collection("memos")

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryFirestoreImpl.swift
@@ -251,26 +251,6 @@ public final class ImageRepositoryFirestoreImpl: ImageRepository, @unchecked Sen
 
     // MARK: - Migration
 
-    /// 현재 사용자의 모든 메모 sub-collection 을 Firestore 에서 enumerate 해 이미지 메타를 모은다.
-    /// 메타 마이그레이션이 이미 끝난 상태에서 재진입할 때 익명 Core Data 가 cleanup 됐을 수 있으므로,
-    /// 익명 enumerate 대신 Firestore 를 진실의 출처로 삼는다.
-    func enumerateAllImageInfosFromFirestore() async throws -> [MemoImageInfo] {
-        let memosCollection = firestore.collection("users").document(userID).collection("memos")
-        let memoSnapshot = try await memosCollection.getDocuments()
-        var collected: [MemoImageInfo] = []
-        for memoDoc in memoSnapshot.documents {
-            guard let memoID = UUID(uuidString: memoDoc.documentID) else { continue }
-            let images = try await imageCollection(for: memoID).order(by: "orderIndex").getDocuments()
-            for imgDoc in images.documents {
-                if let dto = try? imgDoc.data(as: FirestoreMemoImage.self),
-                   let info = dto.toDomain() {
-                    collected.append(info)
-                }
-            }
-        }
-        return collected
-    }
-
     /// 익명 Core Data 의 이미지 메타데이터만 Firestore 에 import. Storage 바이너리 업로드는 별도 단계.
     /// 한 장 실패해도 다음 진행. setData(merge: true) 로 멱등.
     func importImageMetadata(_ images: [MemoImageInfo]) async throws {

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
@@ -20,7 +20,7 @@ import UIKit
 /// - 전환 시 활성 impl의 `imageUpdatedPublisher`를 내부 subject로 forward.
 /// - 로그인 시 익명 이미지(전 메모 + 휴지통)를 Storage + Firestore로 1회 마이그레이션.
 ///   메모 마이그레이션과 병렬로 진행되므로, 익명 enumeration은 `anonymousMemoRepository`를 직접 조회.
-public final class ImageRepositoryRouter: ImageRepository, PendingUploadResumeTrigger, @unchecked Sendable {
+public final class ImageRepositoryRouter: ImageRepository, PendingUploadResumeTrigger, UploadProgressObservable, @unchecked Sendable {
 
     private let authService: AuthService
     private let anonymousImpl: ImageRepository
@@ -37,10 +37,16 @@ public final class ImageRepositoryRouter: ImageRepository, PendingUploadResumeTr
     private var _isMigrationInFlight: Bool = false
     private var _authCancellable: AnyCancellable?
     private var _publisherCancellable: AnyCancellable?
+    private var _progressForwardCancellable: AnyCancellable?
 
     private let updatedSubject = PassthroughSubject<ImageUpdateType, Never>()
     public var imageUpdatedPublisher: AnyPublisher<ImageUpdateType, Never> {
         updatedSubject.eraseToAnyPublisher()
+    }
+
+    private let imageUploadProgressSubject = CurrentValueSubject<UploadProgressSnapshot?, Never>(nil)
+    public var imageUploadProgressPublisher: AnyPublisher<UploadProgressSnapshot?, Never> {
+        imageUploadProgressSubject.eraseToAnyPublisher()
     }
 
     public init(
@@ -73,22 +79,31 @@ public final class ImageRepositoryRouter: ImageRepository, PendingUploadResumeTr
                 storage: storage,
                 progressStore: progressStore
             )
-            lock.lock()
-            _progressStore = progressStore
-            _firestoreImpl = impl
-            _activeImpl = impl
-            _currentUserID = userID
-            lock.unlock()
+            let progressForwardCancellable = progressStore.progressPublisher
+                .sink { [imageUploadProgressSubject] snapshot in
+                    imageUploadProgressSubject.send(snapshot)
+                }
+            lock.withLock {
+                _progressStore = progressStore
+                _firestoreImpl = impl
+                _activeImpl = impl
+                _currentUserID = userID
+                _progressForwardCancellable?.cancel()
+                _progressForwardCancellable = progressForwardCancellable
+            }
             attachForwarding(from: impl)
             triggerMigrationIfNeeded(to: impl, userID: userID)
         } else {
-            lock.lock()
-            _firestoreImpl = nil
-            _progressStore = nil
-            _activeImpl = anonymousImpl
-            _currentUserID = nil
-            lock.unlock()
+            lock.withLock {
+                _firestoreImpl = nil
+                _progressStore = nil
+                _activeImpl = anonymousImpl
+                _currentUserID = nil
+                _progressForwardCancellable?.cancel()
+                _progressForwardCancellable = nil
+            }
             attachForwarding(from: anonymousImpl)
+            imageUploadProgressSubject.send(nil)
         }
     }
 
@@ -154,6 +169,7 @@ public final class ImageRepositoryRouter: ImageRepository, PendingUploadResumeTr
                 if isImageMetaDataMigrated {
                     // 익명 Core Data 가 cleanup 됐을 수 있으므로 Firestore 가 진실의 출처.
                     imageInfosToUpload = try await firestoreImpl.enumerateAllImageInfosFromFirestore()
+                    progressStore?.setProgressTarget(imageInfosToUpload)
                     await cleanupCoordinator.reportMigrationCompleted(userID: userID)
                     if let progressStore, progressStore.isAllUploaded(amongst: imageInfosToUpload) {
                         return // 바이너리까지 다 끝남 — 진짜 short-circuit
@@ -166,6 +182,7 @@ public final class ImageRepositoryRouter: ImageRepository, PendingUploadResumeTr
                         let imageInfosOfMemo = try await anonymousImpl.getAllImageInfo(for: memo)
                         collectedImageInfos.append(contentsOf: imageInfosOfMemo)
                     }
+                    progressStore?.setProgressTarget(collectedImageInfos)
                     if !collectedImageInfos.isEmpty {
                         try await firestoreImpl.importImageMetadata(collectedImageInfos)
                     }

--- a/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageRepositoryRouter.swift
@@ -133,10 +133,10 @@ public final class ImageRepositoryRouter: ImageRepository, PendingUploadResumeTr
     /// 바이너리 업로드는 분리된 백그라운드 Task — readiness gate 와 무관.
     ///
     /// 재진입 동작:
-    /// - 메타 미완 → 메타 업로드 + 바이너리 업로드 둘 다 진행.
-    /// - 메타 완료, 바이너리 미완 → 메타 skip, Firestore 에서 이미지 enumerate 후 바이너리만 재개
-    ///   (per-image progress store 가 이미 완료된 variant 는 skip).
-    /// - 메타 + 바이너리 모두 완료 → short-circuit (cleanup 보고만).
+    /// - 메타 미완 → 익명 enumerate 결과로 target 영속화 + 메타 업로드 + 바이너리 업로드 진행.
+    /// - 메타 완료, 영속화된 target 있음 → 그 target 으로 바이너리 단계만 재개 (Firestore 에서
+    ///   다시 enumerate 하지 않음 — sign-in 이후 새로 만든 이미지가 분모에 섞이는 걸 막기 위해).
+    /// - 메타 완료, 영속화된 target 없음 → 마이그레이션 이미 끝났다는 의미 → short-circuit.
     private func triggerMigrationIfNeeded(to firestoreImpl: ImageRepositoryFirestoreImpl, userID: String) {
         let metaMarkerKey = Self.metaMarkerKey(for: userID)
         let legacyMarkerKey = Self.legacyMarkerKey(for: userID)
@@ -167,13 +167,14 @@ public final class ImageRepositoryRouter: ImageRepository, PendingUploadResumeTr
             do {
                 let imageInfosToUpload: [MemoImageInfo]
                 if isImageMetaDataMigrated {
-                    // 익명 Core Data 가 cleanup 됐을 수 있으므로 Firestore 가 진실의 출처.
-                    imageInfosToUpload = try await firestoreImpl.enumerateAllImageInfosFromFirestore()
-                    progressStore?.setProgressTarget(imageInfosToUpload)
-                    await cleanupCoordinator.reportMigrationCompleted(userID: userID)
-                    if let progressStore, progressStore.isAllUploaded(amongst: imageInfosToUpload) {
-                        return // 바이너리까지 다 끝남 — 진짜 short-circuit
+                    let storedTarget = progressStore?.currentTarget ?? []
+                    if storedTarget.isEmpty {
+                        // 메타도 끝났고 영속화된 target 도 없음 → 마이그레이션 이미 완료. cleanup 만 보고.
+                        await cleanupCoordinator.reportMigrationCompleted(userID: userID)
+                        return
                     }
+                    imageInfosToUpload = storedTarget
+                    await cleanupCoordinator.reportMigrationCompleted(userID: userID)
                 } else {
                     let activeMemos = try await anonymousMemoRepository.getAllMemos()
                     let trashedMemos = try await anonymousMemoRepository.getAllMemosInTrash()

--- a/Projects/Core/SyncImpl/Sources/ImageUploadProgressStore.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageUploadProgressStore.swift
@@ -3,18 +3,22 @@
 //  NoteCard
 //
 
+import Combine
 import Domain
 import Foundation
+import SyncInterface
 
 /// 익명 → Firestore 마이그레이션에서 이미지 바이너리(Storage) 업로드의 per-image 완료 여부를
-/// UserDefaults 에 영속화한다.
+/// UserDefaults 에 영속화하고, 진행 상황(`UploadProgressSnapshot`)을 Combine publisher 로 노출한다.
 ///
 /// 한 사용자 안에서 원본·썸네일을 **별도로** 추적해, 한 쪽만 올라간 상태에서 끊겨도 복원 시
 /// 남은 쪽만 다시 시도할 수 있게 한다.
 ///
-/// - 키: `sync.imageBinaryUpload.<userID>` 한 개. 값은 `Set<String>` 직렬화 (`[String]`).
+/// - 영속 key: `sync.imageBinaryUpload.<userID>` 한 개. 값은 `Set<String>` 직렬화 (`[String]`).
 /// - 토큰 형식: `"original:<imageInfo.id>"`, `"thumbnail:<imageInfo.thumbnailID>"`.
-/// - 동시 호출 보호: 내부 NSLock. 모든 API 는 동기 — async 컨텍스트에서도 짧게 호출하고 빠짐.
+/// - 진행 상황은 `setProgressTarget(_:)` 으로 알려준 이미지 목록을 기준으로 계산. mark / clear
+///   시점마다 자동 emit. 전부 완료됐거나 target 이 비어 있으면 nil 을 emit 해 UI 가 표시를 숨김.
+/// - 동시 호출 보호: 내부 NSLock. 모든 API 동기.
 final class ImageUploadProgressStore: @unchecked Sendable {
 
     enum Variant: String, Sendable {
@@ -25,6 +29,12 @@ final class ImageUploadProgressStore: @unchecked Sendable {
     private let userID: String
     private let userDefaults: UserDefaults
     private let lock = NSLock()
+    private var totalImageInfos: [MemoImageInfo] = []
+    private let progressSubject = CurrentValueSubject<UploadProgressSnapshot?, Never>(nil)
+
+    var progressPublisher: AnyPublisher<UploadProgressSnapshot?, Never> {
+        progressSubject.eraseToAnyPublisher()
+    }
 
     init(userID: String, userDefaults: UserDefaults = .standard) {
         self.userID = userID
@@ -40,48 +50,67 @@ final class ImageUploadProgressStore: @unchecked Sendable {
     // MARK: - API
 
     func markUploaded(imageInfo: MemoImageInfo, variant: Variant) {
-        lock.lock()
-        defer { lock.unlock() }
-        var set = currentSet()
-        set.insert(token(for: imageInfo, variant: variant))
-        save(set)
+        lock.withLock {
+            var set = currentSet()
+            set.insert(token(for: imageInfo, variant: variant))
+            save(set)
+        }
+        recalculateAndEmit()
     }
 
     func isUploaded(imageInfo: MemoImageInfo, variant: Variant) -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return currentSet().contains(token(for: imageInfo, variant: variant))
+        lock.withLock {
+            currentSet().contains(token(for: imageInfo, variant: variant))
+        }
     }
 
     /// 주어진 이미지 전부의 원본·썸네일이 모두 마킹되어 있으면 true. 빈 배열은 true.
     func isAllUploaded(amongst infos: [MemoImageInfo]) -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        let set = currentSet()
-        for info in infos {
-            if !set.contains(token(for: info, variant: .original)) { return false }
-            if !set.contains(token(for: info, variant: .thumbnail)) { return false }
+        lock.withLock {
+            let set = currentSet()
+            for info in infos {
+                if !set.contains(token(for: info, variant: .original)) { return false }
+                if !set.contains(token(for: info, variant: .thumbnail)) { return false }
+            }
+            return true
         }
-        return true
     }
 
-    /// 미완료 항목의 variant 합 — 원본/썸네일 각각 1 카운트. UI 진행 표시용 (이번 PR 미사용).
+    /// 미완료 항목의 variant 합 — 원본/썸네일 각각 1 카운트.
     func pendingCount(amongst infos: [MemoImageInfo]) -> Int {
-        lock.lock()
-        defer { lock.unlock() }
-        let set = currentSet()
-        var count = 0
-        for info in infos {
-            if !set.contains(token(for: info, variant: .original)) { count += 1 }
-            if !set.contains(token(for: info, variant: .thumbnail)) { count += 1 }
+        lock.withLock {
+            let set = currentSet()
+            var count = 0
+            for info in infos {
+                if !set.contains(token(for: info, variant: .original)) { count += 1 }
+                if !set.contains(token(for: info, variant: .thumbnail)) { count += 1 }
+            }
+            return count
         }
-        return count
+    }
+
+    /// 마이그레이션 대상 이미지 목록을 알려줘 progress 계산의 기준으로 사용. 이후 mark 시점마다
+    /// 자동으로 (completed, total) snapshot 을 emit. 전부 완료됐거나 infos 가 비면 nil 을 emit.
+    func setProgressTarget(_ infos: [MemoImageInfo]) {
+        lock.withLock {
+            totalImageInfos = infos
+        }
+        recalculateAndEmit()
+    }
+
+    /// progress 표시를 명시적으로 끔 (sign-out 등). nil 을 emit.
+    func clearProgressTarget() {
+        lock.withLock {
+            totalImageInfos = []
+        }
+        progressSubject.send(nil)
     }
 
     func clearAll() {
-        lock.lock()
-        defer { lock.unlock() }
-        userDefaults.removeObject(forKey: storageKey)
+        lock.withLock {
+            userDefaults.removeObject(forKey: storageKey)
+        }
+        recalculateAndEmit()
     }
 
     // MARK: - Internals
@@ -102,5 +131,30 @@ final class ImageUploadProgressStore: @unchecked Sendable {
 
     private func save(_ set: Set<String>) {
         userDefaults.set(Array(set), forKey: storageKey)
+    }
+
+    private func recalculateAndEmit() {
+        let (set, infos): (Set<String>, [MemoImageInfo]) = lock.withLock {
+            (currentSet(), totalImageInfos)
+        }
+        guard !infos.isEmpty else {
+            progressSubject.send(nil)
+            return
+        }
+        var completed = 0
+        for info in infos {
+            if set.contains(token(for: info, variant: .original))
+                && set.contains(token(for: info, variant: .thumbnail)) {
+                completed += 1
+            }
+        }
+        if completed >= infos.count {
+            progressSubject.send(nil)
+        } else {
+            progressSubject.send(UploadProgressSnapshot(
+                completedImageCount: completed,
+                totalImageCount: infos.count
+            ))
+        }
     }
 }

--- a/Projects/Core/SyncImpl/Sources/ImageUploadProgressStore.swift
+++ b/Projects/Core/SyncImpl/Sources/ImageUploadProgressStore.swift
@@ -8,16 +8,20 @@ import Domain
 import Foundation
 import SyncInterface
 
-/// 익명 → Firestore 마이그레이션에서 이미지 바이너리(Storage) 업로드의 per-image 완료 여부를
-/// UserDefaults 에 영속화하고, 진행 상황(`UploadProgressSnapshot`)을 Combine publisher 로 노출한다.
+/// 익명 → Firestore 마이그레이션에서 이미지 바이너리(Storage) 업로드의 per-image 완료 여부와
+/// 마이그레이션 대상 이미지 목록을 UserDefaults 에 영속화하고, 진행 상황
+/// (`UploadProgressSnapshot`)을 Combine publisher 로 노출한다.
 ///
 /// 한 사용자 안에서 원본·썸네일을 **별도로** 추적해, 한 쪽만 올라간 상태에서 끊겨도 복원 시
 /// 남은 쪽만 다시 시도할 수 있게 한다.
 ///
-/// - 영속 key: `sync.imageBinaryUpload.<userID>` 한 개. 값은 `Set<String>` 직렬화 (`[String]`).
-/// - 토큰 형식: `"original:<imageInfo.id>"`, `"thumbnail:<imageInfo.thumbnailID>"`.
-/// - 진행 상황은 `setProgressTarget(_:)` 으로 알려준 이미지 목록을 기준으로 계산. mark / clear
-///   시점마다 자동 emit. 전부 완료됐거나 target 이 비어 있으면 nil 을 emit 해 UI 가 표시를 숨김.
+/// - 완료 마킹 key: `sync.imageBinaryUpload.<userID>` — 값은 `Set<String>` 직렬화 (`[String]`).
+///   토큰 형식: `"original:<imageInfo.id>"`, `"thumbnail:<imageInfo.thumbnailID>"`.
+/// - 마이그레이션 대상 key: `sync.imageMigrationTarget.<userID>` — 값은 JSON `[MemoImageInfo]`.
+///   `setProgressTarget(_:)` 시 영속화되고, 모든 항목이 완료되면 자동으로 삭제된다 (재진입 시
+///   "이미 끝남"으로 해석할 수 있도록).
+/// - 진행 상황은 mark / setProgressTarget 시점마다 자동 재계산해 emit. 완료됐거나 target 이
+///   비어 있으면 nil 을 emit 해 UI 가 표시를 숨김.
 /// - 동시 호출 보호: 내부 NSLock. 모든 API 동기.
 final class ImageUploadProgressStore: @unchecked Sendable {
 
@@ -29,7 +33,7 @@ final class ImageUploadProgressStore: @unchecked Sendable {
     private let userID: String
     private let userDefaults: UserDefaults
     private let lock = NSLock()
-    private var totalImageInfos: [MemoImageInfo] = []
+    private var totalImageInfos: [MemoImageInfo]
     private let progressSubject = CurrentValueSubject<UploadProgressSnapshot?, Never>(nil)
 
     var progressPublisher: AnyPublisher<UploadProgressSnapshot?, Never> {
@@ -39,15 +43,26 @@ final class ImageUploadProgressStore: @unchecked Sendable {
     init(userID: String, userDefaults: UserDefaults = .standard) {
         self.userID = userID
         self.userDefaults = userDefaults
+        self.totalImageInfos = Self.loadTarget(userID: userID, userDefaults: userDefaults)
     }
 
     static func storageKey(for userID: String) -> String {
         "sync.imageBinaryUpload.\(userID)"
     }
 
+    static func targetStorageKey(for userID: String) -> String {
+        "sync.imageMigrationTarget.\(userID)"
+    }
+
     private var storageKey: String { Self.storageKey(for: userID) }
+    private var targetStorageKey: String { Self.targetStorageKey(for: userID) }
 
     // MARK: - API
+
+    /// 현재 보유한 마이그레이션 대상 이미지 목록 (영속화 + 메모리). 완료됐거나 미설정이면 빈 배열.
+    var currentTarget: [MemoImageInfo] {
+        lock.withLock { totalImageInfos }
+    }
 
     func markUploaded(imageInfo: MemoImageInfo, variant: Variant) {
         lock.withLock {
@@ -89,19 +104,22 @@ final class ImageUploadProgressStore: @unchecked Sendable {
         }
     }
 
-    /// 마이그레이션 대상 이미지 목록을 알려줘 progress 계산의 기준으로 사용. 이후 mark 시점마다
-    /// 자동으로 (completed, total) snapshot 을 emit. 전부 완료됐거나 infos 가 비면 nil 을 emit.
+    /// 마이그레이션 대상 이미지 목록을 알려줘 영속화하고 progress 계산의 기준으로 삼는다.
+    /// 이후 mark 시점마다 자동으로 (completed, total) snapshot 을 emit. 모두 완료되면 영속화도
+    /// 자동 삭제 + nil emit.
     func setProgressTarget(_ infos: [MemoImageInfo]) {
         lock.withLock {
             totalImageInfos = infos
+            saveTarget(infos)
         }
         recalculateAndEmit()
     }
 
-    /// progress 표시를 명시적으로 끔 (sign-out 등). nil 을 emit.
+    /// progress 표시 + 영속화된 target 을 명시적으로 삭제 (sign-out 등).
     func clearProgressTarget() {
         lock.withLock {
             totalImageInfos = []
+            userDefaults.removeObject(forKey: targetStorageKey)
         }
         progressSubject.send(nil)
     }
@@ -133,6 +151,19 @@ final class ImageUploadProgressStore: @unchecked Sendable {
         userDefaults.set(Array(set), forKey: storageKey)
     }
 
+    private func saveTarget(_ infos: [MemoImageInfo]) {
+        guard let data = try? JSONEncoder().encode(infos) else {
+            userDefaults.removeObject(forKey: targetStorageKey)
+            return
+        }
+        userDefaults.set(data, forKey: targetStorageKey)
+    }
+
+    private static func loadTarget(userID: String, userDefaults: UserDefaults) -> [MemoImageInfo] {
+        guard let data = userDefaults.data(forKey: targetStorageKey(for: userID)) else { return [] }
+        return (try? JSONDecoder().decode([MemoImageInfo].self, from: data)) ?? []
+    }
+
     private func recalculateAndEmit() {
         let (set, infos): (Set<String>, [MemoImageInfo]) = lock.withLock {
             (currentSet(), totalImageInfos)
@@ -149,6 +180,11 @@ final class ImageUploadProgressStore: @unchecked Sendable {
             }
         }
         if completed >= infos.count {
+            // 완료 — 영속화된 target 자동 삭제 (재진입 시 "이미 끝남" 으로 해석) + nil emit (row hide).
+            lock.withLock {
+                totalImageInfos = []
+                userDefaults.removeObject(forKey: targetStorageKey)
+            }
             progressSubject.send(nil)
         } else {
             progressSubject.send(UploadProgressSnapshot(

--- a/Projects/Core/SyncImpl/Sources/NoOpUploadProgressObservable.swift
+++ b/Projects/Core/SyncImpl/Sources/NoOpUploadProgressObservable.swift
@@ -1,0 +1,15 @@
+//
+//  NoOpUploadProgressObservable.swift
+//  NoteCard
+//
+
+import Combine
+import Foundation
+import SyncInterface
+
+/// Firebase 미설정·익명 단독 환경에서 사용. 항상 nil 을 한 번 emit 해 UI 가 표시를 숨기게 함.
+final class NoOpUploadProgressObservable: UploadProgressObservable, @unchecked Sendable {
+    var imageUploadProgressPublisher: AnyPublisher<UploadProgressSnapshot?, Never> {
+        Just(nil).eraseToAnyPublisher()
+    }
+}

--- a/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
+++ b/Projects/Core/SyncImpl/Sources/SyncBootstrap.swift
@@ -152,6 +152,17 @@ public enum SyncBootstrap {
         return NoOpPendingUploadResumeTrigger()
     }
 
+    /// `makeImageRepository` 의 결과가 Router 면 그걸 그대로 `UploadProgressObservable` 로 노출.
+    /// 익명 단독 환경에선 항상 nil 을 emit 하는 NoOp 반환 (UI 는 표시를 숨김).
+    public static func makeUploadProgressObservable(
+        imageRepository: ImageRepository
+    ) -> UploadProgressObservable {
+        if let router = imageRepository as? ImageRepositoryRouter {
+            return router
+        }
+        return NoOpUploadProgressObservable()
+    }
+
     /// 첫 사인인 후 home 진입 가능 시점까지 대기시키는 readiness gate. Firebase 미설정 시 즉시 통과.
     /// 세 Repository 가 모두 Router 구현이 아니면 (= 익명 단독) 게이트가 의미 없어 NoOp 반환.
     public static func makeFirstSignInReadinessCoordinator(

--- a/Projects/Core/SyncImpl/Tests/ImageUploadProgressStoreTests.swift
+++ b/Projects/Core/SyncImpl/Tests/ImageUploadProgressStoreTests.swift
@@ -342,6 +342,64 @@ final class ImageUploadProgressStoreTests: XCTestCase {
         XCTAssertEqual(progress(), UploadProgressSnapshot(completedImageCount: 1, totalImageCount: 2))
     }
 
+    // MARK: - target 영속화
+
+    func test_setProgressTarget_후_currentTarget_은_같은_목록을_반환한다() {
+        // given
+        let sut = makeSUT()
+        let infoA = makeImageInfo()
+        let infoB = makeImageInfo()
+
+        // when
+        sut.setProgressTarget([infoA, infoB])
+
+        // then
+        XCTAssertEqual(sut.currentTarget, [infoA, infoB])
+    }
+
+    func test_새_인스턴스에서도_영속화된_target_을_자동_로드한다() {
+        // given
+        let infoA = makeImageInfo()
+        let infoB = makeImageInfo()
+        let firstSUT = makeSUT()
+        firstSUT.setProgressTarget([infoA, infoB])
+
+        // when
+        let secondSUT = makeSUT()
+
+        // then
+        XCTAssertEqual(secondSUT.currentTarget, [infoA, infoB])
+    }
+
+    func test_clearProgressTarget_후에는_영속화된_target_도_삭제된다() {
+        // given
+        let info = makeImageInfo()
+        let firstSUT = makeSUT()
+        firstSUT.setProgressTarget([info])
+
+        // when
+        firstSUT.clearProgressTarget()
+        let secondSUT = makeSUT()
+
+        // then
+        XCTAssertTrue(secondSUT.currentTarget.isEmpty)
+    }
+
+    func test_모든_이미지_완료_시_영속화된_target_이_자동_삭제된다() {
+        // given
+        let info = makeImageInfo()
+        let firstSUT = makeSUT()
+        firstSUT.setProgressTarget([info])
+
+        // when: 원본·썸네일 모두 mark → 완료 감지 → 영속화 삭제
+        firstSUT.markUploaded(imageInfo: info, variant: .original)
+        firstSUT.markUploaded(imageInfo: info, variant: .thumbnail)
+        let secondSUT = makeSUT()
+
+        // then: 새 인스턴스도 target 비어 있음
+        XCTAssertTrue(secondSUT.currentTarget.isEmpty)
+    }
+
     // MARK: - 사용자 격리
 
     func test_다른_userID_의_store_는_상태가_분리된다() {

--- a/Projects/Core/SyncImpl/Tests/ImageUploadProgressStoreTests.swift
+++ b/Projects/Core/SyncImpl/Tests/ImageUploadProgressStoreTests.swift
@@ -1,13 +1,16 @@
+import Combine
 import XCTest
 import Domain
+import SyncInterface
 @testable import SyncImpl
 
-/// `ImageUploadProgressStore` 의 mark·조회·영속화·격리 동작을 검증.
+/// `ImageUploadProgressStore` 의 mark·조회·영속화·격리 + 진행상황 publisher 동작을 검증.
 /// 각 테스트는 UserDefaults suite 를 새로 만들어 다른 테스트와 격리.
 final class ImageUploadProgressStoreTests: XCTestCase {
 
     private var suiteName: String!
     private var userDefaults: UserDefaults!
+    private var cancellables: Set<AnyCancellable> = []
     private let userID = "test-user"
 
     override func setUp() {
@@ -17,6 +20,7 @@ final class ImageUploadProgressStoreTests: XCTestCase {
     }
 
     override func tearDown() {
+        cancellables.removeAll()
         userDefaults.removePersistentDomain(forName: suiteName)
         userDefaults = nil
         suiteName = nil
@@ -209,6 +213,133 @@ final class ImageUploadProgressStoreTests: XCTestCase {
         // then
         XCTAssertFalse(sut.isUploaded(imageInfo: info, variant: .original))
         XCTAssertFalse(sut.isUploaded(imageInfo: info, variant: .thumbnail))
+    }
+
+    // MARK: - progressPublisher
+
+    /// CurrentValueSubject 라 구독 시점에 현재값이 즉시 emit. 마지막 emit 값을 캡처해 반환.
+    private func captureProgress(of sut: ImageUploadProgressStore) -> () -> UploadProgressSnapshot? {
+        var lastEmitted: UploadProgressSnapshot?
+        sut.progressPublisher
+            .sink { lastEmitted = $0 }
+            .store(in: &cancellables)
+        return { lastEmitted }
+    }
+
+    func test_progressPublisher_초기값은_nil() {
+        // given
+        let sut = makeSUT()
+
+        // when
+        let progress = captureProgress(of: sut)
+
+        // then
+        XCTAssertNil(progress())
+    }
+
+    func test_setProgressTarget_빈_배열이면_nil_을_emit() {
+        // given
+        let sut = makeSUT()
+        let progress = captureProgress(of: sut)
+
+        // when
+        sut.setProgressTarget([])
+
+        // then
+        XCTAssertNil(progress())
+    }
+
+    func test_setProgressTarget_후_아무것도_mark_안되어있으면_completed_0_을_emit() {
+        // given
+        let sut = makeSUT()
+        let infoA = makeImageInfo()
+        let infoB = makeImageInfo()
+        let progress = captureProgress(of: sut)
+
+        // when
+        sut.setProgressTarget([infoA, infoB])
+
+        // then
+        XCTAssertEqual(progress(), UploadProgressSnapshot(completedImageCount: 0, totalImageCount: 2))
+    }
+
+    func test_원본만_mark_하면_completed_가_증가하지_않는다() {
+        // given: target 2 장
+        let sut = makeSUT()
+        let infoA = makeImageInfo()
+        let infoB = makeImageInfo()
+        sut.setProgressTarget([infoA, infoB])
+        let progress = captureProgress(of: sut)
+
+        // when: infoA 원본만 mark
+        sut.markUploaded(imageInfo: infoA, variant: .original)
+
+        // then: 썸네일 미완 → 한 장도 완료된 게 없음
+        XCTAssertEqual(progress(), UploadProgressSnapshot(completedImageCount: 0, totalImageCount: 2))
+    }
+
+    func test_한_이미지의_원본과_썸네일_둘다_mark_되어야_completed_가_증가한다() {
+        // given
+        let sut = makeSUT()
+        let infoA = makeImageInfo()
+        let infoB = makeImageInfo()
+        sut.setProgressTarget([infoA, infoB])
+        let progress = captureProgress(of: sut)
+
+        // when
+        sut.markUploaded(imageInfo: infoA, variant: .original)
+        sut.markUploaded(imageInfo: infoA, variant: .thumbnail)
+
+        // then
+        XCTAssertEqual(progress(), UploadProgressSnapshot(completedImageCount: 1, totalImageCount: 2))
+    }
+
+    func test_모든_이미지가_완료되면_nil_을_emit() {
+        // given
+        let sut = makeSUT()
+        let info = makeImageInfo()
+        sut.setProgressTarget([info])
+        let progress = captureProgress(of: sut)
+
+        // when
+        sut.markUploaded(imageInfo: info, variant: .original)
+        sut.markUploaded(imageInfo: info, variant: .thumbnail)
+
+        // then: 완료 시 hide 의미로 nil
+        XCTAssertNil(progress())
+    }
+
+    func test_clearProgressTarget_후에는_nil_을_emit() {
+        // given
+        let sut = makeSUT()
+        let info = makeImageInfo()
+        sut.setProgressTarget([info])
+        let progress = captureProgress(of: sut)
+        XCTAssertNotNil(progress())
+
+        // when
+        sut.clearProgressTarget()
+
+        // then
+        XCTAssertNil(progress())
+    }
+
+    func test_setProgressTarget_재호출_시_새_target_기준으로_재계산() {
+        // given: 첫 target 1장 + 그 장 완료
+        let sut = makeSUT()
+        let infoA = makeImageInfo()
+        sut.setProgressTarget([infoA])
+        sut.markUploaded(imageInfo: infoA, variant: .original)
+        sut.markUploaded(imageInfo: infoA, variant: .thumbnail)
+        let progress = captureProgress(of: sut)
+        XCTAssertNil(progress()) // 첫 target 기준 완료
+
+        // when: 새 target 으로 교체 (infoB 추가)
+        let infoB = makeImageInfo()
+        sut.setProgressTarget([infoA, infoB])
+
+        // then: infoB 미완 → 1 / 2
+        XCTAssertEqual(progress(), UploadProgressSnapshot(completedImageCount: 1, totalImageCount: 2))
     }
 
     // MARK: - 사용자 격리

--- a/Projects/Core/SyncInterface/Sources/UploadProgressObservable.swift
+++ b/Projects/Core/SyncInterface/Sources/UploadProgressObservable.swift
@@ -1,0 +1,13 @@
+//
+//  UploadProgressObservable.swift
+//  NoteCard
+//
+
+import Combine
+import Foundation
+
+/// 첫 sign-in 마이그레이션의 이미지 바이너리 업로드 진행 상황을 UI 가 관찰할 수 있게 노출.
+/// `nil` 은 표시할 진행이 없음 (idle / 완료 / sign-out) — UI 는 표시를 숨김.
+public protocol UploadProgressObservable: Sendable {
+    var imageUploadProgressPublisher: AnyPublisher<UploadProgressSnapshot?, Never> { get }
+}

--- a/Projects/Core/SyncInterface/Sources/UploadProgressSnapshot.swift
+++ b/Projects/Core/SyncInterface/Sources/UploadProgressSnapshot.swift
@@ -1,0 +1,20 @@
+//
+//  UploadProgressSnapshot.swift
+//  NoteCard
+//
+
+import Foundation
+
+/// 익명 → Firestore 첫 마이그레이션의 이미지 바이너리 업로드 진행 상황 스냅샷.
+/// "장 단위" — 한 이미지의 원본·썸네일이 모두 올라간 경우에만 `completedImageCount` 에 카운트.
+///
+/// UI 는 nil 일 때 표시를 숨기고, 값이 있을 때 "X장 / Y장" 형태로 보여준다.
+public struct UploadProgressSnapshot: Equatable, Sendable {
+    public let completedImageCount: Int
+    public let totalImageCount: Int
+
+    public init(completedImageCount: Int, totalImageCount: Int) {
+        self.completedImageCount = completedImageCount
+        self.totalImageCount = totalImageCount
+    }
+}

--- a/Projects/Domain/Sources/Models/MemoImageInfo.swift
+++ b/Projects/Domain/Sources/Models/MemoImageInfo.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Shared
 
-public struct MemoImageInfo: Hashable, Sendable {
+public struct MemoImageInfo: Hashable, Codable, Sendable {
     public let id: UUID
     public let thumbnailID: UUID
     public var temporaryOrderIndex: Int

--- a/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailView.swift
+++ b/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailView.swift
@@ -77,6 +77,8 @@ final class AccountDetailView: UIView {
 
     let syncStatusRow = AccountDetailView.makeInfoRow(title: L10n.Account.syncStatusLabel, value: L10n.Account.syncStatusComingSoon)
     let lastSyncedRow = AccountDetailView.makeInfoRow(title: L10n.Account.lastSyncedLabel, value: L10n.Account.lastSyncedNever)
+    /// 첫 sign-in 마이그레이션 진행 중에만 보이는 row. 평상시 hidden.
+    let imageUploadProgressRow = AccountDetailView.makeInfoRow(title: L10n.Account.imageUploadLabel, value: "")
 
     let syncRetryMessageLabel: UILabel = {
         let label = UILabel()
@@ -145,7 +147,8 @@ final class AccountDetailView: UIView {
         identityStack.spacing = 4
         identityStack.alignment = .center
 
-        let infoStack = UIStackView(arrangedSubviews: [syncStatusRow, lastSyncedRow])
+        imageUploadProgressRow.isHidden = true
+        let infoStack = UIStackView(arrangedSubviews: [syncStatusRow, lastSyncedRow, imageUploadProgressRow])
         infoStack.axis = .vertical
         infoStack.spacing = 8
         infoStack.alignment = .fill

--- a/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
+++ b/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
@@ -19,6 +19,7 @@ public final class AccountDetailViewController: UIViewController {
     private let syncStatusService: SyncStatusService
     private let readinessCoordinator: FirstSignInReadinessCoordinator
     private let signOutCoordinator: SignOutCoordinator
+    private let uploadProgressObservable: UploadProgressObservable
     private let readinessTimeout: TimeInterval
     private var cancellables = Set<AnyCancellable>()
     private var lastSyncedAt: Date?
@@ -38,6 +39,7 @@ public final class AccountDetailViewController: UIViewController {
         syncStatusService: SyncStatusService,
         readinessCoordinator: FirstSignInReadinessCoordinator,
         signOutCoordinator: SignOutCoordinator,
+        uploadProgressObservable: UploadProgressObservable,
         readinessTimeout: TimeInterval = 90
     ) {
         self.authService = authService
@@ -45,6 +47,7 @@ public final class AccountDetailViewController: UIViewController {
         self.syncStatusService = syncStatusService
         self.readinessCoordinator = readinessCoordinator
         self.signOutCoordinator = signOutCoordinator
+        self.uploadProgressObservable = uploadProgressObservable
         self.readinessTimeout = readinessTimeout
         super.init(nibName: nil, bundle: nil)
     }
@@ -98,6 +101,14 @@ public final class AccountDetailViewController: UIViewController {
             }
             .store(in: &cancellables)
 
+        // 첫 sign-in 마이그레이션 진행 중에만 row 가 보이고 "X장 / Y장" 갱신. snapshot 이 nil 이면 hide.
+        uploadProgressObservable.imageUploadProgressPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] snapshot in
+                self?.renderImageUploadProgress(snapshot)
+            }
+            .store(in: &cancellables)
+
         // RelativeDateTimeFormatter 결과 ("방금 전" → "1분 전" → ...) 를 시간이 흐름에 따라 갱신.
         // viewWillAppear / viewWillDisappear 와 별개로 30초 tick. 화면이 가려져 있어도 무해.
         lastSyncedRefreshTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
@@ -115,6 +126,20 @@ public final class AccountDetailViewController: UIViewController {
         case .synced:  text = L10n.Account.syncStatusSynced
         }
         rootView.updateRow(rootView.syncStatusRow, value: text)
+    }
+
+    private func renderImageUploadProgress(_ snapshot: UploadProgressSnapshot?) {
+        if let snapshot {
+            let text = String(
+                format: L10n.Account.imageUploadProgressFormat,
+                snapshot.completedImageCount,
+                snapshot.totalImageCount
+            )
+            rootView.updateRow(rootView.imageUploadProgressRow, value: text)
+            rootView.imageUploadProgressRow.isHidden = false
+        } else {
+            rootView.imageUploadProgressRow.isHidden = true
+        }
     }
 
     private func renderLastSyncedRelativeText() {

--- a/Projects/Feature/SettingsFeature/Sources/SettingsViewController.swift
+++ b/Projects/Feature/SettingsFeature/Sources/SettingsViewController.swift
@@ -23,6 +23,7 @@ public final class SettingsViewController: UITableViewController {
     private let syncStatusService: SyncStatusService
     private let readinessCoordinator: FirstSignInReadinessCoordinator
     private let signOutCoordinator: SignOutCoordinator
+    private let uploadProgressObservable: UploadProgressObservable
     private let makeTrashViewController: () -> UIViewController
 
     public init(
@@ -34,6 +35,7 @@ public final class SettingsViewController: UITableViewController {
         syncStatusService: SyncStatusService,
         readinessCoordinator: FirstSignInReadinessCoordinator,
         signOutCoordinator: SignOutCoordinator,
+        uploadProgressObservable: UploadProgressObservable,
         makeTrashViewController: @escaping () -> UIViewController
     ) {
         self.memoRepository = memoRepository
@@ -44,6 +46,7 @@ public final class SettingsViewController: UITableViewController {
         self.syncStatusService = syncStatusService
         self.readinessCoordinator = readinessCoordinator
         self.signOutCoordinator = signOutCoordinator
+        self.uploadProgressObservable = uploadProgressObservable
         self.makeTrashViewController = makeTrashViewController
         super.init(nibName: nil, bundle: nil)
     }
@@ -406,7 +409,8 @@ extension SettingsViewController {
                 accountDeletionService: accountDeletionService,
                 syncStatusService: syncStatusService,
                 readinessCoordinator: readinessCoordinator,
-                signOutCoordinator: signOutCoordinator
+                signOutCoordinator: signOutCoordinator,
+                uploadProgressObservable: uploadProgressObservable
             )
         case IndexPath(row: 0, section: 1):
             targetVC = ThemeColorPickingViewController()


### PR DESCRIPTION
## 배경
- 첫 sign-in 직후 익명 → Firestore 마이그레이션의 이미지 바이너리 업로드는 길게는 수십 초 ~ 수 분이 걸려, 사용자가 끝났는지 알기 어려웠음. 계정 상세 화면에 장 단위 진행 상황 ("3장 / 24장") 표시 추가.
- 개발 중 발견된 부작용 1: 재진입 시 분모가 부풀려지는 버그. 메타 마이그레이션이 끝난 상태에서 앱을 다시 켜면 Firestore 의 모든 메모 sub-collection 을 enumerate 해 분모를 다시 계산했고, sign-in 이후 새로 만든 이미지까지 포함되어 "9장 / 43장" 같은 잘못된 값이 나왔음.
- 개발 중 발견된 부작용 2: "이미지 업로드" 라벨이 generic 해서 일상적인 동기화로 오해될 수 있음.

## 변경사항
- 진행 상황 publisher 도입
  - `UploadProgressSnapshot` 신규: `completedImageCount`, `totalImageCount`.
  - `ImageUploadProgressStore` 에 `progressPublisher` / `setProgressTarget` / `clearProgressTarget` / `currentTarget` API.
  - 한 이미지의 원본·썸네일이 모두 mark 되어야 `completedImageCount` 가 1 증가 (장 단위).
  - 완료되거나 target 이 비어 있으면 nil 을 emit 해 UI 가 표시를 숨김.
- 마이그레이션 대상 영속화 (재진입 시 분모 부풀림 버그 수정)
  - `MemoImageInfo` 에 `Codable` conform.
  - `sync.imageMigrationTarget.<userID>` 키로 JSON 직렬화. init 시 자동 로드.
  - 모든 항목 완료 시 자동 삭제 → 다음 진입은 short-circuit.
  - Router 가 메타 완료 + 영속화 target 있으면 그 목록으로 바이너리 단계만 재개. 영속화가 없으면 마이그레이션 완료된 것으로 보고 short-circuit.
  - Firestore 전체 enumerate fallback (`enumerateAllImageInfosFromFirestore`) 제거 — 분모 부풀림의 근본 원인이었음.
- DI 와이어업
  - `UploadProgressObservable` protocol 신규 (`SyncInterface`) + NoOp + `SyncBootstrap` factory.
  - `ImageRepositoryRouter` 가 conform — 사용자별 store 의 publisher 를 forward subject 로 노출. sign-out 시 nil emit.
  - `AppEnvironment` → `MainTabBarController` → `SettingsViewController` → `AccountDetailViewController` 로 통과.
- AccountDetail UI
  - `imageUploadProgressRow` 신규. `infoStack` 마지막에 배치, 기본 hidden (StackView 자동 collapse).
  - publisher snapshot 이 value 면 "X장 / Y장" 으로 갱신 후 show, nil 이면 hide.
  - L10n 한·영: `imageUploadLabel` ("초기 이미지 업로드" / "Initial image upload"), `imageUploadProgressFormat` ("%1\$d장 / %2\$d장" / "%1\$d of %2\$d").
- 단위 테스트
  - `ImageUploadProgressStoreTests` 에 12 개 추가 — progress publisher 8 개 + target 영속화 4 개.

## 테스트 방법
- 익명 모드에서 메모 + 이미지 다수 추가 → sign-in → AccountDetail 진입 → "초기 이미지 업로드" row 가 "X장 / Y장" 으로 갱신되는지 확인. 업로드 진행에 따라 X 가 증가.
- 마이그레이션 진행 중 앱 강제 종료 → 다시 켜기 → AccountDetail 의 분모(Y) 가 처음과 동일하게 유지되는지 확인 (재진입 시 부풀려지지 않음). 업로드는 끊긴 지점부터 이어 받음.
- 모든 이미지 완료 → row 가 자동으로 사라지는지 확인. 그 뒤 앱을 다시 켜도 row 가 다시 안 보임.
- 단위 테스트 36 개 통과 확인.

## 리뷰 노트
- 이전 PR (#82) 에서 추가된 `enumerateAllImageInfosFromFirestore` 함수를 이번에 제거. 호출자 없음 확인.
- 마이그레이션 대상 영속화는 사용자 ID 별 키 분리. sign-out 시 `clearProgressTarget` 으로 함께 삭제.
- 백그라운드 동작은 여전히 스코프 밖. Foreground 또는 launch 시 자동 재개.

🤖 Generated with [Claude Code](https://claude.com/claude-code)