### PR TITLE
feat(analytics): sign-in / sync-retry funnel + 익명 데이터 통계 로깅

### DIFF
--- a/NoteCard/Global/Application/AppDelegate.swift
+++ b/NoteCard/Global/Application/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 import Data
 import Domain
 import DesignSystem
@@ -18,6 +19,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     /// 앱 전체가 공유하는 의존성. 프로세스 수명 동안 하나만 존재한다.
     let environment = AppEnvironment()
+    /// AppDelegate 수명 동안 살아 있는 Combine 구독들. 현재는 인증 상태 → 분석 user_id
+    /// 동기화 한 건.
+    private var cancellables: Set<AnyCancellable> = []
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -62,7 +66,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if UserDefaults.standard.string(forKey: UserDefaultsKeys.themeColor.rawValue) == nil {
             UserDefaults.standard.set(ThemeColor.black.rawValue, forKey: UserDefaultsKeys.themeColor.rawValue)
         }
-        
+
+        // 인증 상태 ↔ 분석 user_id 동기화. sign-in 경로 (LoginVC / AccountDetail) 가 성공
+        // 시점에 setUserId 를 호출하지만, sign-out·force sign-out·sentinel 만료 등 어떤
+        // 경로로 사용자가 nil 이 되든 익명 상태로 되돌리도록 publisher 를 단일 진입점으로 사용.
+        let analytics = environment.analytics
+        environment.authService.authStatePublisher
+            .map(\.?.id)
+            .removeDuplicates()
+            .sink { userId in
+                analytics.setUserId(userId)
+            }
+            .store(in: &cancellables)
+
         return true
     }
     

--- a/NoteCard/Global/Application/AppDelegate.swift
+++ b/NoteCard/Global/Application/AppDelegate.swift
@@ -79,7 +79,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
             .store(in: &cancellables)
 
+        emitDailyAnonymousStatsIfNeeded(environment: environment)
+
         return true
+    }
+
+    /// 익명 사용자의 데이터 규모 분포를 보기 위해 하루에 최대 1 회 anonymous_data_stats 를
+    /// emit. 마지막 emit 이 같은 날(사용자 캘린더 기준) 이면 skip. sign-in 된 사용자는 sign-in
+    /// 경로에서 이미 1 회 emit 되므로 여기선 발화하지 않음.
+    private func emitDailyAnonymousStatsIfNeeded(environment: AppEnvironment) {
+        guard environment.authService.currentUser == nil else { return }
+        let lastKey = "analytics.lastAnonymousStatsEmittedAt"
+        let now = Date()
+        if let last = UserDefaults.standard.object(forKey: lastKey) as? Date,
+           Calendar.current.isDate(last, inSameDayAs: now) {
+            return
+        }
+        let counts = environment.anonymousDataCountsProvider()
+        environment.analytics.log(.anonymousDataStats(
+            memoCount: counts.memoCount,
+            trashedMemoCount: counts.trashedMemoCount,
+            categoryCount: counts.categoryCount,
+            imageCount: counts.imageCount
+        ))
+        UserDefaults.standard.set(now, forKey: lastKey)
     }
     
     // MARK: UISceneSession Lifecycle

