### PR TITLE
feat(popup-card): 메모 내 검색 기능 추가

### DIFF
--- a/NoteCard/Presentation/PopupCardView/PopupCardSearchBar.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardSearchBar.swift
@@ -1,0 +1,213 @@
+//
+//  PopupCardSearchBar.swift
+//  NoteCard
+//
+//  Created by 김민성 on 6/9/26.
+//
+
+import UIKit
+import DesignSystem
+import Shared
+
+/// PopupCard 본문 TextView 와 키보드 사이에 붙는 '메모 내 검색' 바.
+/// 검색어 입력 / 결과 카운트 / 이전·다음 이동 / 종료만 담당하는 순수 뷰이며,
+/// 실제 검색·하이라이트 로직은 PopupCardViewController 가 클로저로 받아 처리한다.
+final class PopupCardSearchBar: UIView {
+
+    let searchTextField = UITextField()
+
+    private let loadingIndicator = UIActivityIndicatorView(style: .medium)
+    private let previousButton = UIButton(type: .system)
+    private let nextButton = UIButton(type: .system)
+    private let countLabel = UILabel()
+    private let closeButton = UIButton(type: .system)
+    private let controlStackView = UIStackView()
+
+    var onQueryChanged: ((String) -> Void)?
+    var onTapPrevious: (() -> Void)?
+    var onTapNext: (() -> Void)?
+    var onTapClose: (() -> Void)?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+
+        setupSearchTextField()
+        setupControls()
+        configureHierarchy()
+        setupConstraints()
+        setupActions()
+
+        updateCount(current: 0, total: 0)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// 결과 카운트("현재/전체") 갱신. 일치가 없으면 이동 버튼을 비활성화한다.
+    func updateCount(current: Int, total: Int) {
+        countLabel.text = "\(current)/\(total)"
+        let hasMatches = total > 0
+        previousButton.isEnabled = hasMatches
+        nextButton.isEnabled = hasMatches
+        previousButton.alpha = hasMatches ? 1 : 0.3
+        nextButton.alpha = hasMatches ? 1 : 0.3
+    }
+
+    func setLoading(_ isLoading: Bool) {
+        if isLoading {
+            loadingIndicator.startAnimating()
+        } else {
+            loadingIndicator.stopAnimating()
+        }
+    }
+
+    func focusTextField() {
+        searchTextField.becomeFirstResponder()
+    }
+
+    func reset() {
+        searchTextField.text = ""
+        updateCount(current: 0, total: 0)
+        setLoading(false)
+    }
+
+}
+
+
+// MARK: - Initial UI Settings
+
+private extension PopupCardSearchBar {
+
+    func setupSearchTextField() {
+        // UIImageView를 직접 leftView로 넣으면 frame이 적용되지 않아, UIView로 감싼 뒤 subview로 넣는다.
+        let leftContainer = UIView(frame: CGRect(x: 0, y: 0, width: 35, height: 20))
+        let magnifyingImageView = UIImageView(image: UIImage(systemName: "magnifyingglass"))
+        magnifyingImageView.contentMode = .scaleAspectFit
+        magnifyingImageView.frame = leftContainer.bounds
+        magnifyingImageView.tintColor = .secondaryLabel
+        leftContainer.addSubview(magnifyingImageView)
+        searchTextField.leftView = leftContainer
+        searchTextField.leftViewMode = .always
+
+        let rightContainer = UIView(frame: CGRect(x: 0, y: 0, width: 28, height: 20))
+        loadingIndicator.hidesWhenStopped = true
+        loadingIndicator.center = CGPoint(x: rightContainer.bounds.midX, y: rightContainer.bounds.midY)
+        loadingIndicator.autoresizingMask = [.flexibleTopMargin, .flexibleBottomMargin, .flexibleLeftMargin, .flexibleRightMargin]
+        rightContainer.addSubview(loadingIndicator)
+        searchTextField.rightView = rightContainer
+        searchTextField.rightViewMode = .always
+
+        searchTextField.borderStyle = .none
+        searchTextField.backgroundColor = .secondarySystemBackground
+        searchTextField.layer.cornerRadius = 10
+        searchTextField.layer.cornerCurve = .continuous
+        searchTextField.font = UIFont.systemFont(ofSize: 15)
+        searchTextField.tintColor = .currentTheme
+        searchTextField.placeholder = L10n.PopupCard.searchPlaceholder
+        searchTextField.returnKeyType = .search
+        searchTextField.autocorrectionType = .no
+        searchTextField.spellCheckingType = .no
+        searchTextField.delegate = self
+    }
+
+    func setupControls() {
+        let symbolConfiguration = UIImage.SymbolConfiguration(pointSize: 14, weight: .semibold)
+        previousButton.setImage(
+            UIImage(systemName: "arrowtriangle.left.fill", withConfiguration: symbolConfiguration),
+            for: .normal
+        )
+        nextButton.setImage(
+            UIImage(systemName: "arrowtriangle.right.fill", withConfiguration: symbolConfiguration),
+            for: .normal
+        )
+        previousButton.tintColor = .currentTheme
+        nextButton.tintColor = .currentTheme
+        previousButton.accessibilityLabel = L10n.PopupCard.searchPreviousMatch
+        nextButton.accessibilityLabel = L10n.PopupCard.searchNextMatch
+
+        countLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 14, weight: .regular)
+        countLabel.textColor = .label
+        countLabel.textAlignment = .center
+        countLabel.setContentHuggingPriority(.required, for: .horizontal)
+
+        let closeSymbolConfiguration = UIImage.SymbolConfiguration(pointSize: 20, weight: .regular)
+        closeButton.setImage(
+            UIImage(systemName: "xmark.circle.fill", withConfiguration: closeSymbolConfiguration),
+            for: .normal
+        )
+        closeButton.tintColor = .secondaryLabel
+        closeButton.accessibilityLabel = L10n.PopupCard.searchClose
+
+        controlStackView.axis = .horizontal
+        controlStackView.alignment = .center
+        controlStackView.spacing = 6
+        controlStackView.addArrangedSubview(previousButton)
+        controlStackView.addArrangedSubview(countLabel)
+        controlStackView.addArrangedSubview(nextButton)
+        controlStackView.addArrangedSubview(closeButton)
+    }
+
+    func configureHierarchy() {
+        addSubview(searchTextField)
+        addSubview(controlStackView)
+    }
+
+    func setupConstraints() {
+        searchTextField.translatesAutoresizingMaskIntoConstraints = false
+        controlStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            searchTextField.topAnchor.constraint(equalTo: topAnchor, constant: 7),
+            searchTextField.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -7),
+            searchTextField.leadingAnchor.constraint(equalTo: leadingAnchor),
+            searchTextField.heightAnchor.constraint(equalToConstant: 35),
+
+            controlStackView.leadingAnchor.constraint(equalTo: searchTextField.trailingAnchor, constant: 8),
+            controlStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            controlStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            countLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 44),
+            previousButton.widthAnchor.constraint(equalToConstant: 32),
+            nextButton.widthAnchor.constraint(equalToConstant: 32),
+            closeButton.widthAnchor.constraint(equalToConstant: 32),
+        ])
+    }
+
+    func setupActions() {
+        searchTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
+        previousButton.addTarget(self, action: #selector(previousButtonTapped), for: .touchUpInside)
+        nextButton.addTarget(self, action: #selector(nextButtonTapped), for: .touchUpInside)
+        closeButton.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
+    }
+
+    @objc func textFieldDidChange(_ textField: UITextField) {
+        onQueryChanged?(textField.text ?? "")
+    }
+
+    @objc func previousButtonTapped() {
+        onTapPrevious?()
+    }
+
+    @objc func nextButtonTapped() {
+        onTapNext?()
+    }
+
+    @objc func closeButtonTapped() {
+        onTapClose?()
+    }
+
+}
+
+
+// MARK: - UITextFieldDelegate
+
+extension PopupCardSearchBar: UITextFieldDelegate {
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return false
+    }
+
+}

