### PR TITLE
fix(ipad): actionSheet popover anchor 누락으로 인한 crash 수정

### DIFF
--- a/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
+++ b/NoteCard/Presentation/MemoView/MemoEditingToolbarView.swift
@@ -31,7 +31,9 @@ final class MemoEditingToolbarView: UIView {
 
     // MARK: - Callbacks
 
-    var onDeleteTapped: (() -> Void)?
+    /// 삭제 버튼 탭 시 호출. 인자는 popover anchor (iPad actionSheet) 용 source view —
+    /// 호출 측은 그 view 의 frame 을 기준으로 popoverPresentationController 를 설정하면 됨.
+    var onDeleteTapped: ((UIView) -> Void)?
 
     // MARK: - Subviews
 
@@ -163,7 +165,7 @@ final class MemoEditingToolbarView: UIView {
     }
 
     @objc private func deleteTapped() {
-        onDeleteTapped?()
+        onDeleteTapped?(deleteButton)
     }
 
     // MARK: - Public API

--- a/NoteCard/Presentation/MemoView/MemoViewController.swift
+++ b/NoteCard/Presentation/MemoView/MemoViewController.swift
@@ -280,8 +280,8 @@ private extension MemoViewController {
         }
         rootView.editingToolbar.configureMenu(menu)
         rootView.editingToolbar.setSelectedCount(0)
-        rootView.editingToolbar.onDeleteTapped = { [weak self] in
-            self?.deleteEverySelectedMemo()
+        rootView.editingToolbar.onDeleteTapped = { [weak self] sourceView in
+            self?.deleteEverySelectedMemo(sourceView: sourceView)
         }
     }
     
@@ -410,10 +410,10 @@ private extension MemoViewController {
         self.present(naviCon, animated: true)
     }
     
-    @objc func deleteEverySelectedMemo() {
+    func deleteEverySelectedMemo(sourceView: UIView) {
         guard self.smallCardCollectionView.isEditing else { return }
         guard let selectedIndexPaths = self.smallCardCollectionView.indexPathsForSelectedItems else { return }
-        
+
         let alertCon: UIAlertController
         if self.memoVCType == .trash {
             alertCon = UIAlertController(
@@ -421,6 +421,9 @@ private extension MemoViewController {
                 message: L10n.Common.actionCannotBeUndone,
                 preferredStyle: UIAlertController.Style.actionSheet
             )
+            // iPad 에서 actionSheet 는 popover 로 표시되므로 anchor 가 없으면 crash.
+            alertCon.popoverPresentationController?.sourceView = sourceView
+            alertCon.popoverPresentationController?.sourceRect = sourceView.bounds
         } else {
             alertCon = UIAlertController(
                 title: L10n.MemoView.deleteSelectedMemos,

--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -547,6 +547,12 @@ extension PopupCardViewController {
         let alertstyle: UIAlertController.Style = memo.isInTrash ? .actionSheet : .alert
         let alertCon = UIAlertController(title: title, message: message, preferredStyle: alertstyle)
         alertCon.view.tintColor = .currentTheme
+        if alertstyle == .actionSheet {
+            // iPad 에서 actionSheet 는 popover 로 표시되므로 anchor 가 없으면 crash.
+            // 메뉴를 띄운 ellipsisButton 자리에서 popover 가 나오게 anchor 지정.
+            alertCon.popoverPresentationController?.sourceView = rootView.ellipsisButton
+            alertCon.popoverPresentationController?.sourceRect = rootView.ellipsisButton.bounds
+        }
         
         let cancelAction = UIAlertAction(title: L10n.Common.cancel, style: .cancel)
         let deleteAction = UIAlertAction(title: L10n.Common.delete, style: .destructive) { [weak self] action in


### PR DESCRIPTION
## 배경
- iPad 에서 `UIAlertController(preferredStyle: .actionSheet)` 는 popover 로 표시되어 `sourceView` / `sourceRect` 또는 `barButtonItem` anchor 가 반드시 필요. 두 위치에서 anchor 누락으로 `present` 시 `NSGenericException` 으로 앱이 강제 종료됨.
- iPhone 에선 actionSheet 가 sheet 형태로 표시돼 anchor 가 무시되므로 증상이 안 보였음.
- 재현 시나리오
  - 휴지통 화면에서 메모 다중 선택 → 하단 editingToolbar 의 삭제 버튼 → crash.
  - 휴지통 메모를 popup card 에서 열어 ellipsisButton 메뉴의 "삭제" → 같은 종류 crash (잠재).

## 변경사항
- `MemoEditingToolbarView.onDeleteTapped` 클로저 시그니처에 `UIView` 인자 추가. 내부 `deleteTapped` 가 자신의 `deleteButton` 을 anchor 후보로 넘김.
- `MemoViewController.deleteEverySelectedMemo(sourceView:)` 로 시그니처 변경.
  - actionSheet (휴지통 다중 선택 삭제) 분기에서 `popoverPresentationController.sourceView` / `sourceRect` 설정.
  - `@objc` 제거 — selector 호출자 없음.
- `PopupCardViewController.askDeleting` 의 actionSheet (휴지통 메모 단일 삭제) 분기에서 `rootView.ellipsisButton` 을 popover anchor 로 지정.

## 테스트 방법
- iPad 시뮬레이터
  - 휴지통 화면 → 메모 다중 선택 → 하단 삭제 버튼 → "정말 삭제하시겠습니까?" actionSheet 가 deleteButton 옆에 popover 로 정상 표시.
  - 휴지통 메모를 popup card 에서 열어 우상단 ellipsisButton 메뉴 → "삭제" → actionSheet 가 ellipsisButton 옆에 popover 로 정상 표시.
- iPhone 시뮬레이터에서 같은 흐름이 회귀 없이 sheet 형태로 동작.

## 리뷰 노트
- `SettingsViewController.showDeleteAllAlert` (휴지통 비우기) 는 이미 `popoverPresentationController.sourceView = self.tableView` 가 지정되어 있어 변경 불필요. 코드 전수 grep 으로 actionSheet 사용처 3 곳 모두 확인.
- iPhone 회귀 영향 없음 — actionSheet 가 sheet 형태로 표시돼 anchor 가 무시됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)