### PR TITLE
fix(popup-card): 원격 동기화로 메모 갱신 시 수정일·즐겨찾기 라벨 실시간 반영

### DIFF
--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -131,9 +131,10 @@ class PopupCardViewController: UIViewController {
                         self.memo = updatedMemo
                         self.categories = try await self.fetchCategories()
 
+                        // 통합 갱신 — 직접 title / memoText 만 set 하면 memoDateLabel (~~에 수정됨) 과
+                        // likeButton.isSelected (다른 기기에서 즐겨찾기 토글) 가 stale 로 남는다.
+                        self.rootView.configureView(with: updatedMemo)
                         self.rootView.categoryCollectionView.reloadData()
-                        self.rootView.titleTextField.text = updatedMemo.memoTitle
-                        self.rootView.memoTextView.text = updatedMemo.memoText
                     } catch RepositoryError.notFound {
                         self.dismiss(animated: true)
                     } catch {


### PR DESCRIPTION
## 배경
- 로그인 상태에서 다른 기기로 메모를 수정하면 PopupCard 에 떠 있는 "~~에 수정됨" (`memoDateLabel`) 문구가 즉시 반영되지 않고, PopupCard 를 닫았다 다시 열어야 갱신되는 문제.
- 원인: `PopupCardViewController` 의 `memoUpdatedPublisher` sink 안에서 title / memoText / categoryCollectionView 만 직접 갱신하고 `memoDateLabel` 은 누락. 같은 종류로 `likeButton.isSelected` (즐겨찾기) 도 stale 잠재.

## 변경사항
- sink 안의 개별 set 3 줄 (`titleTextField.text` / `memoTextView.text` / `categoryCollectionView.reloadData`) 을 `rootView.configureView(with: updatedMemo)` + `categoryCollectionView.reloadData()` 로 교체.
- `PopupCardView` 에 이미 있던 통합 메서드 `configureView(with:)` 가 title / memoText / memoDateLabel / likeButton / isInTrash 분기를 한 번에 반영하므로 `memoDateLabel` 도 자동 갱신.
- 부수 효과: 다른 기기에서 즐겨찾기를 토글해도 `likeButton.isSelected` 가 함께 반영. `memoTextView` 가 `setLineSpace(...)` 로 일관 적용되어 line spacing 까지 정확.

## 테스트 방법
- 두 기기 (또는 한 기기 + Firestore console) 에서 같은 메모를 한쪽에서 수정 → 다른 쪽 기기의 PopupCard 가 열린 상태에서 "~~에 수정됨" 라벨이 실시간 갱신되는지 확인.
- 같은 흐름으로 즐겨찾기 토글 시 별 아이콘 상태가 함께 갱신되는지 확인.
- 자기 기기에서 메모 편집 중 sink 가 발화해도 자기 편집 흐름이 깨지지 않는지 확인 (debounce 0.5s 가 흡수).

## 리뷰 노트
- sink 위쪽의 휴지통 ↔ 복원 모드 전이 가드 (`guard updatedMemo.isInTrash == initialIsInTrash else dismiss`) 가 그대로라 `isInTrash` 분기 가드도 안전.
- 단일 변경이라 단위 테스트 추가 없음. UI 변화는 시뮬레이터 수동 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)