--- a/NoteCard/Presentation/PopupCardView/PopupCardView.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardView.swift
@@ -57,6 +57,8 @@ final class PopupCardView: UIView {
     
     private(set) var memoTextView: UITextView!
     let memoDateLabel = UILabel()
+    let inMemoSearchBar = PopupCardSearchBar()
+    private var inMemoSearchBarConstraints: [NSLayoutConstraint] = []
 
     private let environment: AppEnvironment
 
@@ -188,6 +190,32 @@ final class PopupCardView: UIView {
             memoTextView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
             memoTextViewBottom,
         ])
+    }
+
+    /// 검색바를 화면에 붙이고 본문 TextView 의 bottom 을 검색바 top 으로 끌어올린다(push-up).
+    /// 평소에는 hierarchy 에서 빼두므로, 검색하지 않을 때는 본문 레이아웃에 전혀 영향을 주지 않는다.
+    func showInMemoSearchBar() {
+        addSubview(inMemoSearchBar)
+        inMemoSearchBar.translatesAutoresizingMaskIntoConstraints = false
+        memoTextViewBottomToKeyboardTop.isActive = false
+        let constraints = [
+            inMemoSearchBar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            inMemoSearchBar.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            inMemoSearchBar.bottomAnchor.constraint(equalTo: keyboardLayoutGuide.topAnchor, constant: -10),
+            memoTextView.bottomAnchor.constraint(equalTo: inMemoSearchBar.topAnchor, constant: -10),
+        ]
+        NSLayoutConstraint.activate(constraints)
+        inMemoSearchBarConstraints = constraints
+    }
+
+    /// 검색바를 떼어내고 본문 TextView 의 bottom 을 다시 키보드 가이드로 되돌린다.
+    /// searchTextField 의 resign 으로 키보드가 내려가며, pending 된 제약 변경이 그 애니메이션에 함께 실린다.
+    func hideInMemoSearchBar() {
+        inMemoSearchBar.searchTextField.resignFirstResponder()
+        NSLayoutConstraint.deactivate(inMemoSearchBarConstraints)
+        inMemoSearchBarConstraints = []
+        inMemoSearchBar.removeFromSuperview()
+        memoTextViewBottomToKeyboardTop.isActive = true
     }
     
     private func updateTitleTextField() {
@@ -384,14 +412,16 @@ extension PopupCardView {
     }
     
     private func setupMemoTextView() {
-        if #available(iOS 16.0, *) {
-            // iOS 16.0 이후에서는 TextKit2 사용기 기본값이기 때문에,
-            // TextKit1 사용으로 통일하기 위해 usingTextLayoutManager 매개변수에 false 할당.
-            memoTextView = UITextView(usingTextLayoutManager: false)
-        } else {
-            memoTextView = UITextView()
-        }
-        
+        // 하이라이트가 행간만큼 늘어지지 않도록 커스텀 NSLayoutManager 를 사용한 TextKit1 스택을 직접 구성한다.
+        // (iOS 16+ 기본값인 TextKit2 대신 TextKit1 을 강제하는 효과도 겸한다.)
+        let textStorage = NSTextStorage()
+        let layoutManager = TightBackgroundLayoutManager()
+        let textContainer = NSTextContainer(size: .zero)
+        textContainer.widthTracksTextView = true
+        textStorage.addLayoutManager(layoutManager)
+        layoutManager.addTextContainer(textContainer)
+        memoTextView = UITextView(frame: .zero, textContainer: textContainer)
+
         let bar = UIToolbar(frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)))
         let hideKeyboardButton = UIBarButtonItem(
             image: .init(systemName: "keyboard.chevron.compact.down"),

--- a/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
+++ b/NoteCard/Presentation/PopupCardView/PopupCardViewController.swift
@@ -35,7 +35,13 @@ class PopupCardViewController: UIViewController {
     private var restoreMemoAction: UIAction!
     private var presentEditingModeAction: UIAction!
     private var deleteMemoAction: UIAction!
+    private var searchInThisMemoAction: UIAction!
     private var cancellables = Set<AnyCancellable>()
+
+    @Published private var inMemoSearchQuery: String = ""
+    private var matchRanges: [NSRange] = []
+    private var currentMatchIndex: Int = 0
+    private var isInMemoSearchActive = false
     
     init(memo: Memo, indexPath: IndexPath, editingEnabled: Bool = true, environment: AppEnvironment) {
         self.memo = memo
@@ -86,6 +92,8 @@ class PopupCardViewController: UIViewController {
             memoTextViewTapGesture.isEnabled = false
         }
         
+        setupInMemoSearch()
+
         // PopupCard 표시 중에만 해당 메모의 image sub-collection listener attach.
         // cancellables 라이프사이클에 묶여 dismiss 시 자동 detach.
         environment.imageRepository.observeImageChanges(for: memo.memoID)
@@ -229,7 +237,16 @@ private extension PopupCardViewController {
                 self.askDeleting()
             }
         )
-        
+
+        searchInThisMemoAction = UIAction(
+            title: L10n.PopupCard.searchInThisMemo,
+            image: UIImage(systemName: "magnifyingglass"),
+            handler: { [weak self] action in
+                guard let self else { return }
+                self.enterInMemoSearchMode()
+            }
+        )
+
         rootView.titleTextField.addTarget(self, action: #selector(titleTextFieldEditingDidEndOnExit), for: .editingDidEndOnExit)
     }
     
@@ -254,7 +271,7 @@ private extension PopupCardViewController {
             rootView.titleTextField.isUserInteractionEnabled = false
             rootView.memoTextView.isUserInteractionEnabled = false
         } else {
-            rootView.ellipsisButton.menu = UIMenu(children: [presentEditingModeAction, deleteMemoAction])
+            rootView.ellipsisButton.menu = UIMenu(children: [searchInThisMemoAction, presentEditingModeAction, deleteMemoAction])
         }
         rootView.likeButton.addTarget(self, action: #selector(likeButtonTapped), for: .touchUpInside)
     }
@@ -393,6 +410,174 @@ extension PopupCardViewController {
 }
 
 
+// MARK: - In-Memo Search
+
+private extension PopupCardViewController {
+
+    func setupInMemoSearch() {
+        rootView.inMemoSearchBar.onQueryChanged = { [weak self] query in
+            self?.inMemoSearchQuery = query
+        }
+        rootView.inMemoSearchBar.onTapPrevious = { [weak self] in
+            self?.moveToPreviousMatch()
+        }
+        rootView.inMemoSearchBar.onTapNext = { [weak self] in
+            self?.moveToNextMatch()
+        }
+        rootView.inMemoSearchBar.onTapClose = { [weak self] in
+            self?.exitInMemoSearchMode()
+        }
+
+        $inMemoSearchQuery
+            .debounce(for: 0.2, scheduler: RunLoop.main)
+            .sink { [weak self] query in
+                self?.runInMemoSearch(query: query)
+            }
+            .store(in: &cancellables)
+    }
+
+    func enterInMemoSearchMode() {
+        guard !isInMemoSearchActive else { return }
+        isInMemoSearchActive = true
+
+        // 본문 bottom 을 검색바 top 으로 끌어올린(push-up) 뒤 검색바를 first responder 로 만들어 키보드를 띄운다.
+        // 제약 변경을 pending 으로 둔 채 키보드를 올려, 검색바 등장과 본문 축소가 키보드 애니메이션에 함께 실리게 한다.
+        rootView.showInMemoSearchBar()
+        rootView.inMemoSearchBar.focusTextField()
+
+        // 검색 중에는 본문 편집을 잠가 일치 위치(NSRange)가 무효화되지 않도록 한다.
+        // (검색바가 first responder 를 가져가므로 키보드는 그대로 유지된다.)
+        rootView.memoTextView.isEditable = false
+        memoTextViewTapGesture.isEnabled = false
+    }
+
+    func exitInMemoSearchMode() {
+        guard isInMemoSearchActive else { return }
+        isInMemoSearchActive = false
+
+        clearMatchHighlights()
+        inMemoSearchQuery = ""
+        rootView.inMemoSearchBar.reset()
+
+        // 검색바를 떼어내며 키보드가 내려가고, pending 된 제약 변경(본문이 다시 늘어남)이 그 애니메이션에 함께 실린다.
+        // 본문은 top 기준이라 아래로 늘어나도 컨텐츠 offset 이 튀지 않는다.
+        rootView.hideInMemoSearchBar()
+
+        if editingEnabled {
+            rootView.memoTextView.isEditable = true
+            memoTextViewTapGesture.isEnabled = true
+        }
+    }
+
+    func runInMemoSearch(query: String) {
+        // 검색 모드가 아닐 때(예: 화면 진입 직후 @Published 초기값 방출)는 본문을 건드리지 않는다.
+        guard isInMemoSearchActive else { return }
+        guard !query.isEmpty else {
+            clearMatchHighlights()
+            rootView.inMemoSearchBar.updateCount(current: 0, total: 0)
+            rootView.inMemoSearchBar.setLoading(false)
+            return
+        }
+
+        rootView.inMemoSearchBar.setLoading(true)
+        let text = rootView.memoTextView.text ?? ""
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let ranges = Self.matchRanges(of: query, in: text)
+            DispatchQueue.main.async {
+                guard let self else { return }
+                // 결과를 기다리는 사이 검색어가 또 바뀌었다면, 곧 새 검색이 다시 갱신하므로 이번 결과는 버린다.
+                guard query == self.inMemoSearchQuery else { return }
+                self.applyMatches(ranges)
+                self.rootView.inMemoSearchBar.setLoading(false)
+            }
+        }
+    }
+
+    func applyMatches(_ ranges: [NSRange]) {
+        matchRanges = ranges
+        currentMatchIndex = 0
+        applyMatchHighlights()
+        if !ranges.isEmpty {
+            scrollToCurrentMatch()
+        }
+        updateMatchCount()
+    }
+
+    func moveToNextMatch() {
+        guard !matchRanges.isEmpty else { return }
+        currentMatchIndex = (currentMatchIndex + 1) % matchRanges.count
+        applyMatchHighlights()
+        scrollToCurrentMatch()
+        updateMatchCount()
+    }
+
+    func moveToPreviousMatch() {
+        guard !matchRanges.isEmpty else { return }
+        currentMatchIndex = (currentMatchIndex - 1 + matchRanges.count) % matchRanges.count
+        applyMatchHighlights()
+        scrollToCurrentMatch()
+        updateMatchCount()
+    }
+
+    func applyMatchHighlights() {
+        let textStorage = rootView.memoTextView.textStorage
+        let fullRange = NSRange(location: 0, length: textStorage.length)
+        let normalColor = UIColor.currentTheme.withAlphaComponent(0.5)
+        let currentColor = UIColor.currentTheme.withAlphaComponent(0.85)
+
+        textStorage.beginEditing()
+        textStorage.removeAttribute(.backgroundColor, range: fullRange)
+        for (index, range) in matchRanges.enumerated() {
+            let highlightColor = index == currentMatchIndex ? currentColor : normalColor
+            textStorage.addAttribute(.backgroundColor, value: highlightColor, range: range)
+        }
+        textStorage.endEditing()
+    }
+
+    func clearMatchHighlights() {
+        matchRanges = []
+        currentMatchIndex = 0
+        // 배경색 제거가 스크롤 위치를 흔들지 않도록 offset 을 보존한다.
+        let savedOffset = rootView.memoTextView.contentOffset
+        let textStorage = rootView.memoTextView.textStorage
+        let fullRange = NSRange(location: 0, length: textStorage.length)
+        textStorage.removeAttribute(.backgroundColor, range: fullRange)
+        rootView.memoTextView.contentOffset = savedOffset
+    }
+
+    func scrollToCurrentMatch() {
+        guard matchRanges.indices.contains(currentMatchIndex) else { return }
+        rootView.memoTextView.scrollRangeToVisible(matchRanges[currentMatchIndex])
+    }
+
+    func updateMatchCount() {
+        let current = matchRanges.isEmpty ? 0 : currentMatchIndex + 1
+        rootView.inMemoSearchBar.updateCount(current: current, total: matchRanges.count)
+    }
+
+    /// 표시 중인 본문에서 검색어와 일치하는 모든 NSRange 를 찾는다.
+    /// NSString 기준으로 탐색해 한글 등 결합 문자에서도 하이라이트 범위가 어긋나지 않도록 한다.
+    static func matchRanges(of query: String, in text: String) -> [NSRange] {
+        guard !query.isEmpty else { return [] }
+        let nsText = text as NSString
+        var ranges: [NSRange] = []
+        var searchStart = 0
+        while searchStart < nsText.length {
+            let remainingRange = NSRange(location: searchStart, length: nsText.length - searchStart)
+            let foundRange = nsText.range(of: query, options: [.caseInsensitive], range: remainingRange)
+            if foundRange.location == NSNotFound {
+                break
+            }
+            ranges.append(foundRange)
+            searchStart = foundRange.location + max(foundRange.length, 1)
+        }
+        return ranges
+    }
+
+}
+
+
 // MARK: - Domain.Category Fetching
 private extension PopupCardViewController {
     
@@ -451,6 +636,10 @@ private extension PopupCardViewController {
     /// 편집 진입 — MemoDetailVC 가 원본 + 썸네일 둘 다 필요한 ImageUIModel 을 요구하므로
     /// 모든 이미지를 sync 로 받아서 변환 후 진입. 한 장이라도 실패하면 alert.
     func enterEditingMode() async {
+        // 편집 모드(formSheet)로 넘어가기 전에 검색 모드를 정리한다.
+        // 그대로 두면 편집 후 돌아왔을 때 stale 한 검색 상태(하이라이트·일치 위치)가 남는다.
+        exitInMemoSearchMode()
+
         do {
             let models = try await fetchAllImageUIModelsForEditing()
             let memoEditingVC = MemoDetailViewController(

--- a/NoteCard/Presentation/PopupCardView/TightBackgroundLayoutManager.swift
+++ b/NoteCard/Presentation/PopupCardView/TightBackgroundLayoutManager.swift
@@ -1,0 +1,34 @@
+//
+//  TightBackgroundLayoutManager.swift
+//  NoteCard
+//
+//  Created by 김민성 on 6/9/26.
+//
+
+import UIKit
+
+/// `.backgroundColor` 속성을 그릴 때 line fragment 에 포함된 행간(lineSpacing)만큼
+/// 아래쪽을 깎아, 하이라이트가 글자 영역보다 길게 늘어지지 않도록 하는 NSLayoutManager.
+///
+/// 기본 NSLayoutManager 는 배경색을 line fragment rect 전체(= 글자 높이 + 행간)에 칠하기 때문에
+/// 행간만큼 하이라이트가 다음 줄 쪽으로 늘어나 보인다.
+final class TightBackgroundLayoutManager: NSLayoutManager {
+
+    /// 본문에 적용된 행간. 배경 사각형 높이에서 이만큼을 덜어낸다.
+    var lineSpacing: CGFloat = 5
+
+    override func fillBackgroundRectArray(
+        _ rectArray: UnsafePointer<CGRect>,
+        count rectCount: Int,
+        forCharacterRange charRange: NSRange,
+        color: UIColor
+    ) {
+        color.setFill()
+        for index in 0..<rectCount {
+            var rect = rectArray[index]
+            rect.size.height = max(0, rect.size.height - lineSpacing)
+            UIBezierPath(rect: rect).fill()
+        }
+    }
+
+}

--- a/Projects/Core/Shared/Resources/Localizable.xcstrings
+++ b/Projects/Core/Shared/Resources/Localizable.xcstrings
@@ -1341,6 +1341,91 @@
         }
       }
     },
+    "popupCard.searchClose": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close search"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검색 종료"
+          }
+        }
+      }
+    },
+    "popupCard.searchInThisMemo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search in This Memo"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 메모에서 검색"
+          }
+        }
+      }
+    },
+    "popupCard.searchNextMatch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next match"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다음 검색 결과"
+          }
+        }
+      }
+    },
+    "popupCard.searchPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검색"
+          }
+        }
+      }
+    },
+    "popupCard.searchPreviousMatch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Previous match"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이전 검색 결과"
+          }
+        }
+      }
+    },
     "settings.ascending": {
       "extractionState": "manual",
       "localizations": {

--- a/Projects/Core/Shared/Sources/Localization/L10n.swift
+++ b/Projects/Core/Shared/Sources/Localization/L10n.swift
@@ -63,6 +63,11 @@ public enum L10n {
         public static let noTitle = "popupCard.noTitle".localized()
         public static let editingPreloadFailedTitle = "popupCard.editingPreloadFailedTitle".localized()
         public static let editingPreloadFailedMessage = "popupCard.editingPreloadFailedMessage".localized()
+        public static let searchInThisMemo = "popupCard.searchInThisMemo".localized()
+        public static let searchPlaceholder = "popupCard.searchPlaceholder".localized()
+        public static let searchPreviousMatch = "popupCard.searchPreviousMatch".localized()
+        public static let searchNextMatch = "popupCard.searchNextMatch".localized()
+        public static let searchClose = "popupCard.searchClose".localized()
     }
 
     public enum MemoView {


### PR DESCRIPTION
## 배경
- PopupCard(단일 메모 상세)에서 긴 메모의 특정 단어를 찾기 어려움. 기존 검색은 별도 탭의 전체 메모 검색만 존재.

## 변경사항
- PopupCard 옵션 메뉴에 '이 메모에서 검색' 추가
- 검색 바(검색어 입력 · 결과 카운트 · 이전/다음 이동 · 종료)를 본문 TextView 와 키보드 사이에 표시
  - 검색 중에만 뷰 계층에 add/remove 하여, 검색하지 않을 때는 본문 레이아웃에 영향 없음
  - 본문 TextView 하단을 검색 바 상단으로 끌어올림(push-up)
- 입력 0.2s debounce 후 본문에서 일치 항목을 찾아 형광펜 배경(현재 테마색)으로 표시
  - 전체 일치 alpha 0.5, 현재 포커스 일치 alpha 0.85
  - 일치 영역이 행간만큼 아래로 늘어지지 않도록 배경 렌더링 전용 레이아웃 매니저 적용
- 이전/다음 이동 시 해당 위치로 스크롤, '현재/전체' 카운트 표시
- 검색 중 본문 편집 잠금, 편집 모드 진입 시 검색 모드 종료
- 신규 문자열(en/ko) L10n 반영

## 테스트 방법
- 메모를 열어 우상단 옵션 메뉴 → '이 메모에서 검색' 선택
- 검색어 입력 → 본문 일치 항목이 형광펜으로 표시되고 카운트가 갱신되는지 확인
- 삼각형 이전/다음 버튼으로 일치 항목 사이 이동 및 스크롤 확인
- ✕ 로 종료 시 하이라이트 제거·키보드 내림 확인
- 검색 중 편집 모드 진입 후 복귀 시 검색 상태가 남지 않는지 확인

## 리뷰 노트
- 본문 TextView 는 배경 하이라이트를 글자 높이에 맞추기 위해 커스텀 NSLayoutManager 를 쓴 TextKit1 스택으로 직접 구성 (기존 `usingTextLayoutManager: false` 와 동일하게 TextKit1 유지)
- known issue: 검색 종료 시 키보드가 내려가는 과정에서 드물게 본문이 잠깐 스크롤됨. 키보드가 완전히 내려오면 원위치. 후속 처리 예정
- 이미지 전체보기 진입 경로에서는 검색 모드를 종료하지 않음 (본문 텍스트가 바뀌지 않아 일치 위치는 유지됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)