--- a/NoteCard/Global/Application/AppEnvironment.swift
+++ b/NoteCard/Global/Application/AppEnvironment.swift
@@ -32,6 +32,8 @@ struct AppEnvironment {
     let signOutCoordinator: SignOutCoordinator
     let pendingUploadResumeTrigger: PendingUploadResumeTrigger
     let uploadProgressObservable: UploadProgressObservable
+    /// 익명 stack 의 entity 카운트 스냅샷을 즉시 반환. sign-in 시점·daily 통계 emit 에 사용.
+    let anonymousDataCountsProvider: @Sendable () -> AnonymousDataCounts
 
     let coreDataStack: CoreDataStack
 
@@ -111,6 +113,9 @@ struct AppEnvironment {
         self.uploadProgressObservable = SyncBootstrap.makeUploadProgressObservable(
             imageRepository: imageRepository
         )
+        self.anonymousDataCountsProvider = { [coreDataStack] in
+            AnonymousDataInspector.snapshotCounts(in: coreDataStack)
+        }
     }
 
     /// Crashlytics를 켜고(가능하면) Amplitude 기반 `Analytics`를 만든다.

--- a/NoteCard/Global/Application/SceneDelegate.swift
+++ b/NoteCard/Global/Application/SceneDelegate.swift
@@ -175,7 +175,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     private func makeLoginViewController(environment: AppEnvironment) -> LoginViewController {
         LoginViewController(
             authService: environment.authService,
-            readinessCoordinator: environment.firstSignInReadinessCoordinator
+            readinessCoordinator: environment.firstSignInReadinessCoordinator,
+            analytics: environment.analytics,
+            provideAnonymousCounts: environment.anonymousDataCountsProvider
         ) { [weak self] outcome in
             UserDefaults.standard.set(true, forKey: UserDefaultsKey.didShowSyncIntroduction.rawValue)
             switch outcome {

--- a/NoteCard/Presentation/TabBar/MainTabBarController.swift
+++ b/NoteCard/Presentation/TabBar/MainTabBarController.swift
@@ -107,6 +107,7 @@ class MainTabBarController: UITabBarController {
             readinessCoordinator: environment.firstSignInReadinessCoordinator,
             signOutCoordinator: environment.signOutCoordinator,
             uploadProgressObservable: environment.uploadProgressObservable,
+            provideAnonymousCounts: environment.anonymousDataCountsProvider,
             makeTrashViewController: { [environment] in
                 MemoViewController(memoVCType: .trash, environment: environment)
             }

--- a/Projects/Core/AnalyticsImpl/Sources/AmplitudeAnalytics.swift
+++ b/Projects/Core/AnalyticsImpl/Sources/AmplitudeAnalytics.swift
@@ -26,4 +26,10 @@ public final class AmplitudeAnalytics: Analytics, @unchecked Sendable {
     public func log(_ event: AnalyticsInterface.AnalyticsEvent) {
         amplitude.track(eventType: event.name, eventProperties: event.properties)
     }
+
+    public func setUserId(_ userId: String?) {
+        // Amplitude 는 nil 을 넘기면 anonymous user 로 전환되고, 같은 device_id 가
+        // 새 user_id 와 또는 anonymous 상태와 자동으로 연결된다 (identity merge).
+        amplitude.setUserId(userId: userId)
+    }
 }

--- a/Projects/Core/AnalyticsImpl/Sources/AnalyticsBootstrap.swift
+++ b/Projects/Core/AnalyticsImpl/Sources/AnalyticsBootstrap.swift
@@ -26,10 +26,15 @@ public enum AnalyticsBootstrap {
         #endif
     }
 
-    /// Amplitude 기반 `Analytics` 구현을 만든다.
+    /// Amplitude + Firebase Analytics 둘 다에 fan-out 하는 `Analytics` 구현을 만든다.
+    /// `FirebaseApp.configure()` 가 먼저 호출되어 있어야 Firebase 쪽 이벤트가 실제로 전송된다
+    /// (Configure 가 없으면 Firebase 쪽은 silently no-op).
     /// - Parameter amplitudeAPIKey: Amplitude 프로젝트 API Key.
     public static func makeAnalytics(amplitudeAPIKey: String) -> Analytics {
-        AmplitudeAnalytics(apiKey: amplitudeAPIKey)
+        CompositeAnalytics([
+            AmplitudeAnalytics(apiKey: amplitudeAPIKey),
+            FirebaseEventAnalytics(),
+        ])
     }
 
     /// 분석 비활성(테스트·프리뷰·키 부재) 시 사용할 no-op 구현.

--- a/Projects/Core/AnalyticsImpl/Sources/CompositeAnalytics.swift
+++ b/Projects/Core/AnalyticsImpl/Sources/CompositeAnalytics.swift
@@ -1,0 +1,28 @@
+import AnalyticsInterface
+import Foundation
+
+/// 여러 `Analytics` 구현체에 동일 호출을 fan-out 한다. 호출 측은 한 인스턴스만 들고 있어도
+/// Amplitude·Firebase Analytics 등 여러 dashboard 에 동시에 보낼 수 있다.
+///
+/// 순서 보장은 등록된 배열 순서. 한 구현체에서 에러가 발생해도 다른 구현체로의 전파는 보존
+/// 하기 위해 그냥 호출만 한다 (현 시점 구현체들은 throws 없음).
+public final class CompositeAnalytics: Analytics, @unchecked Sendable {
+
+    private let underlying: [Analytics]
+
+    public init(_ underlying: [Analytics]) {
+        self.underlying = underlying
+    }
+
+    public func log(_ event: AnalyticsEvent) {
+        for analytics in underlying {
+            analytics.log(event)
+        }
+    }
+
+    public func setUserId(_ userId: String?) {
+        for analytics in underlying {
+            analytics.setUserId(userId)
+        }
+    }
+}

--- a/Projects/Core/AnalyticsImpl/Sources/FirebaseEventAnalytics.swift
+++ b/Projects/Core/AnalyticsImpl/Sources/FirebaseEventAnalytics.swift
@@ -1,0 +1,22 @@
+import AnalyticsInterface
+import FirebaseAnalytics
+import Foundation
+
+/// Firebase Analytics SDK 를 감싼 `Analytics` 구현. Amplitude 와 함께 `CompositeAnalytics`
+/// 로 묶여 동일 이벤트가 두 dashboard 모두에 도착하도록 한다.
+///
+/// `FirebaseApp.configure()` 가 먼저 호출되어 있어야 한다 (AnalyticsBootstrap.startCrashReporting).
+/// Configure 가 안 되어 있으면 `Analytics.logEvent` 가 내부적으로 no-op 처리된다.
+public final class FirebaseEventAnalytics: AnalyticsInterface.Analytics, @unchecked Sendable {
+
+    public init() {}
+
+    // FirebaseAnalytics 모듈에도 `Analytics` 타입이 있어 모듈명으로 한정한다.
+    public func log(_ event: AnalyticsInterface.AnalyticsEvent) {
+        FirebaseAnalytics.Analytics.logEvent(event.name, parameters: event.properties)
+    }
+
+    public func setUserId(_ userId: String?) {
+        FirebaseAnalytics.Analytics.setUserID(userId)
+    }
+}

--- a/Projects/Core/AnalyticsImpl/Sources/NoOpAnalytics.swift
+++ b/Projects/Core/AnalyticsImpl/Sources/NoOpAnalytics.swift
@@ -11,4 +11,8 @@ public final class NoOpAnalytics: Analytics, @unchecked Sendable {
     public func log(_ event: AnalyticsEvent) {
         // 이벤트를 의도적으로 버린다.
     }
+
+    public func setUserId(_ userId: String?) {
+        // 의도적으로 무시.
+    }
 }

--- a/Projects/Core/AnalyticsInterface/Sources/Analytics.swift
+++ b/Projects/Core/AnalyticsInterface/Sources/Analytics.swift
@@ -1,10 +1,15 @@
 import Foundation
 
-/// 외부 분석 SDK(예: Sentry, Crashlytics, Amplitude) 통합 지점을 추상화하는 인터페이스.
+/// 외부 분석 SDK(예: Amplitude, Firebase Analytics) 통합 지점을 추상화하는 인터페이스.
 /// 구현체는 별도 모듈(AnalyticsImpl)에 두고, App composition root에서만 인스턴스를
 /// 만들어 의존 주입한다.
 public protocol Analytics: AnyObject, Sendable {
     func log(_ event: AnalyticsEvent)
+
+    /// 사용자 식별자 설정. sign-in 시점에 Firebase UID 를 넘기면 그 이후 이벤트가 같은
+    /// user_id 로 묶이고, 익명 시기의 device_id 와도 identity merge 가능. sign-out 시
+    /// `nil` 을 넘겨 익명 사용자로 되돌린다.
+    func setUserId(_ userId: String?)
 }
 
 public struct AnalyticsEvent: Sendable, Hashable {

--- a/Projects/Core/AnalyticsInterface/Sources/AnalyticsEvent+NoteCard.swift
+++ b/Projects/Core/AnalyticsInterface/Sources/AnalyticsEvent+NoteCard.swift
@@ -59,4 +59,96 @@ extension AnalyticsEvent {
             "has_title": String(hasTitle),
         ]
     }
+
+    // MARK: - Sign-in funnel
+
+    /// Apple Sign-in 을 시도한 진입 화면.
+    public enum SignInSource: String {
+        case loginScreen = "login_screen"
+        case accountDetail = "account_detail"
+    }
+
+    /// Sign-in 시도의 최종 결과.
+    public enum SignInOutcome: String {
+        case success
+        /// Apple 시트에서 사용자가 취소.
+        case cancelled
+        /// Apple 또는 Firebase Auth 단계에서 실패 (`AuthError`).
+        case authError = "auth_error"
+        /// 인증은 끝났으나 readiness gate 가 timeout.
+        case readinessTimeout = "readiness_timeout"
+        case unknownError = "unknown_error"
+    }
+
+    /// 사용자가 Apple Sign-in 버튼을 탭한 시점.
+    public static func signInStarted(source: SignInSource) -> AnalyticsEvent {
+        AnalyticsEvent(name: "sign_in_started", properties: ["source": source.rawValue])
+    }
+
+    /// Sign-in 흐름이 끝났을 때 (성공·취소·각종 실패 포함).
+    public static func signInOutcome(
+        source: SignInSource,
+        outcome: SignInOutcome,
+        durationMs: Int
+    ) -> AnalyticsEvent {
+        AnalyticsEvent(
+            name: "sign_in_outcome",
+            properties: [
+                "source": source.rawValue,
+                "outcome": outcome.rawValue,
+                "duration_ms": String(durationMs),
+            ]
+        )
+    }
+
+    /// 로그인 화면에서 사용자가 "그냥 사용" 을 확정한 시점.
+    public static func signInSkipped() -> AnalyticsEvent {
+        AnalyticsEvent(name: "sign_in_skipped")
+    }
+
+    // MARK: - Sync retry funnel
+
+    /// AccountDetail 의 "동기화 재시도" 버튼 탭 결과.
+    public enum SyncRetryOutcome: String {
+        case success
+        case readinessTimeout = "readiness_timeout"
+        case unknownError = "unknown_error"
+    }
+
+    /// 사용자가 AccountDetail 의 "동기화 재시도" 버튼을 탭한 시점.
+    public static func syncRetryTapped() -> AnalyticsEvent {
+        AnalyticsEvent(name: "sync_retry_tapped")
+    }
+
+    /// 동기화 재시도 흐름이 끝났을 때.
+    public static func syncRetryOutcome(outcome: SyncRetryOutcome, durationMs: Int) -> AnalyticsEvent {
+        AnalyticsEvent(
+            name: "sync_retry_outcome",
+            properties: [
+                "outcome": outcome.rawValue,
+                "duration_ms": String(durationMs),
+            ]
+        )
+    }
+
+    // MARK: - 익명 데이터 통계
+
+    /// 익명 사용자의 데이터 규모. sign-in 시점 또는 daily launch 시 emit.
+    /// 메모 컨텐츠나 이미지 파일은 절대 수집하지 않고 카운트만.
+    public static func anonymousDataStats(
+        memoCount: Int,
+        trashedMemoCount: Int,
+        categoryCount: Int,
+        imageCount: Int
+    ) -> AnalyticsEvent {
+        AnalyticsEvent(
+            name: "anonymous_data_stats",
+            properties: [
+                "memo_count": String(memoCount),
+                "trashed_memo_count": String(trashedMemoCount),
+                "category_count": String(categoryCount),
+                "image_count": String(imageCount),
+            ]
+        )
+    }
 }

--- a/Projects/Data/Sources/CoreData/AnonymousDataInspector.swift
+++ b/Projects/Data/Sources/CoreData/AnonymousDataInspector.swift
@@ -4,6 +4,7 @@
 //
 
 import CoreData
+import Domain
 import Foundation
 
 /// 현재 stack(주로 익명 stack)의 데이터 규모·존재 여부를 동기로 확인하는 진단 helper.
@@ -66,17 +67,3 @@ public enum AnonymousDataInspector {
     }
 }
 
-/// `AnonymousDataInspector.snapshotCounts` 결과. 분석 통계에 그대로 실어 보낸다.
-public struct AnonymousDataCounts: Sendable, Equatable {
-    public let memoCount: Int
-    public let trashedMemoCount: Int
-    public let categoryCount: Int
-    public let imageCount: Int
-
-    public init(memoCount: Int, trashedMemoCount: Int, categoryCount: Int, imageCount: Int) {
-        self.memoCount = memoCount
-        self.trashedMemoCount = trashedMemoCount
-        self.categoryCount = categoryCount
-        self.imageCount = imageCount
-    }
-}

--- a/Projects/Data/Sources/CoreData/AnonymousDataInspector.swift
+++ b/Projects/Data/Sources/CoreData/AnonymousDataInspector.swift
@@ -6,10 +6,11 @@
 import CoreData
 import Foundation
 
-/// 현재 stack(주로 익명 stack)에 사용자 데이터가 존재하는지 동기로 확인하는 진단 helper.
+/// 현재 stack(주로 익명 stack)의 데이터 규모·존재 여부를 동기로 확인하는 진단 helper.
 ///
-/// SceneDelegate가 신규/기존 사용자를 분기할 때 사용. async API 없이 즉시 결과가 필요한
-/// composition-root 시점의 한정된 용도. 일반 데이터 조회는 `MemoRepository`를 거친다.
+/// SceneDelegate 의 신규/기존 사용자 분기와 분석 통계 (`anonymous_data_stats`) 가 주요 용도.
+/// async API 없이 즉시 결과가 필요한 composition-root / 짧은 분석 호출에 한정.
+/// 일반 데이터 조회는 `MemoRepository` 를 거친다.
 public enum AnonymousDataInspector {
 
     /// stack에 메모 또는 카테고리가 1개 이상 존재하는지 반환. 에러 발생 시 안전하게 `false`.
@@ -31,5 +32,51 @@ public enum AnonymousDataInspector {
             has = ((try? context.count(for: categoryRequest)) ?? 0) > 0
         }
         return has
+    }
+
+    /// stack 의 entity 별 row 수를 한 번의 perform 블록에서 모아 반환. 에러 발생 시 해당
+    /// 항목만 0 으로 안전 처리. 분석 통계에 보낼 익명 데이터 규모 측정 등에 사용.
+    public static func snapshotCounts(in stack: CoreDataStack) -> AnonymousDataCounts {
+        let context = stack.backgroundContext
+        var memoCount = 0
+        var trashedMemoCount = 0
+        var categoryCount = 0
+        var imageCount = 0
+        context.performAndWait {
+            let activeRequest = MemoEntity.fetchRequest()
+            activeRequest.predicate = NSPredicate(format: "isInTrash == false")
+            memoCount = (try? context.count(for: activeRequest)) ?? 0
+
+            let trashedRequest = MemoEntity.fetchRequest()
+            trashedRequest.predicate = NSPredicate(format: "isInTrash == true")
+            trashedMemoCount = (try? context.count(for: trashedRequest)) ?? 0
+
+            let categoryRequest = CategoryEntity.fetchRequest()
+            categoryCount = (try? context.count(for: categoryRequest)) ?? 0
+
+            let imageRequest = ImageEntity.fetchRequest()
+            imageCount = (try? context.count(for: imageRequest)) ?? 0
+        }
+        return AnonymousDataCounts(
+            memoCount: memoCount,
+            trashedMemoCount: trashedMemoCount,
+            categoryCount: categoryCount,
+            imageCount: imageCount
+        )
+    }
+}
+
+/// `AnonymousDataInspector.snapshotCounts` 결과. 분석 통계에 그대로 실어 보낸다.
+public struct AnonymousDataCounts: Sendable, Equatable {
+    public let memoCount: Int
+    public let trashedMemoCount: Int
+    public let categoryCount: Int
+    public let imageCount: Int
+
+    public init(memoCount: Int, trashedMemoCount: Int, categoryCount: Int, imageCount: Int) {
+        self.memoCount = memoCount
+        self.trashedMemoCount = trashedMemoCount
+        self.categoryCount = categoryCount
+        self.imageCount = imageCount
     }
 }

--- a/Projects/Data/Tests/AnonymousDataInspectorTests.swift
+++ b/Projects/Data/Tests/AnonymousDataInspectorTests.swift
@@ -1,0 +1,132 @@
+import CoreData
+import XCTest
+import Domain
+@testable import Data
+
+/// `AnonymousDataInspector.snapshotCounts` 의 entity 별 카운트 정확성을 검증.
+/// 매 테스트마다 inMemory stack 으로 격리.
+final class AnonymousDataInspectorTests: XCTestCase {
+
+    private var stack: CoreDataStack!
+    private var memoRepository: MemoRepositoryImpl!
+    private var categoryRepository: CategoryRepositoryImpl!
+
+    override func setUp() {
+        super.setUp()
+        stack = CoreDataStack(inMemory: true)
+        memoRepository = MemoRepositoryImpl(stack: stack)
+        categoryRepository = CategoryRepositoryImpl(stack: stack)
+    }
+
+    override func tearDown() {
+        memoRepository = nil
+        categoryRepository = nil
+        stack = nil
+        super.tearDown()
+    }
+
+    // MARK: - 빈 stack
+
+    func test_빈_stack_은_모든_카운트가_0() {
+        // when
+        let counts = AnonymousDataInspector.snapshotCounts(in: stack)
+
+        // then
+        XCTAssertEqual(counts.memoCount, 0)
+        XCTAssertEqual(counts.trashedMemoCount, 0)
+        XCTAssertEqual(counts.categoryCount, 0)
+        XCTAssertEqual(counts.imageCount, 0)
+    }
+
+    // MARK: - 메모 / 휴지통 분리
+
+    func test_활성_메모만_있으면_memoCount_만_증가() async throws {
+        // given
+        _ = try await memoRepository.createNewMemo()
+        _ = try await memoRepository.createNewMemo()
+
+        // when
+        let counts = AnonymousDataInspector.snapshotCounts(in: stack)
+
+        // then
+        XCTAssertEqual(counts.memoCount, 2)
+        XCTAssertEqual(counts.trashedMemoCount, 0)
+    }
+
+    func test_휴지통으로_옮긴_메모는_trashedMemoCount_에_잡힌다() async throws {
+        // given: 3 장 중 1 장 휴지통으로
+        let memo1 = try await memoRepository.createNewMemo()
+        _ = try await memoRepository.createNewMemo()
+        _ = try await memoRepository.createNewMemo()
+        try await memoRepository.moveToTrash(memo1)
+
+        // when
+        let counts = AnonymousDataInspector.snapshotCounts(in: stack)
+
+        // then
+        XCTAssertEqual(counts.memoCount, 2)
+        XCTAssertEqual(counts.trashedMemoCount, 1)
+    }
+
+    // MARK: - 카테고리
+
+    func test_카테고리_생성_시_categoryCount_증가() async throws {
+        // given
+        try await categoryRepository.create(name: "업무")
+        try await categoryRepository.create(name: "개인")
+
+        // when
+        let counts = AnonymousDataInspector.snapshotCounts(in: stack)
+
+        // then
+        XCTAssertEqual(counts.categoryCount, 2)
+    }
+
+    // MARK: - 이미지
+
+    func test_이미지_entity_는_imageCount_에_잡힌다() async throws {
+        // given: 메모 + 그 메모에 ImageEntity 직접 부착 (Picker 없이 raw entity 시드)
+        let memo = try await memoRepository.createNewMemo()
+        try seedImageEntities(memoID: memo.memoID, count: 5)
+
+        // when
+        let counts = AnonymousDataInspector.snapshotCounts(in: stack)
+
+        // then
+        XCTAssertEqual(counts.memoCount, 1)
+        XCTAssertEqual(counts.imageCount, 5)
+    }
+
+    // MARK: - 헬퍼
+
+    /// 메모에 raw ImageEntity 를 N 개 부착. PHPicker 흐름을 거치지 않고도 카운트 검증 가능.
+    private func seedImageEntities(memoID: UUID, count: Int) throws {
+        let context = stack.backgroundContext
+        var thrown: Error?
+        context.performAndWait {
+            let request = MemoEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "memoID == %@", memoID as CVarArg)
+            do {
+                guard let memoEntity = try context.fetch(request).first else {
+                    thrown = NSError(domain: "test", code: 1)
+                    return
+                }
+                for index in 0..<count {
+                    let image = ImageEntity(context: context)
+                    image.uuid = UUID()
+                    image.thumbnailUUID = UUID()
+                    image.orderIndex = Int64(index)
+                    image.temporaryOrderIndex = Int64(index)
+                    image.isTemporaryAppended = false
+                    image.isTemporaryDeleted = false
+                    image.fileExtension = "jpeg"
+                    image.memo = memoEntity
+                }
+                try context.save()
+            } catch {
+                thrown = error
+            }
+        }
+        if let thrown { throw thrown }
+    }
+}

--- a/Projects/Domain/Sources/Models/AnonymousDataCounts.swift
+++ b/Projects/Domain/Sources/Models/AnonymousDataCounts.swift
@@ -1,0 +1,23 @@
+//
+//  AnonymousDataCounts.swift
+//  NoteCard
+//
+
+import Foundation
+
+/// 익명 stack 의 entity 별 row 수 스냅샷. 분석 이벤트 `anonymous_data_stats` 와
+/// `AnonymousDataInspector.snapshotCounts` 가 공통으로 사용. 메모 컨텐츠·이미지 파일은
+/// 절대 수집하지 않고 카운트만.
+public struct AnonymousDataCounts: Sendable, Equatable {
+    public let memoCount: Int
+    public let trashedMemoCount: Int
+    public let categoryCount: Int
+    public let imageCount: Int
+
+    public init(memoCount: Int, trashedMemoCount: Int, categoryCount: Int, imageCount: Int) {
+        self.memoCount = memoCount
+        self.trashedMemoCount = trashedMemoCount
+        self.categoryCount = categoryCount
+        self.imageCount = imageCount
+    }
+}

--- a/Projects/Feature/LoginFeature/Sources/LoginViewController.swift
+++ b/Projects/Feature/LoginFeature/Sources/LoginViewController.swift
@@ -3,7 +3,9 @@
 //  NoteCard
 //
 
+import AnalyticsInterface
 import Combine
+import Domain
 import Shared
 import SyncInterface
 import UIKit
@@ -23,6 +25,8 @@ public final class LoginViewController: UIViewController {
     private let authService: AuthService
     private let readinessCoordinator: FirstSignInReadinessCoordinator
     private let readinessTimeout: TimeInterval
+    private let analytics: Analytics
+    private let provideAnonymousCounts: @Sendable () -> AnonymousDataCounts
     private let onCompletion: (Outcome) -> Void
 
     private var cancellables = Set<AnyCancellable>()
@@ -34,11 +38,15 @@ public final class LoginViewController: UIViewController {
     public init(
         authService: AuthService,
         readinessCoordinator: FirstSignInReadinessCoordinator,
+        analytics: Analytics,
+        provideAnonymousCounts: @escaping @Sendable () -> AnonymousDataCounts,
         readinessTimeout: TimeInterval = 90,
         onCompletion: @escaping (Outcome) -> Void
     ) {
         self.authService = authService
         self.readinessCoordinator = readinessCoordinator
+        self.analytics = analytics
+        self.provideAnonymousCounts = provideAnonymousCounts
         self.readinessTimeout = readinessTimeout
         self.onCompletion = onCompletion
         super.init(nibName: nil, bundle: nil)
@@ -67,26 +75,46 @@ public final class LoginViewController: UIViewController {
         rootView.errorLabel.text = nil
         setLoading(true)
         readinessCoordinator.reportSigningIn()
+        analytics.log(.signInStarted(source: .loginScreen))
+        let counts = provideAnonymousCounts()
+        analytics.log(.anonymousDataStats(
+            memoCount: counts.memoCount,
+            trashedMemoCount: counts.trashedMemoCount,
+            categoryCount: counts.categoryCount,
+            imageCount: counts.imageCount
+        ))
+        let startedAt = Date()
         Task { [weak self] in
             guard let self else { return }
+            let logOutcome: (AnalyticsEvent.SignInOutcome) -> Void = { outcome in
+                let durationMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+                self.analytics.log(.signInOutcome(source: .loginScreen, outcome: outcome, durationMs: durationMs))
+            }
             do {
                 let user = try await self.authService.signInWithApple()
                 try await self.readinessCoordinator.awaitReady(userID: user.id, timeout: self.readinessTimeout)
+                self.analytics.setUserId(user.id)
+                logOutcome(.success)
                 await MainActor.run {
                     self.setLoading(false)
                     self.onCompletion(.signedIn)
                 }
             } catch let error as AuthError {
+                let outcome: AnalyticsEvent.SignInOutcome
+                if case .cancelled = error { outcome = .cancelled } else { outcome = .authError }
+                logOutcome(outcome)
                 await MainActor.run {
                     self.setLoading(false)
                     self.present(error: error)
                 }
             } catch is SignInReadinessError {
+                logOutcome(.readinessTimeout)
                 await MainActor.run {
                     self.setLoading(false)
                     self.rootView.errorLabel.text = L10n.Login.syncTimeoutError
                 }
             } catch {
+                logOutcome(.unknownError)
                 await MainActor.run {
                     self.setLoading(false)
                     self.rootView.errorLabel.text = L10n.Sync.Auth.unknown
@@ -111,6 +139,7 @@ public final class LoginViewController: UIViewController {
     /// readiness gate 가 실패한 뒤 사용자가 skip 을 누른 경우, Firebase 측은 sign-in 된 상태가 잔존.
     /// UI 와 인증 상태를 일치시키기 위해 sign-out 후 .skipped emit.
     private func proceedWithSkip() {
+        analytics.log(.signInSkipped())
         if authService.currentUser == nil {
             onCompletion(.skipped)
             return

--- a/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
+++ b/Projects/Feature/SettingsFeature/Sources/AccountDetailView/AccountDetailViewController.swift
@@ -4,8 +4,10 @@
 //
 
 import AccountDeletionFeature
+import AnalyticsInterface
 import AuthenticationServices
 import Combine
+import Domain
 import Shared
 import SyncInterface
 import UIKit
@@ -20,6 +22,8 @@ public final class AccountDetailViewController: UIViewController {
     private let readinessCoordinator: FirstSignInReadinessCoordinator
     private let signOutCoordinator: SignOutCoordinator
     private let uploadProgressObservable: UploadProgressObservable
+    private let analytics: Analytics
+    private let provideAnonymousCounts: @Sendable () -> AnonymousDataCounts
     private let readinessTimeout: TimeInterval
     private var cancellables = Set<AnyCancellable>()
     private var lastSyncedAt: Date?
@@ -40,6 +44,8 @@ public final class AccountDetailViewController: UIViewController {
         readinessCoordinator: FirstSignInReadinessCoordinator,
         signOutCoordinator: SignOutCoordinator,
         uploadProgressObservable: UploadProgressObservable,
+        analytics: Analytics,
+        provideAnonymousCounts: @escaping @Sendable () -> AnonymousDataCounts,
         readinessTimeout: TimeInterval = 90
     ) {
         self.authService = authService
@@ -48,6 +54,8 @@ public final class AccountDetailViewController: UIViewController {
         self.readinessCoordinator = readinessCoordinator
         self.signOutCoordinator = signOutCoordinator
         self.uploadProgressObservable = uploadProgressObservable
+        self.analytics = analytics
+        self.provideAnonymousCounts = provideAnonymousCounts
         self.readinessTimeout = readinessTimeout
         super.init(nibName: nil, bundle: nil)
     }
@@ -181,18 +189,38 @@ public final class AccountDetailViewController: UIViewController {
     @objc private func signInTapped() {
         setLoading(true)
         readinessCoordinator.reportSigningIn()
+        analytics.log(.signInStarted(source: .accountDetail))
+        let counts = provideAnonymousCounts()
+        analytics.log(.anonymousDataStats(
+            memoCount: counts.memoCount,
+            trashedMemoCount: counts.trashedMemoCount,
+            categoryCount: counts.categoryCount,
+            imageCount: counts.imageCount
+        ))
+        let startedAt = Date()
         Task { [weak self] in
             guard let self else { return }
             defer { Task { @MainActor in self.setLoading(false) } }
+            let logOutcome: (AnalyticsEvent.SignInOutcome) -> Void = { outcome in
+                let durationMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+                self.analytics.log(.signInOutcome(source: .accountDetail, outcome: outcome, durationMs: durationMs))
+            }
             do {
                 let user = try await self.authService.signInWithApple()
                 try await self.readinessCoordinator.awaitReady(userID: user.id, timeout: self.readinessTimeout)
+                self.analytics.setUserId(user.id)
+                logOutcome(.success)
                 // 성공 시 authStatePublisher가 새 user를 emit → SceneDelegate.observeAuthStateChanges 가 home 으로 전환
             } catch let error as AuthError {
+                let outcome: AnalyticsEvent.SignInOutcome
+                if case .cancelled = error { outcome = .cancelled } else { outcome = .authError }
+                logOutcome(outcome)
                 await MainActor.run { self.presentInline(error: error) }
             } catch is SignInReadinessError {
+                logOutcome(.readinessTimeout)
                 await MainActor.run { self.showAlert(title: L10n.Login.syncTimeoutError) }
             } catch {
+                logOutcome(.unknownError)
                 await MainActor.run { self.showAlert(title: L10n.Sync.Auth.unknown) }
             }
         }
@@ -219,18 +247,27 @@ public final class AccountDetailViewController: UIViewController {
     @objc private func syncRetryTapped() {
         guard let userID = authService.currentUser?.id else { return }
         setLoading(true)
+        analytics.log(.syncRetryTapped())
+        let startedAt = Date()
         Task { [weak self] in
             guard let self else { return }
             defer { Task { @MainActor in self.setLoading(false) } }
+            let logOutcome: (AnalyticsEvent.SyncRetryOutcome) -> Void = { outcome in
+                let durationMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+                self.analytics.log(.syncRetryOutcome(outcome: outcome, durationMs: durationMs))
+            }
             do {
                 try await self.readinessCoordinator.retryReady(userID: userID, timeout: self.readinessTimeout)
+                logOutcome(.success)
                 await MainActor.run {
                     self.rootView.syncRetryContainer.isHidden = true
                     self.showAlert(title: L10n.Account.syncRetrySuccessMessage)
                 }
             } catch is SignInReadinessError {
+                logOutcome(.readinessTimeout)
                 await MainActor.run { self.showAlert(title: L10n.Login.syncTimeoutError) }
             } catch {
+                logOutcome(.unknownError)
                 await MainActor.run { self.showAlert(title: L10n.Sync.Auth.unknown) }
             }
         }

--- a/Projects/Feature/SettingsFeature/Sources/SettingsViewController.swift
+++ b/Projects/Feature/SettingsFeature/Sources/SettingsViewController.swift
@@ -24,6 +24,7 @@ public final class SettingsViewController: UITableViewController {
     private let readinessCoordinator: FirstSignInReadinessCoordinator
     private let signOutCoordinator: SignOutCoordinator
     private let uploadProgressObservable: UploadProgressObservable
+    private let provideAnonymousCounts: @Sendable () -> AnonymousDataCounts
     private let makeTrashViewController: () -> UIViewController
 
     public init(
@@ -36,6 +37,7 @@ public final class SettingsViewController: UITableViewController {
         readinessCoordinator: FirstSignInReadinessCoordinator,
         signOutCoordinator: SignOutCoordinator,
         uploadProgressObservable: UploadProgressObservable,
+        provideAnonymousCounts: @escaping @Sendable () -> AnonymousDataCounts,
         makeTrashViewController: @escaping () -> UIViewController
     ) {
         self.memoRepository = memoRepository
@@ -47,6 +49,7 @@ public final class SettingsViewController: UITableViewController {
         self.readinessCoordinator = readinessCoordinator
         self.signOutCoordinator = signOutCoordinator
         self.uploadProgressObservable = uploadProgressObservable
+        self.provideAnonymousCounts = provideAnonymousCounts
         self.makeTrashViewController = makeTrashViewController
         super.init(nibName: nil, bundle: nil)
     }
@@ -410,7 +413,9 @@ extension SettingsViewController {
                 syncStatusService: syncStatusService,
                 readinessCoordinator: readinessCoordinator,
                 signOutCoordinator: signOutCoordinator,
-                uploadProgressObservable: uploadProgressObservable
+                uploadProgressObservable: uploadProgressObservable,
+                analytics: analytics,
+                provideAnonymousCounts: provideAnonymousCounts
             )
         case IndexPath(row: 0, section: 1):
             targetVC = ThemeColorPickingViewController()


### PR DESCRIPTION
## 배경
- 사용자들이 동기화에 얼마나 진입하는지, 어느 단계에서 이탈하는지 분석 dashboard 에서 추적할 수 없었음. Apple Sign-in 흐름 (LoginScreen / AccountDetail 두 진입점) + 동기화 재시도 funnel 의 단계별 이벤트 + 익명 데이터 규모 통계를 추가.
- 메모 컨텐츠나 이미지 파일은 절대 수집하지 않고, 카운트·enum·duration 같은 메타데이터만.

## 변경사항
- Analytics 인프라 fan-out 확장
  - `Analytics` protocol 에 `setUserId(_:)` 추가. NoOp / Amplitude / Firebase 구현체 모두 conform.
  - `FirebaseEventAnalytics` 신규 — FirebaseAnalytics SDK 의 `logEvent` / `setUserID` 를 wrap.
  - `CompositeAnalytics` 신규 — 등록된 Analytics 배열에 fan-out.
  - `AnalyticsBootstrap.makeAnalytics` 가 Amplitude + Firebase Analytics 를 Composite 로 묶어 반환.
- 익명 데이터 카운트 측정 API
  - `AnonymousDataCounts` struct (Domain) — 활성메모 / 휴지통메모 / 카테고리 / 이미지 4 카운트.
  - `AnonymousDataInspector.snapshotCounts(in:)` — `NSFetchRequest.count` 4 회를 한 perform 블록에서 모아 반환.
  - 단위 테스트 5 개.
- AnalyticsEvent 카탈로그 7 종 추가
  - `sign_in_started` (source: login_screen / account_detail)
  - `sign_in_outcome` (source, outcome: success / cancelled / auth_error / readiness_timeout / unknown_error, duration_ms)
  - `sign_in_skipped`
  - `sync_retry_tapped`
  - `sync_retry_outcome` (outcome: success / readiness_timeout / unknown_error, duration_ms)
  - `anonymous_data_stats` (4 카운트)
- 호출 사이트
  - `LoginViewController.signInTapped`: 진입 시 `sign_in_started` + `anonymous_data_stats`. duration 측정 후 분기마다 `sign_in_outcome`. 성공 시 `setUserId(user.id)`. `proceedWithSkip` 시 `sign_in_skipped`.
  - `AccountDetailViewController.signInTapped`: 같은 패턴 (source: account_detail).
  - `AccountDetailViewController.syncRetryTapped`: `sync_retry_tapped` + 결과 `sync_retry_outcome`.
  - `AppDelegate.didFinishLaunching`: `authStatePublisher` 구독으로 인증 상태가 nil 로 바뀌면 `analytics.setUserId(nil)` 자동 리셋 (force sign-out 등 어떤 경로든 cover).
  - `AppDelegate.didFinishLaunching`: 익명 사용자라면 사용자 캘린더 기준 하루에 한 번 `anonymous_data_stats` emit (`Calendar.isDate(_:inSameDayAs:)` 비교).
- DI 통과
  - `AppEnvironment` 에 `anonymousDataCountsProvider` 클로저 노출.
  - SceneDelegate / MainTabBarController / SettingsViewController 가 LoginVC · AccountDetailVC 까지 통과.

## 테스트 방법
- 익명 모드에서 메모/카테고리/이미지 다수 만든 뒤 LoginScreen 의 Apple Sign-in → Amplitude / Firebase Analytics dashboard 에 `sign_in_started` + `anonymous_data_stats` 도착 확인. Apple 시트 취소 / 정상 완료 / readiness timeout 등 시나리오마다 `sign_in_outcome` 의 outcome 값 확인.
- AccountDetail 의 Apple Sign-in 같은 흐름으로 source=account_detail 로 도착 확인.
- 마이그레이션 끊긴 상태에서 AccountDetail 의 동기화 재시도 버튼 → `sync_retry_tapped` + `sync_retry_outcome` 발화.
- LoginScreen 의 "그냥 사용" → `sign_in_skipped` 발화.
- sign-in 한 사용자 dashboard 에서 user_id 가 Firebase UID 로 묶여있는지 확인. sign-out 후 같은 device 의 후속 이벤트는 user_id 없음 (익명 상태로 복원).
- 익명 사용자가 같은 날 앱을 여러 번 켜도 `anonymous_data_stats` 는 1 회만 emit. 자정 넘긴 후 첫 launch 에 다시 1 회 emit.
- 단위 테스트 (Data 모듈) 94 개 통과.

## 리뷰 노트
- `AnonymousDataCounts` 는 Feature 모듈도 Data 의존 없이 받을 수 있도록 Domain/Sources/Models 에 위치.
- AppDelegate 의 `authStatePublisher` 구독 + `setUserId` 호출은 sign-in 경로의 VC 측 명시 호출과 중복될 수 있지만 `removeDuplicates` 로 SDK 호출은 한 번. VC 측 호출은 outcome 이벤트 직전에 user_id 가 attribute 되도록 동기 보장 목적으로 유지.
- 익명 통계 emit 위치는 `AppDelegate.didFinishLaunching` — UI 무관 + multi-scene 환경에서도 launch 당 정확히 한 번.
- Crashlytics 는 crash 자동 수집 그대로. 분석 이벤트는 보내지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)